### PR TITLE
Updates sirius-kernel to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>
@@ -26,7 +26,14 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>2.13</version>
+            <version>2.15</version>
+        </dependency>
+        <dependency>
+            <groupId>com.scireum</groupId>
+            <artifactId>sirius-kernel</artifactId>
+            <version>[2.15,)</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -47,13 +54,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>2.8.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.scireum</groupId>
-            <artifactId>sirius-kernel</artifactId>
-            <version>LATEST</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updates sirius-kernel to the latest version

Also removes the LATEST reference to the test-jar as maven is
too intelligent to do this correctly. We now resort to a version range.