### PR TITLE
Keeps the original sort order of the fields as reported by the database.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/jdbc/Row.java
+++ b/src/main/java/sirius/db/jdbc/Row.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public class Row {
 
-    protected Map<String, Tuple<String, Object>> fields = Maps.newTreeMap();
+    protected Map<String, Tuple<String, Object>> fields = Maps.newLinkedHashMap();
 
     /**
      * Returns all stored fields as map.


### PR DESCRIPTION
Keeps the original sort order of the fields as reported by the database.

By using a linked hash map, getFieldsList will report the order as supplied by the database instead of sorting lexicogrphically.
This caused an issue in OCM which reports queries directly as CSV fields and therefore relies on the field order.