### PR TITLE
Uses the property to determine the effective field names when selecting specifiy columns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/SmartQuery.java
+++ b/src/main/java/sirius/db/mixing/SmartQuery.java
@@ -563,18 +563,18 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
             if (mf.successiveCall()) {
                 c.getSELECTBuilder().append(", ");
             }
-            String alias = c.determineAlias(field.getParent()).getFirst();
-            if (c.defaultAlias.equals(alias)) {
-                c.getSELECTBuilder().append(alias);
-                c.getSELECTBuilder().append(".");
-                c.getSELECTBuilder().append(field);
-            } else {
-                c.getSELECTBuilder().append(alias);
-                c.getSELECTBuilder().append(".");
+            Tuple<String, EntityDescriptor> joinInfo = c.determineAlias(field.getParent());
+            c.getSELECTBuilder().append(joinInfo.getFirst());
+            c.getSELECTBuilder().append(".");
+            if (Entity.ID.equals(field) || Entity.VERSION.equals(field)) {
                 c.getSELECTBuilder().append(field.getName());
+            } else {
+                c.getSELECTBuilder().append(joinInfo.getSecond().getProperty(field.getName()).getColumnName());
+            }
+            if (!c.defaultAlias.equals(joinInfo.getFirst())) {
                 if (applyAliases) {
                     c.getSELECTBuilder().append(" AS ");
-                    c.getSELECTBuilder().append(alias);
+                    c.getSELECTBuilder().append(joinInfo.getFirst());
                     c.getSELECTBuilder().append("_");
                     c.getSELECTBuilder().append(field.getName());
                 }


### PR DESCRIPTION
Uses the property to determine the effective field names when selecting specifiy columns.

A SmartQuery can be told which columns to select using .field(field1, field2,...). If such a list
is present, we have to actually translate these names into the column names used in the
database as column renamings might be applied to support legacy schema.