### PR TITLE
Adds a convenience parameter to FieldOperator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.5.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.7.2</version>
+    <version>1.8</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>3.3.3</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>[3.3.3,)</version>
+            <version>[3.4,)</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.5.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.8</version>
+    <version>1.9</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/constraints/FieldOperator.java
+++ b/src/main/java/sirius/db/mixing/constraints/FieldOperator.java
@@ -139,7 +139,7 @@ public class FieldOperator extends Constraint {
     }
 
     /**
-     * Also evaluates to true, of the field being addressed is <tt>null</tt>.
+     * Also makes the constraint evaluate to <tt>true</tt>, if the field being addressed is <tt>null</tt>.
      *
      * @return the constraint itself
      */

--- a/src/main/java/sirius/db/mixing/constraints/FieldOperator.java
+++ b/src/main/java/sirius/db/mixing/constraints/FieldOperator.java
@@ -165,7 +165,13 @@ public class FieldOperator extends Constraint {
                     compiler.getWHEREBuilder().append(columnName).append(" IS NULL");
                     return;
                 } else if (op == Operator.NE) {
-                    if (!orNull) {
+                    if (orNull) {
+                        // x IS NOT NULL OR x IS NULL === true
+                        // This constraint is pointless but as we might be in an OR, we still need to
+                        // output a constraint that is always true. As there is no boolean literal in
+                        // SQL, we use this brilliant expression:
+                        compiler.getWHEREBuilder().append("1=1");
+                    } else {
                         compiler.getWHEREBuilder().append(columnName).append(" IS NOT NULL");
                     }
                     return;


### PR DESCRIPTION
Adds a convenience parameter to FieldOperator

Many queries against magnitudes or dates look like
WHERE (field > $param OR field IS NULL)

 This can now be achived using:
 FieldOperator.on(field).greateThan(param).orNull()