### PR TITLE
When we JOIN-FETCH a field which has an alias (the column name in the database does not match the field name) we have to change the aliased column name accordingly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/SmartQuery.java
+++ b/src/main/java/sirius/db/mixing/SmartQuery.java
@@ -579,21 +579,29 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
             Tuple<String, EntityDescriptor> joinInfo = c.determineAlias(field.getParent());
             c.getSELECTBuilder().append(joinInfo.getFirst());
             c.getSELECTBuilder().append(".");
-            if (Entity.ID.getName().equals(field.getName()) || Entity.VERSION.getName().equals(field.getName())) {
-                c.getSELECTBuilder().append(field.getName());
-            } else {
-                c.getSELECTBuilder().append(joinInfo.getSecond().getProperty(field.getName()).getColumnName());
-            }
+            String columnName = fetchEffectiveColumnName(field, joinInfo);
+            c.getSELECTBuilder().append(columnName);
+
             if (!c.defaultAlias.equals(joinInfo.getFirst())) {
                 if (applyAliases) {
                     c.getSELECTBuilder().append(" AS ");
                     c.getSELECTBuilder().append(joinInfo.getFirst());
                     c.getSELECTBuilder().append("_");
-                    c.getSELECTBuilder().append(field.getName());
+                    c.getSELECTBuilder().append(columnName);
                 }
                 c.createJoinFetch(field);
             }
         }
+    }
+
+    private String fetchEffectiveColumnName(Column field, Tuple<String, EntityDescriptor> joinInfo) {
+        String columnName = null;
+        if (Entity.ID.getName().equals(field.getName()) || Entity.VERSION.getName().equals(field.getName())) {
+            columnName = field.getName();
+        } else {
+            columnName = joinInfo.getSecond().getProperty(field.getName()).getColumnName();
+        }
+        return columnName;
     }
 
     private Compiler selectCount() {

--- a/src/main/java/sirius/db/mixing/SmartQuery.java
+++ b/src/main/java/sirius/db/mixing/SmartQuery.java
@@ -595,13 +595,11 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
     }
 
     private String fetchEffectiveColumnName(Column field, Tuple<String, EntityDescriptor> joinInfo) {
-        String columnName = null;
         if (Entity.ID.getName().equals(field.getName()) || Entity.VERSION.getName().equals(field.getName())) {
-            columnName = field.getName();
+            return field.getName();
         } else {
-            columnName = joinInfo.getSecond().getProperty(field.getName()).getColumnName();
+            return joinInfo.getSecond().getProperty(field.getName()).getColumnName();
         }
-        return columnName;
     }
 
     private Compiler selectCount() {


### PR DESCRIPTION
When we JOIN-FETCH a field which has an alias (the column name in the database does not match the field name) we have to change the aliased column name accordingly.

If we join fetch a field which is named ‘address_name1’, with a column name ‘name1’ for table t1,
we have to generate SELECT … name1 AS t1_name1 instead of name1 AS t1_address_name1,
as the readEntity call will look for that column, when executing join fetches