### PR TITLE
Avoid exception on SmartQuery fields copy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>1.13.4</version>
+    <version>1.13.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/SmartQuery.java
+++ b/src/main/java/sirius/db/mixing/SmartQuery.java
@@ -30,11 +30,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -263,7 +259,7 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
     public SmartQuery<E> copy() {
         SmartQuery<E> copy = new SmartQuery<>(type, db);
         copy.distinct = distinct;
-        copy.fields.addAll(fields);
+        copy.fields = new ArrayList<>(fields);
         copy.orderBys.addAll(orderBys);
         copy.constaints.addAll(constaints);
 
@@ -523,8 +519,9 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
         }
 
         private PreparedStatement prepareStatement(Connection c) throws SQLException {
-            PreparedStatement stmt =
-                    c.prepareStatement(getQuery(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            PreparedStatement stmt = c.prepareStatement(getQuery(),
+                                                        ResultSet.TYPE_FORWARD_ONLY,
+                                                        ResultSet.CONCUR_READ_ONLY);
             for (int i = 0; i < parameters.size(); i++) {
                 stmt.setObject(i + 1, parameters.get(i));
             }

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -242,4 +242,16 @@ class SmartQuerySpec extends BaseSpecification {
         qry.count() == 1
     }
 
+    def "copy of query does also copy fields"() {
+        given:
+        SmartQuery<SmartQueryTestEntity> qry = oma.select(SmartQueryTestEntity.class)
+                .fields(SmartQueryTestEntity.TEST_NUMBER, SmartQueryTestEntity.VALUE)
+                .copy()
+                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+        when:
+        def result = qry.queryList()
+        then:
+        result.stream().map({ x -> x.getValue() } as Function).collect(Collectors.toList()) == ["Test", "Hello", "World"]
+    }
+
 }


### PR DESCRIPTION
The fields were an emptyList so calling copy() on SmartQuery caused an UnsupportedOperationException if fields were copied.