### PR TITLE
Fixes an unusual property key lookup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>2.1.1</version>
+    <version>2.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
@@ -151,17 +151,11 @@ public class EntityRefProperty extends Property {
         super.link();
         EntityRef.OnDelete deleteHandler = getEntityRef().getDeleteHandler();
 
-        setTypeNameAsAlternativePropertyKey();
-
         createDeleteCascadeHandler(deleteHandler);
 
         if (deleteHandler == EntityRef.OnDelete.LAZY_CASCADE || deleteHandler == EntityRef.OnDelete.SOFT_CASCADE) {
             createBackgroundCascadeHandler();
         }
-    }
-
-    protected void setTypeNameAsAlternativePropertyKey() {
-        this.alternativePropertyKey = getReferencedType().getName();
     }
 
     protected void createDeleteCascadeHandler(EntityRef.OnDelete deleteHandler) {


### PR DESCRIPTION
Fixes an unusual property key lookup

If A references B in field "b", we use A.b or Model.b as property key
and not com.x.B (because we never do this....)