### PR TITLE
Overwrites checkNullability for AmountProperties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>2.2</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -17,6 +17,7 @@ import sirius.db.mixing.schema.TableColumn;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
 import java.lang.reflect.Field;
@@ -125,5 +126,14 @@ public class AmountProperty extends Property {
             column.setScale(column.getPrecision());
         }
         return column;
+    }
+
+    @Override
+    protected void checkNullability(Object propertyValue) {
+        super.checkNullability(propertyValue);
+
+        if (!isNullable() && ((Amount) propertyValue).isEmpty()) {
+            throw Exceptions.createHandled().withNLSKey("Property.fieldNotNullable").set("field", getLabel()).handle();
+        }
     }
 }


### PR DESCRIPTION
NonNull Amount Properties are often initialized with Amount.NOTHING != null
Amount.NOTHING just wraps a null value and must be checked as well