### PR TITLE
Adds better defaults and monitoring on how many connections are created in total.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>2.3.1</version>
+    <version>2.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/jdbc/Database.java
+++ b/src/main/java/sirius/db/jdbc/Database.java
@@ -9,7 +9,6 @@
 package sirius.db.jdbc;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.dbcp2.BasicDataSource;
 import sirius.kernel.async.Operation;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Strings;
@@ -58,7 +57,7 @@ public class Database {
     private int maxIdle;
     private boolean testOnBorrow;
     private String validationQuery;
-    private BasicDataSource ds;
+    private MonitoredDataSource ds;
     private Set<Capability> capabilities;
 
     /*
@@ -114,7 +113,7 @@ public class Database {
      */
     public DataSource getDatasource() {
         if (ds == null) {
-            ds = new BasicDataSource();
+            ds = new MonitoredDataSource();
             initialize();
         }
         return ds;

--- a/src/main/java/sirius/db/jdbc/MonitoredDataSource.java
+++ b/src/main/java/sirius/db/jdbc/MonitoredDataSource.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp2.ConnectionFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Tracks how many connections are actually created.
+ * <p>
+ * Even if connections are short-lived and not concurrently created, they could still drain the pool of local TCP ports
+ * of the OS. Therefore we track the number of total created connections and warn if there are too many - this is
+ * a strong indication that the connection pool is misconfigured and not working as expected anyway.
+ */
+class MonitoredDataSource extends BasicDataSource {
+
+    @Override
+    protected ConnectionFactory createConnectionFactory() throws SQLException {
+        ConnectionFactory actualFactory = super.createConnectionFactory();
+
+        return new ConnectionFactory() {
+            @Override
+            public Connection createConnection() throws SQLException {
+                Databases.numConnects.inc();
+                return actualFactory.createConnection();
+            }
+        };
+    }
+}

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -39,6 +39,14 @@ health {
         db-pool-utilization.warn = 80
         db-pool-utilization.error = 98
 
+        # JDBC connections establisehd during a check interval.
+        # An increased value here indicates that at least one pool is badly configured
+        # and that it might drain the TCP port pool of the operating system, which
+        # will effectively block or destroy the TCP/IP stack of the OS
+        db-connects.gray = 5
+        db-connects.warn = 15
+        db-connects.error = 30
+
         # JDBC queries
         db-queries.gray = 25
         db-queries.warn = 0
@@ -94,10 +102,10 @@ jdbc {
             initialSize = 0
 
             # Maximal number of open connections
-            maxActive = 10
+            maxActive = 32
 
             # Maximal number of open unused connections
-            maxIdle = 1
+            maxIdle = 16
 
             # Validation query used to determine the fitness of a connection
             validationQuery = ""


### PR DESCRIPTION
Too many short lived connections can drain the pool of local TCP ports
of the OS. This is also a strong indication of a misconfigured connection pool.
Therefore we improve the default values and add an appropriate monitoring.