### PR TITLE
SE-2002 Adds missing NLS Key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>2.4.4</version>
+    <version>2.4.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/resources/db_de.properties
+++ b/src/main/resources/db_de.properties
@@ -27,6 +27,8 @@ Property.parseValueErrorMessage=${message}
 
 StringProperty.dataTruncation=Der Wert '${value}' im Field '${field}' ist mit ${length} Zeichen zu lang. Maximal sind ${maxLength} Zeichen erlaubt.
 
+EntityRefProperty.cannotDeleteEntityWithChildren=Das Objekt, das im Feld '${field}' vorgehalten wird kann nicht gelöscht werden. Es gibt noch '${count}' Objekte des Typs '${type}' die dieses zwingend referenzieren.
+
 MySQLDatabaseDialect.differentDefault=Die Standardwerte "${target}" und "${current}" sind ungleich
 MySQLDatabaseDialect.differentLength=Die Spaltenl\u00E4ngen "${target}" und "${current}" sind ungleich
 MySQLDatabaseDialect.differentNull=Die NOT-NULL-Einstellung ist ungleich.

--- a/src/main/resources/db_de.properties
+++ b/src/main/resources/db_de.properties
@@ -27,7 +27,7 @@ Property.parseValueErrorMessage=${message}
 
 StringProperty.dataTruncation=Der Wert '${value}' im Field '${field}' ist mit ${length} Zeichen zu lang. Maximal sind ${maxLength} Zeichen erlaubt.
 
-EntityRefProperty.cannotDeleteEntityWithChildren=Das Objekt, das im Feld '${field}' vorgehalten wird kann nicht gelöscht werden. Es gibt noch '${count}' Objekte des Typs '${type}' die dieses zwingend referenzieren.
+EntityRefProperty.cannotDeleteEntityWithChildren=Das Objekt, das im Feld '${field}' vorgehalten wird kann nicht gel\u00F6scht werden. Es gibt noch '${count}' Objekte des Typs '${type}' die dieses zwingend referenzieren.
 
 MySQLDatabaseDialect.differentDefault=Die Standardwerte "${target}" und "${current}" sind ungleich
 MySQLDatabaseDialect.differentLength=Die Spaltenl\u00E4ngen "${target}" und "${current}" sind ungleich

--- a/src/main/resources/db_en.properties
+++ b/src/main/resources/db_en.properties
@@ -24,7 +24,7 @@ Property.illegalValue=Invalid value '${value}' in field '${property}'.
 Property.fieldNotNullable=THe field '${field}' must not be empty.
 Property.fieldNotUnique=The value '${value}' is already in use for the field '${field}'.
 
-EntityRefProperty.cannotDeleteEntityWithChildren=The Entity referenced in the field '${field}' can not be deleted. There are '${count}' child Entities of the type '${type}' who reject this change. 
+EntityRefProperty.cannotDeleteEntityWithChildren=The Entity referenced in the field '${field}' can not be deleted. There are '${count}' child Entities of the type '${type}' which reject this change. 
 
 MySQLDatabaseDialect.differentDefault=The default values "${target}" and "${current}" differ
 MySQLDatabaseDialect.differentLength=The column length "${target}" and "${current}" differ

--- a/src/main/resources/db_en.properties
+++ b/src/main/resources/db_en.properties
@@ -24,6 +24,8 @@ Property.illegalValue=Invalid value '${value}' in field '${property}'.
 Property.fieldNotNullable=THe field '${field}' must not be empty.
 Property.fieldNotUnique=The value '${value}' is already in use for the field '${field}'.
 
+EntityRefProperty.cannotDeleteEntityWithChildren=The Entity referenced in the field '${field}' can not be deleted. There are '${count}' child Entities of the type '${type}' who reject this change. 
+
 MySQLDatabaseDialect.differentDefault=The default values "${target}" and "${current}" differ
 MySQLDatabaseDialect.differentLength=The column length "${target}" and "${current}" differ
 MySQLDatabaseDialect.differentNull=The NOT-NULL settings differ


### PR DESCRIPTION
Adds NLS keys for "EntityRefProperty.cannotDeleteEntityWithChildren" in the german and english properties.
Bumps version Number.

- fixes: SE-2002