### PR TITLE
Repairs the generated query for MySQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.0</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/constraints/Exists.java
+++ b/src/main/java/sirius/db/mixing/constraints/Exists.java
@@ -95,7 +95,7 @@ public class Exists extends Constraint {
             compiler.getWHEREBuilder().append("NOT ");
         }
         compiler.getWHEREBuilder()
-                .append("EXISTS(SELECT * FROM ")
+                .append("EXISTS(SELECT NULL FROM ")
                 .append(ed.getTableName())
                 .append(" ")
                 .append(newAlias)


### PR DESCRIPTION
Although it should not matter, what is put into the select MySQL
behaves differently. So we use NULL, which works and clearly signals,
that we only want the existence to be checked and are not interested
in the fields.