### PR TITLE
Distinguishes between null and 0 (entity ids)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.0</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -826,7 +826,9 @@ public class EntityDescriptor {
     private void readIdAndVersion(String alias, Set<String> columns, ResultSet rs, Entity entity) throws SQLException {
         String idColumnLabel = getIdColumnLabel(alias);
         if (columns.contains(idColumnLabel.toUpperCase())) {
-            entity.setId(rs.getLong(idColumnLabel));
+            if (rs.getString(idColumnLabel) != null) {
+                entity.setId(rs.getLong(idColumnLabel));
+            }
         }
         if (isVersioned()) {
             String versionColumnLabel = getVersionColumnLabel(alias);

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -826,8 +826,10 @@ public class EntityDescriptor {
     private void readIdAndVersion(String alias, Set<String> columns, ResultSet rs, Entity entity) throws SQLException {
         String idColumnLabel = getIdColumnLabel(alias);
         if (columns.contains(idColumnLabel.toUpperCase())) {
-            if (rs.getString(idColumnLabel) != null) {
-                entity.setId(rs.getLong(idColumnLabel));
+            entity.setId(rs.getLong(idColumnLabel));
+
+            if (rs.wasNull()) {
+                entity.setId(-1L);
             }
         }
         if (isVersioned()) {

--- a/src/main/java/sirius/db/mixing/EntityRef.java
+++ b/src/main/java/sirius/db/mixing/EntityRef.java
@@ -244,6 +244,6 @@ public class EntityRef<E extends Entity> {
      * @return <tt>true</tt> if the referenced entity was not yet saved to the database, <tt>false</tt> otherwise
      */
     public boolean containsNonpersistentValue() {
-        return id == null && value != null;
+        return value != null && (id == null || value.isNew());
     }
 }

--- a/src/main/java/sirius/db/mixing/OMA.java
+++ b/src/main/java/sirius/db/mixing/OMA.java
@@ -151,7 +151,7 @@ public class OMA {
             for (Property property : ed.getProperties()) {
                 if (property.getField().getType() == EntityRef.class
                     && (Long) property.getValueForColumn(entity) == -1L) {
-                    throw new IllegalArgumentException("Can not save non-existant reference");
+                    throw new IllegalArgumentException("Cannot save non-existant reference");
                 }
             }
 

--- a/src/main/java/sirius/db/mixing/OMA.java
+++ b/src/main/java/sirius/db/mixing/OMA.java
@@ -148,13 +148,6 @@ public class OMA {
             EntityDescriptor ed = entity.getDescriptor();
             ed.beforeSave(entity);
 
-            for (Property property : ed.getProperties()) {
-                if (property.getField().getType() == EntityRef.class
-                    && (Long) property.getValueForColumn(entity) == -1L) {
-                    throw new IllegalArgumentException("Cannot save non-existant reference");
-                }
-            }
-
             if (entity.isNew()) {
                 executeINSERT(entity, ed);
             } else {

--- a/src/main/java/sirius/db/mixing/OMA.java
+++ b/src/main/java/sirius/db/mixing/OMA.java
@@ -148,6 +148,13 @@ public class OMA {
             EntityDescriptor ed = entity.getDescriptor();
             ed.beforeSave(entity);
 
+            for (Property property : ed.getProperties()) {
+                if (property.getField().getType() == EntityRef.class
+                    && (Long) property.getValueForColumn(entity) == -1) {
+                    throw new IllegalArgumentException("Can not save non-existant reference");
+                }
+            }
+
             if (entity.isNew()) {
                 executeINSERT(entity, ed);
             } else {

--- a/src/main/java/sirius/db/mixing/OMA.java
+++ b/src/main/java/sirius/db/mixing/OMA.java
@@ -150,7 +150,7 @@ public class OMA {
 
             for (Property property : ed.getProperties()) {
                 if (property.getField().getType() == EntityRef.class
-                    && (Long) property.getValueForColumn(entity) == -1) {
+                    && (Long) property.getValueForColumn(entity) == -1L) {
                     throw new IllegalArgumentException("Can not save non-existant reference");
                 }
             }

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -26,9 +26,6 @@ class SmartQuerySpec extends BaseSpecification {
     @Part
     static OMA oma
 
-    SmartQueryTestParentEntity parent1
-    SmartQueryTestParentEntity parent2
-
     def setupSpec() {
         oma.getReadyFuture().await(Duration.ofSeconds(60))
         fillSmartQueryTestEntity()
@@ -58,8 +55,6 @@ class SmartQuerySpec extends BaseSpecification {
         p2.setName("Parent 2")
         oma.update(p2)
 
-        parent1 = p1
-        parent2 = p2
 
         SmartQueryTestChildEntity c = new SmartQueryTestChildEntity()
         c.setName("Child 1")
@@ -282,8 +277,6 @@ class SmartQuerySpec extends BaseSpecification {
 
     def "select non existant entity ref"() {
         given:
-        fillSmartQueryTestChildAndParentEntity()
-        and:
         TestEntityWithNullRef testChild = new TestEntityWithNullRef()
         testChild.setName("bliblablub")
 
@@ -309,11 +302,13 @@ class SmartQuerySpec extends BaseSpecification {
 
     def "select existant entity ref without id"() {
         given:
-        fillSmartQueryTestChildAndParentEntity()
+        SmartQueryTestParentEntity parent = new SmartQueryTestParentEntity()
+        parent.setName("Parent 3")
+        oma.update(parent)
         and:
         TestEntityWithNullRef testChild = new TestEntityWithNullRef()
         testChild.setName("bliblablub")
-        testChild.getParent().setValue(parent1)
+        testChild.getParent().setValue(parent)
 
         oma.update(testChild)
 

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -12,6 +12,7 @@ import sirius.db.jdbc.Database
 import sirius.db.mixing.constraints.Exists
 import sirius.db.mixing.constraints.FieldOperator
 import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Strings
 import sirius.kernel.di.std.Part
 import spock.lang.Stepwise
 
@@ -24,6 +25,9 @@ class SmartQuerySpec extends BaseSpecification {
 
     @Part
     static OMA oma
+
+    SmartQueryTestParentEntity parent1
+    SmartQueryTestParentEntity parent2
 
     def setupSpec() {
         oma.getReadyFuture().await(Duration.ofSeconds(60))
@@ -53,6 +57,9 @@ class SmartQuerySpec extends BaseSpecification {
         SmartQueryTestParentEntity p2 = new SmartQueryTestParentEntity()
         p2.setName("Parent 2")
         oma.update(p2)
+
+        parent1 = p1
+        parent2 = p2
 
         SmartQueryTestChildEntity c = new SmartQueryTestChildEntity()
         c.setName("Child 1")
@@ -273,4 +280,59 @@ class SmartQuerySpec extends BaseSpecification {
         result.stream().map({ x -> x.getValue() } as Function).collect(Collectors.toList()) == ["Test", "Hello", "World"]
     }
 
+    def "select non existant entity ref"() {
+        given:
+        fillSmartQueryTestChildAndParentEntity()
+        and:
+        TestEntityWithNullRef testChild = new TestEntityWithNullRef()
+        testChild.setName("bliblablub")
+
+        oma.update(testChild)
+
+        when:
+        def result = oma.select(TestEntityWithNullRef.class)
+                .fields(TestEntityWithNullRef.NAME,
+                        SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME),
+                        SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.ID))
+                .eq(SmartQueryTestChildEntity.ID, testChild.getId()).queryList()
+
+        and:
+        TestEntityWithNullRef found = result.get(0)
+
+        then:
+        found.getParent().isFilled()
+        and:
+        found.getParent().getValue().isNew()
+        and:
+        found.getParent().getId() == -1L
+    }
+
+    def "select existant entity ref without id"() {
+        given:
+        fillSmartQueryTestChildAndParentEntity()
+        and:
+        TestEntityWithNullRef testChild = new TestEntityWithNullRef()
+        testChild.setName("bliblablub")
+        testChild.getParent().setValue(parent1)
+
+        oma.update(testChild)
+
+        when:
+        def result = oma.select(TestEntityWithNullRef.class)
+                .fields(TestEntityWithNullRef.NAME,
+                SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME))
+                .eq(SmartQueryTestChildEntity.ID, testChild.getId()).queryList()
+
+        and:
+        TestEntityWithNullRef found = result.get(0)
+
+        then:
+        found.getParent().isFilled()
+        and:
+        found.getParent().getValue().isNew()
+        and:
+        found.getParent().getId() == -1L
+        and:
+        Strings.isFilled(found.getParent().getValue().getName())
+    }
 }

--- a/src/test/java/sirius/db/mixing/TestEntityWithNullRef.java
+++ b/src/test/java/sirius/db/mixing/TestEntityWithNullRef.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.NullAllowed;
+
+/**
+ * Test entity with an entityRef object that may be null
+ */
+public class TestEntityWithNullRef extends Entity {
+    @Length(50)
+    private String name;
+    public static final Column NAME = Column.named("name");
+
+    public static final Column PARENT = Column.named("parent");
+    @NullAllowed
+    private final EntityRef<SmartQueryTestParentEntity> parent =
+            EntityRef.on(SmartQueryTestParentEntity.class, EntityRef.OnDelete.CASCADE);
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public EntityRef<SmartQueryTestParentEntity> getParent() {
+        return parent;
+    }
+}


### PR DESCRIPTION
By checking if a fetched id is null before assigning it we are able to differ between new objects (not found) and found ones with the id 0.
Also adds a before save check to the doUpdate method which checks if an entity ref points to a not saved entity.