### PR TITLE
Monitors long running connections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.0.1</version>
+    <version>3.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>6.0</version>
+            <version>6.7</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>6.0</version>
+            <version>6.7</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/sirius/db/jdbc/Databases.java
+++ b/src/main/java/sirius/db/jdbc/Databases.java
@@ -50,12 +50,16 @@ import java.util.stream.Collectors;
 public class Databases {
 
     protected static final Log LOG = Log.get("db");
-    protected static final Log SLOW_QUERIES_LOG = Log.get("db-slow-queries");
+    protected static final Log SLOW_DB_LOG = Log.get("db-slow");
     private static final Map<String, Database> datasources = Maps.newConcurrentMap();
 
     @ConfigValue("jdbc.logQueryThreshold")
     private static Duration longQueryThreshold;
     private static long longQueryThresholdMillis = -1;
+
+    @ConfigValue("jdbc.logConnectionThreshold")
+    private static Duration longConnectionThreshold;
+    private static long longConnectionThresholdMillis = -1;
 
     protected static Counter numUses = new Counter();
     protected static Counter numConnects = new Counter();
@@ -156,7 +160,7 @@ public class Databases {
     }
 
     /**
-     * Converts the threshold into a long containing milliseconds for performance reasons.
+     * Converts the threshold for "slow queries" into a long containing milliseconds for performance reasons.
      *
      * @return the threshold for long queries in milliseconds
      */
@@ -166,6 +170,20 @@ public class Databases {
         }
 
         return longQueryThresholdMillis;
+    }
+
+
+    /**
+     * Converts the threshold for "long connections" into a long containing milliseconds for performance reasons.
+     *
+     * @return the threshold for long queries in milliseconds
+     */
+    protected static long getLongConnectionThresholdMillis() {
+        if (longConnectionThresholdMillis < 0) {
+            longConnectionThresholdMillis = longConnectionThreshold.toMillis();
+        }
+
+        return longConnectionThresholdMillis;
     }
 
     /**

--- a/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
@@ -54,10 +54,10 @@ class WrappedPreparedStatement implements PreparedStatement {
         Databases.queryDuration.addValue(w.elapsedMillis());
         if (w.elapsedMillis() > Databases.getLongQueryThresholdMillis()) {
             Databases.numSlowQueries.inc();
-            Databases.SLOW_QUERIES_LOG.INFO("A slow query was executed (%s): %s\n%s",
-                                            w.duration(),
-                                            sql,
-                                            ExecutionPoint.snapshot().toString());
+            Databases.SLOW_DB_LOG.INFO("A slow query was executed (%s): %s\n%s",
+                                       w.duration(),
+                                       sql,
+                                       ExecutionPoint.snapshot().toString());
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/WrappedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedStatement.java
@@ -50,10 +50,10 @@ class WrappedStatement implements Statement {
         Databases.queryDuration.addValue(w.elapsedMillis());
         if (w.elapsedMillis() > Databases.getLongQueryThresholdMillis()) {
             Databases.numSlowQueries.inc();
-            Databases.SLOW_QUERIES_LOG.INFO("A slow query was executed (%s): %s\n%s",
-                                            w.duration(),
-                                            sql,
-                                            ExecutionPoint.snapshot().toString());
+            Databases.SLOW_DB_LOG.INFO("A slow query was executed (%s): %s\n%s",
+                                       w.duration(),
+                                       sql,
+                                       ExecutionPoint.snapshot().toString());
         }
     }
 

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -87,8 +87,11 @@ health {
 # Defines database connectivity settings
 jdbc {
 
-    # Every query which takes longer will be logged to "db-slow-queries" on level INFO
+    # Every query which takes longer will be logged to "db-slow" on level INFO
     logQueryThreshold = 10 seconds
+
+    # Every connection which lasts longer will be logged to "db-slow" on level INFO
+    logConnectionThreshold = 30 seconds
 
     # A profile provides a template for database connections.
     # Each value of the profile serves as backup or default value for the one in the database secion.


### PR DESCRIPTION
If a connections lasts longer than 30s (which is
nothing but an educated guess), we log an
info text in the db-slow log to assist in debugging
wired shit