### PR TITLE
Determines the defaultValue of primitive boolean properties to be 0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -63,6 +63,15 @@ public class BooleanProperty extends Property {
     }
 
     @Override
+    protected void determineDefaultValue() {
+        if (field.getType().isPrimitive()) {
+            this.defaultValue = "0";
+        } else {
+            super.determineDefaultValue();
+        }
+    }
+
+    @Override
     protected Object transformToColumn(Object object) {
         return ((Boolean) object) ? 1 : 0;
     }


### PR DESCRIPTION
Otherwise, there can be non nullable boolean fields without default
value in the schema while primitive booleans always should
default to false.