### PR TITLE
Improves MongoDB API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.2.2</version>
+    <version>3.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>2.12.4</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/src/main/java/sirius/db/mongo/Filter.java
+++ b/src/main/java/sirius/db/mongo/Filter.java
@@ -63,6 +63,26 @@ public class Filter {
     }
 
     /**
+     * Builds a filter which verifies that the given field exists.
+     *
+     * @param key the name of the field to check
+     * @return a filter representing the given operation
+     */
+    public static Filter exists(String key) {
+        return op("$exists", key, true);
+    }
+
+    /**
+     * Builds a filter which verifies that the given field does not exist.
+     *
+     * @param key the name of the field to check
+     * @return a filter representing the given operation
+     */
+    public static Filter notExists(String key) {
+        return op("$exists", key, false);
+    }
+
+    /**
      * Builds a filter which represents <tt>field == value</tt>
      *
      * @param key   the name of the field to check

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -117,7 +117,7 @@ public class Finder extends QueryBuilder<Finder> {
     public Optional<Document> singleIn(String collection) {
         Watch w = Watch.start();
         try {
-            DBObject obj = mongo.db().getCollection(collection).findOne(filterObject, fields);
+            DBObject obj = mongo.db().getCollection(collection).findOne(filterObject, fields, orderBy);
             if (obj == null) {
                 return Optional.empty();
             } else {

--- a/src/main/java/sirius/db/mongo/Updater.java
+++ b/src/main/java/sirius/db/mongo/Updater.java
@@ -45,9 +45,9 @@ public class Updater extends QueryBuilder<Updater> {
     }
 
     /**
-     * Specifies that multiple documents should be updated.
+     * Specifies that a new document should be created if the update filter does not match anything.
      * <p>
-     * By default only one document is updated.
+     * By default nothing happens if the update filter does not match anything.
      *
      * @return the builder itself for fluent method calls
      */


### PR DESCRIPTION
- new MongoDB Java Library Version: 3.4.2
- Support for *upsert*: `db().update().upsert().where(...).set(...).executeFor(...);`
- now respects orders set by `orderByAsc` or `orderByDesc` when retrieving a single document with `singleIn(collection)`
- new Filters: `Filter.exists(key)` and `Filter.notExists(key)`