### PR TITLE
Adds a public method to check if Redis is still running.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.3.1</version>
+    <version>3.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>


### PR DESCRIPTION
Applications can call it prior to the actual Redis call to prevent `HandledExceptions` caused by `JedisConnectionExceptions` to be thrown at this place:

```
if (redis.isRunning()) {
    return redis.query(...);
} else {
    return null;
}
```