### PR TITLE
Doesn't stop Jedis until awaitTermination …

### DIFF
--- a/src/main/java/sirius/db/redis/Redis.java
+++ b/src/main/java/sirius/db/redis/Redis.java
@@ -169,14 +169,13 @@ public class Redis implements Lifecycle {
                           .handle();
             }
         }
-        if (jedis != null) {
-            jedis.close();
-        }
     }
 
     @Override
     public void awaitTermination() {
-        // Noting to do
+        if (jedis != null) {
+            jedis.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
…to prevent JedisConnectionException in AsyncTasks

That Exceptions occured during shutdown because Jedis was stopped before the Tasks Lifecycle, of which some Tasks still wanted to access Jedis.