### PR TITLE
BooleanSqlProperty Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -86,6 +86,6 @@ public class BooleanProperty extends Property {
 
     @Override
     protected int getSQLType() {
-        return Types.TINYINT;
+        return Types.BOOLEAN;
     }
 }

--- a/src/main/java/sirius/db/mixing/schema/HSQLDBDatabaseDialect.java
+++ b/src/main/java/sirius/db/mixing/schema/HSQLDBDatabaseDialect.java
@@ -133,7 +133,7 @@ public class HSQLDBDatabaseDialect extends BasicDatabaseDialect {
             return "BIGINT";
         }
         if (Types.BOOLEAN == type || Types.BIT == type) {
-            return "SMALLINT";
+            return "BOOLEAN";
         }
         if (Types.DOUBLE == type) {
             return "DOUBLE";


### PR DESCRIPTION
BooleanProperty.getSQLType() now returns Types.BOOLEAN instead of Types.TINYINT.
HSQLDatabaseDialect now stores Booleans as Booleans. They can still be assigned by [0, 1].
Before BooleanProperties were turned to a smallint field using the HSQLDatabaseDialect
Using the MYSQLDatabaseDialect Types.BOOLEAN is still converted into a tinyint(1).
Will this cause any unforeseen errors ?

- fixes: SE-2626