### PR TITLE
Fixes an IllegalArgumentException thrown by Java Reflection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.4</version>
+    <version>3.3.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.3.3</version>
+    <version>3.4.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>


### PR DESCRIPTION
If we join-fetch a primitive field (like a long), and the join
doesn't work (i.e. no entity on the right side), the column remains
null, which isn't an appropriate value for a primitive field.

In this case, we simply ignore null as a value for primitive fields.