### PR TITLE
Always fetch join columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
@@ -174,7 +174,7 @@ public class EntityRefProperty extends Property {
     /**
      * Updates the field ({@link EntityRef} within the given parent to point to the given child.
      * <p>
-     * If also ensures that the ID is propagated correctly. If a join fetch is executed, the id property might have
+     * It also ensures that the ID is propagated correctly. If a join fetch is executed, the id property might have
      * beend skipped. This will reset the id within the EntityRef to -1, which is the placeholder of the id in the
      * partially fetched entity. Therefore, we remember the original id, which is filled via the foreign key. We then
      * apply the join-fetched value and restore the id (on both sides) if required.
@@ -191,8 +191,9 @@ public class EntityRefProperty extends Property {
         // was not contained in the join fetch - which is quite common
         if (targetRef.getId() != referencedId && referencedId != -1) {
             child.setId(referencedId);
-            targetRef.setId(referencedId);
         }
+
+        targetRef.setId(referencedId == -1L ? null : referencedId);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -306,7 +306,7 @@ class SmartQuerySpec extends BaseSpecification {
         found.getParent().isEmpty()
     }
 
-    def "select existant entity ref without id"() {
+    def "select existant entity ref with automatic id fetching"() {
         given:
         SmartQueryTestParentEntity parent = new SmartQueryTestParentEntity()
         parent.setName("Parent 3")
@@ -329,6 +329,8 @@ class SmartQuerySpec extends BaseSpecification {
 
         then:
         found.getParent().isFilled()
+        and:
+        !found.getParent().getValue().isNew()
         and:
         Strings.isFilled(found.getParent().getValue().getName())
     }

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -303,11 +303,7 @@ class SmartQuerySpec extends BaseSpecification {
         TestEntityWithNullRef found = result.get(0)
 
         then:
-        found.getParent().isFilled()
-        and:
-        found.getParent().getValue().isNew()
-        and:
-        found.getParent().getId() == -1L
+        found.getParent().isEmpty()
     }
 
     def "select existant entity ref without id"() {
@@ -333,10 +329,6 @@ class SmartQuerySpec extends BaseSpecification {
 
         then:
         found.getParent().isFilled()
-        and:
-        found.getParent().getValue().isNew()
-        and:
-        found.getParent().getId() == -1L
         and:
         Strings.isFilled(found.getParent().getValue().getName())
     }


### PR DESCRIPTION
Always fetch the Id of the join columns as they are placed in the EntityRef implementation and a call to isFilled() may signal a wrong state, if a query was build using .fields() and the join-column was omitted.