### PR TITLE
Always fetch Join-columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/EntityRef.java
+++ b/src/main/java/sirius/db/mixing/EntityRef.java
@@ -187,7 +187,7 @@ public class EntityRef<E extends Entity> {
      * @return <tt>true</tt> if an entity is referenced (the stored id is not <tt>null</tt>). <tt>false</tt> otherwise
      */
     public boolean isFilled() {
-        return id != null;
+        return id != null && id != -1L;
     }
 
     /**
@@ -196,7 +196,7 @@ public class EntityRef<E extends Entity> {
      * @return <tt>true</tt> if no entity is referenced, <tt>false</tt> if a non null id is present.
      */
     public boolean isEmpty() {
-        return id == null;
+        return id == null || id == -1L;
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/SmartQuery.java
+++ b/src/main/java/sirius/db/mixing/SmartQuery.java
@@ -587,9 +587,9 @@ public class SmartQuery<E extends Entity> extends BaseQuery<E> {
         Monoflop mf = Monoflop.create();
         List<Column> requiredFields = new ArrayList<>();
 
-        for (Column field : fields) {
+        fields.forEach(field -> {
             appendToSELECT(c, applyAliases, mf, field, true, requiredFields);
-        }
+        });
 
         // make sure that the join fields are always fetched
         requiredFields.forEach(requiredField -> {

--- a/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EntityRefProperty.java
@@ -174,7 +174,7 @@ public class EntityRefProperty extends Property {
     /**
      * Updates the field ({@link EntityRef} within the given parent to point to the given child.
      * <p>
-     * If also ensures that the ID is propagated correctly. If a join fetch is executed, the id property might have
+     * It also ensures that the ID is propagated correctly. If a join fetch is executed, the id property might have
      * beend skipped. This will reset the id within the EntityRef to -1, which is the placeholder of the id in the
      * partially fetched entity. Therefore, we remember the original id, which is filled via the foreign key. We then
      * apply the join-fetched value and restore the id (on both sides) if required.

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -295,22 +295,18 @@ class SmartQuerySpec extends BaseSpecification {
         when:
         def result = oma.select(TestEntityWithNullRef.class)
                 .fields(TestEntityWithNullRef.NAME,
-                        SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME),
-                        SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.ID))
+                SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME),
+                SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.ID))
                 .eq(SmartQueryTestChildEntity.ID, testChild.getId()).queryList()
 
         and:
         TestEntityWithNullRef found = result.get(0)
 
         then:
-        found.getParent().isFilled()
-        and:
-        found.getParent().getValue().isNew()
-        and:
-        found.getParent().getId() == -1L
+        found.getParent().isEmpty()
     }
 
-    def "select existant entity ref without id"() {
+    def "select existant entity ref with automatic id fetching"() {
         given:
         SmartQueryTestParentEntity parent = new SmartQueryTestParentEntity()
         parent.setName("Parent 3")
@@ -334,9 +330,7 @@ class SmartQuerySpec extends BaseSpecification {
         then:
         found.getParent().isFilled()
         and:
-        found.getParent().getValue().isNew()
-        and:
-        found.getParent().getId() == -1L
+        !found.getParent().getValue().isNew()
         and:
         Strings.isFilled(found.getParent().getValue().getName())
     }


### PR DESCRIPTION
As we always fetch the Id of an EntityRef, we can treat -1L and null as empty.