### PR TITLE
Fixes some checks for schema updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.4.3</version>
+    <version>3.4.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/schema/MySQLDatabaseDialect.java
+++ b/src/main/java/sirius/db/mixing/schema/MySQLDatabaseDialect.java
@@ -36,12 +36,24 @@ public class MySQLDatabaseDialect extends BasicDatabaseDialect {
             return reason;
         }
 
-        if (target.isNullable() != current.isNullable() && target.getType() != Types.TIMESTAMP
-            || target.getDefaultValue() != null) {
+        // TIMESTAMP values cannot be null -> we gracefully ignore this
+        // here, since the alter statement would be ignored anyway.
+        if (target.getType() == Types.TIMESTAMP) {
+            return null;
+        }
+
+        if (target.isNullable() != current.isNullable()) {
+            // Don't change the column to NOT NULL if no default value exists, because some existing field values could
+            // be NULL
+            if (!target.isNullable() && target.getDefaultValue() == null) {
+                return null;
+            }
+
             return NLS.get("MySQLDatabaseDialect.differentNull");
         }
 
-        if (areDefaultsDifferent(target, current)) {
+        // Change the default value if it was changed. Don't remove it in case the new default is empty
+        if (areDefaultsDifferent(target, current) && target.getDefaultValue() != null) {
             return NLS.fmtr("MySQLDatabaseDialect.differentDefault")
                       .set(KEY_TARGET, target.getDefaultValue())
                       .set(KEY_CURRENT, current.getDefaultValue())
@@ -52,13 +64,7 @@ public class MySQLDatabaseDialect extends BasicDatabaseDialect {
     }
 
     protected boolean areDefaultsDifferent(TableColumn target, TableColumn current) {
-        if (equalValue(target.getDefaultValue(), current.getDefaultValue())) {
-            return false;
-        }
-
-        // TIMESTAMP values cannot be null -> we gracefully ignore this
-        // here, sice the alter statement would be ignored anyway.
-        return target.getType() != Types.TIMESTAMP || target.getDefaultValue() != null;
+        return !equalValue(target.getDefaultValue(), current.getDefaultValue());
     }
 
     protected String checkColumnSettings(TableColumn target, TableColumn current) {


### PR DESCRIPTION
The checks detected wrong changes of the nullable attribute when columns had default values. Changes are prevented if the new setting is NULL and the column has no default value. Some refactoring was done.