### PR TITLE
Fix selecting via inMixin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.5</version>
+    <version>3.5.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/Column.java
+++ b/src/main/java/sirius/db/mixing/Column.java
@@ -88,7 +88,7 @@ public class Column {
      * @return a column representing the combined path of this column and the given mixin
      */
     public Column inMixin(Class<?> mixinType) {
-        return new Column(name + SUBFIELD_SEPARATOR + mixinType.getSimpleName(), null);
+        return new Column(mixinType.getSimpleName() + SUBFIELD_SEPARATOR + name, null);
     }
 
     /**

--- a/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/mixing/SmartQuerySpec.groovy
@@ -334,4 +334,19 @@ class SmartQuerySpec extends BaseSpecification {
         and:
         Strings.isFilled(found.getParent().getValue().getName())
     }
+
+    def "select a entity with attached mixin by value in mixin"() {
+        given:
+        SmartQueryTestMixinEntity mixinEntity = new SmartQueryTestMixinEntity()
+        mixinEntity.setValue("testvalue1")
+        SmartQueryTestMixinEntityMixin mixinEntityMixin = mixinEntity.as(SmartQueryTestMixinEntityMixin.class)
+        mixinEntityMixin.setMixinValue("mixinvalue1")
+        oma.update(mixinEntity)
+        when:
+        SmartQueryTestMixinEntity entity = oma.select(SmartQueryTestMixinEntity.class).eq(SmartQueryTestMixinEntityMixin.MIXIN_VALUE.inMixin(SmartQueryTestMixinEntityMixin.class), "mixinvalue1").queryFirst()
+        then:
+        !mixinEntity.isNew()
+        and:
+        mixinEntity.getId() == entity.getId()
+    }
 }

--- a/src/test/java/sirius/db/mixing/SmartQueryTestMixinEntity.java
+++ b/src/test/java/sirius/db/mixing/SmartQueryTestMixinEntity.java
@@ -1,0 +1,26 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.mixing.annotations.Length;
+
+public class SmartQueryTestMixinEntity extends Entity {
+
+    @Length(50)
+    private String value;
+    public static final Column VALUE = Column.named("value");
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/sirius/db/mixing/SmartQueryTestMixinEntityMixin.java
+++ b/src/test/java/sirius/db/mixing/SmartQueryTestMixinEntityMixin.java
@@ -1,0 +1,28 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.Mixin;
+
+@Mixin(SmartQueryTestMixinEntity.class)
+public class SmartQueryTestMixinEntityMixin extends Mixable {
+
+    @Length(50)
+    private String mixinValue;
+    public static final Column MIXIN_VALUE = Column.named("mixinValue");
+
+    public String getMixinValue() {
+        return mixinValue;
+    }
+
+    public void setMixinValue(String mixinValue) {
+        this.mixinValue = mixinValue;
+    }
+}


### PR DESCRIPTION
The column name and the mixin name were swapped in the inMixin select in Column. Now entities can be selected via values of their mixins without problems.