### PR TITLE
Repairs a broken query generation pattern.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.6.2</version>
+    <version>3.6.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mixing/TranslationState.java
+++ b/src/main/java/sirius/db/mixing/TranslationState.java
@@ -1,0 +1,53 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.kernel.commons.Tuple;
+
+import java.util.Map;
+
+/**
+ * Keeps track of the internal JOIN and column translation state of a {@link sirius.db.mixing.SmartQuery.Compiler}.
+ * <p>
+ * This is mainly used by constraints which generate internal JOINS like {@link sirius.db.mixing.constraints.Exists}.
+ */
+public class TranslationState {
+
+    private final EntityDescriptor ed;
+    private final String defaultAlias;
+    private final StringBuilder joins;
+    private final Map<String, Tuple<String, EntityDescriptor>> joinTable;
+
+    protected TranslationState(EntityDescriptor ed,
+                            String defaultAlias,
+                            StringBuilder joins,
+                            Map<String, Tuple<String, EntityDescriptor>> joinTable) {
+
+        this.ed = ed;
+        this.defaultAlias = defaultAlias;
+        this.joins = joins;
+        this.joinTable = joinTable;
+    }
+
+    protected EntityDescriptor getEd() {
+        return ed;
+    }
+
+    protected String getDefaultAlias() {
+        return defaultAlias;
+    }
+
+    protected StringBuilder getJoins() {
+        return joins;
+    }
+
+    protected Map<String, Tuple<String, EntityDescriptor>> getJoinTable() {
+        return joinTable;
+    }
+}


### PR DESCRIPTION
If a table was JOINed within an EXISTS clause, an invalid query was generated, as we didn't expect that to happen.

We now support JOINs within an EXISTS constraint.