### PR TITLE
Allows to create unique temporary databases in MongoDB for test environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.8</version>
+    <version>3.9</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mongo/Mongo.java
+++ b/src/main/java/sirius/db/mongo/Mongo.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Maps;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.ServerAddress;
+import sirius.kernel.Sirius;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Watch;
@@ -50,6 +51,7 @@ public class Mongo {
     @Parts(IndexDescription.class)
     private PartCollection<IndexDescription> indexDescriptions;
 
+    protected boolean temporaryDB;
     protected volatile boolean tracing;
     protected volatile int traceLimit;
     protected Map<String, Tuple<String, String>> traceData = Maps.newConcurrentMap();
@@ -91,6 +93,12 @@ public class Mongo {
                                                  .collect(Collectors.toList()));
         }
 
+        if (dbName.contains("${timestamp}")) {
+            temporaryDB = true;
+            dbName = dbName.replace("${timestamp}", String.valueOf(System.currentTimeMillis()));
+            LOG.INFO("Using unique db name: %s", dbName);
+        }
+
         createIndices(mongoClient.getDB(dbName));
     }
 
@@ -109,6 +117,24 @@ public class Mongo {
                                                   idx.getClass().getName())
                           .handle();
             }
+        }
+    }
+
+    /**
+     * Deletes the temporary DB (used by UNIT tests).
+     */
+    protected void dropTemporaryDB() {
+        if (Sirius.isStartedAsTest() && temporaryDB && mongoClient != null) {
+            this.db().dropDatabase();
+        }
+    }
+
+    /**
+     * Closes the connection
+     */
+    protected void close() {
+        if (mongoClient != null) {
+            mongoClient.close();
         }
     }
 

--- a/src/main/java/sirius/db/mongo/Mongo.java
+++ b/src/main/java/sirius/db/mongo/Mongo.java
@@ -94,6 +94,11 @@ public class Mongo {
         }
 
         if (dbName.contains("${timestamp}")) {
+            if (!Sirius.isStartedAsTest()) {
+                throw Exceptions.handle()
+                                .withSystemErrorMessage("${timestamp} in mongo.db is only allowed in test environment!")
+                                .handle();
+            }
             temporaryDB = true;
             dbName = dbName.replace("${timestamp}", String.valueOf(System.currentTimeMillis()));
             LOG.INFO("Using unique db name: %s", dbName);

--- a/src/main/java/sirius/db/mongo/MongoLifecycle.java
+++ b/src/main/java/sirius/db/mongo/MongoLifecycle.java
@@ -1,0 +1,51 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo;
+
+import sirius.kernel.Lifecycle;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+
+/**
+ * Starts and stops the elasticsearch client.
+ */
+@Register(classes = Lifecycle.class)
+public class MongoLifecycle implements Lifecycle {
+
+    @Part
+    private Mongo mongo;
+
+    @Override
+    public int getPriority() {
+        return 75;
+    }
+
+    @Override
+    public void started() {
+        // nothing to do here, MongoDB gets intialized on first usage
+    }
+
+    @Override
+    public void stopped() {
+        // nothing to do here
+    }
+
+    @Override
+    public void awaitTermination() {
+        // We wait until this last call before we cut the connection to the database to permit
+        // other stopping lifecycles access until the very end...
+        mongo.dropTemporaryDB();
+        mongo.close();
+    }
+
+    @Override
+    public String getName() {
+        return "MongoDB";
+    }
+}

--- a/src/main/java/sirius/db/mongo/MongoLifecycle.java
+++ b/src/main/java/sirius/db/mongo/MongoLifecycle.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 
 /**
- * Starts and stops the elasticsearch client.
+ * Starts and stops the {@link Mongo} client.
  */
 @Register(classes = Lifecycle.class)
 public class MongoLifecycle implements Lifecycle {


### PR DESCRIPTION
similar to https://github.com/scireum/sirius-search/commit/30a6b4c2a0c48fabb0a45f95d7b469609490709c#diff-f84b96d667f494d11d616390e1f2a5b4R74

allows `mongo.db="junit-${timestamp}"`