### PR TITLE
getObject now unsures that it has a "map-like" BasicDBObject" at hands.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-db</artifactId>
-    <version>3.9</version>
+    <version>3.9.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS DB</name>

--- a/src/main/java/sirius/db/mongo/Document.java
+++ b/src/main/java/sirius/db/mongo/Document.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mongo;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -94,7 +95,12 @@ public class Document {
      * @return the object stored for the field
      */
     public DBObject getObject(String field) {
-        return get(field).get(DBObject.class, ReadonlyObject.EMPTY_OBJECT);
+        Object result = get(field).get();
+        if (result instanceof BasicDBObject) {
+            return (DBObject) result;
+        }
+
+        return ReadonlyObject.EMPTY_OBJECT;
     }
 
     /**


### PR DESCRIPTION
This is required as "everything" is a DBObject, even a list which leads to
quite a terrible behaviour when treated like an object.