### PR TITLE
Fixing joining on legacy fields

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -442,7 +442,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E> {
                  .append(".id = ")
                  .append(parentAlias.getFirst())
                  .append(".")
-                 .append(parent.getName());
+                 .append(parentAlias.getSecond().rewritePropertyName(parent.getName()));
             result = Tuple.create(tableAlias, other);
             joinTable.put(path, result);
             return result;


### PR DESCRIPTION
Without this joining on legacy fields would fail as the framework used the field name instead of the legacy name.