### PR TITLE
Limit MySQL foreign key lengths

### DIFF
--- a/src/main/java/sirius/db/jdbc/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/jdbc/properties/SQLEntityRefProperty.java
@@ -13,9 +13,9 @@ import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
+import sirius.db.jdbc.OMA;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SQLEntityRef;
-import sirius.db.jdbc.OMA;
 import sirius.db.jdbc.schema.ForeignKey;
 import sirius.db.jdbc.schema.SQLPropertyInfo;
 import sirius.db.jdbc.schema.Table;
@@ -85,6 +85,12 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
         if (SQLEntity.class.isAssignableFrom(getReferencedType()) && Strings.areEqual(getDescriptor().getRealm(),
                                                                                       getReferencedDescriptor().getRealm())) {
             ForeignKey fk = new ForeignKey();
+            fk.setName("fk_"
+                       + descriptor.getRelationName()
+                       + "_"
+                       + getPropertyName()
+                       + "_"
+                       + referencedDescriptor.getRelationName());
             fk.setName("fk_" + getPropertyName());
             fk.setForeignTable(getReferencedDescriptor().getRelationName());
             fk.addForeignColumn(1, SQLEntity.ID.getName());

--- a/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
@@ -72,6 +72,8 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
     public String generateAddForeignKey(Table table, ForeignKey key) {
         return MessageFormat.format("ALTER TABLE `{0}` ADD CONSTRAINT `{1}` FOREIGN KEY ({2}) REFERENCES `{3}` ({4})",
                                     table.getName(),
+                                    getConstraintCharacterLimit() > 0 ?
+                                    Strings.limit(key.getName(), getConstraintCharacterLimit()) :
                                     key.getName(),
                                     String.join(", ", key.getColumns()),
                                     key.getForeignTable(),
@@ -128,7 +130,11 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
 
     @Override
     public String generateDropForeignKey(Table table, ForeignKey key) {
-        return MessageFormat.format("ALTER TABLE `{0}` DROP FOREIGN KEY `{1}`", table.getName(), key.getName());
+        return MessageFormat.format("ALTER TABLE `{0}` DROP FOREIGN KEY `{1}`",
+                                    table.getName(),
+                                    getConstraintCharacterLimit() > 0 ?
+                                    Strings.limit(key.getName(), getConstraintCharacterLimit()) :
+                                    key.getName());
     }
 
     @Override
@@ -408,5 +414,17 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
         }
 
         return Value.of(engine.value());
+    }
+
+    /**
+     * Determines the length a constraint should have.
+     * <p>
+     * If no limit is known, <tt>0</tt> is returned as limit.
+     *
+     * @return the maximum allowed length of a constraint or
+     * <tt>0</tt> if no limit is known
+     */
+    protected int getConstraintCharacterLimit() {
+        return 0;
     }
 }

--- a/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
@@ -72,9 +72,7 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
     public String generateAddForeignKey(Table table, ForeignKey key) {
         return MessageFormat.format("ALTER TABLE `{0}` ADD CONSTRAINT `{1}` FOREIGN KEY ({2}) REFERENCES `{3}` ({4})",
                                     table.getName(),
-                                    getConstraintCharacterLimit() > 0 ?
-                                    Strings.limit(key.getName(), getConstraintCharacterLimit()) :
-                                    key.getName(),
+                                    Strings.limit(key.getName(), getConstraintCharacterLimit()),
                                     String.join(", ", key.getColumns()),
                                     key.getForeignTable(),
                                     String.join(", ", key.getForeignColumns()));
@@ -132,9 +130,7 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
     public String generateDropForeignKey(Table table, ForeignKey key) {
         return MessageFormat.format("ALTER TABLE `{0}` DROP FOREIGN KEY `{1}`",
                                     table.getName(),
-                                    getConstraintCharacterLimit() > 0 ?
-                                    Strings.limit(key.getName(), getConstraintCharacterLimit()) :
-                                    key.getName());
+                                    Strings.limit(key.getName(), getConstraintCharacterLimit()));
     }
 
     @Override
@@ -418,13 +414,10 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
 
     /**
      * Determines the length a constraint should have.
-     * <p>
-     * If no limit is known, <tt>0</tt> is returned as limit.
      *
-     * @return the maximum allowed length of a constraint or
-     * <tt>0</tt> if no limit is known
+     * @return the maximum allowed length of a constraint
      */
     protected int getConstraintCharacterLimit() {
-        return 0;
+        return 1024;
     }
 }

--- a/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
@@ -124,4 +124,9 @@ public class MySQLDatabaseDialect extends BasicDatabaseDialect {
     public boolean shouldDropKey(Table targetTable, Table currentTable, Key key) {
         return true;
     }
+
+    @Override
+    protected int getConstraintCharacterLimit() {
+        return 64;
+    }
 }


### PR DESCRIPTION
MySQL puts a limit on constraints of 64 characters. The constraint symbols have to be unique. The last changes generated non unique constraint names for foreign keys which lead to some error messages. So therefore the old constraint names are now restored, however, to avoid errors caused by too long constriant symbols, these are now limited for MySQL.