### PR TITLE
Remove wrong foreign key name

### DIFF
--- a/src/main/java/sirius/db/jdbc/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/jdbc/properties/SQLEntityRefProperty.java
@@ -91,7 +91,6 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
                        + getPropertyName()
                        + "_"
                        + referencedDescriptor.getRelationName());
-            fk.setName("fk_" + getPropertyName());
             fk.setForeignTable(getReferencedDescriptor().getRelationName());
             fk.addForeignColumn(1, SQLEntity.ID.getName());
             fk.addColumn(1, getPropertyName());


### PR DESCRIPTION
The correct old format was overwritten with the short foreign key name.