### PR TITLE
Store mappable classes thread-safe

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityLoadAction.java
+++ b/src/main/java/sirius/db/mixing/EntityLoadAction.java
@@ -25,7 +25,8 @@ import java.util.List;
  */
 public class EntityLoadAction implements ClassLoadAction {
 
-    private static List<Class<? extends BaseEntity<?>>> mappableClasses = new ArrayList<>();
+    private static List<Class<? extends BaseEntity<?>>> mappableClasses =
+            Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Once a new instance is created - which only happens during framework initialization, we reset the list of known

--- a/src/main/java/sirius/db/mixing/NestedLoadAction.java
+++ b/src/main/java/sirius/db/mixing/NestedLoadAction.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class NestedLoadAction implements ClassLoadAction {
 
-    private static List<Class<? extends Nested>> mappableClasses = new ArrayList<>();
+    private static List<Class<? extends Nested>> mappableClasses = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Once a new instance is created - which only happens during framework initialization, we reset the list of known


### PR DESCRIPTION
Classloading occurs within a parallel stream which might corrupt 'mappableClasses' which might lead to errors like
"X is not a managed entity".