### PR TITLE
Corrects the failOnOver method in BaseQuery

### DIFF
--- a/src/main/java/sirius/db/mixing/query/BaseQuery.java
+++ b/src/main/java/sirius/db/mixing/query/BaseQuery.java
@@ -159,14 +159,14 @@ public abstract class BaseQuery<Q, E extends BaseEntity<?>> {
 
         iterateAll(entity -> {
             result.add(entity);
-            failIOnOverflow(result);
+            failOnOverflow(result);
         });
 
         return result;
     }
 
-    protected void failIOnOverflow(List<E> result) {
-        if (result.size() >= MAX_LIST_SIZE) {
+    protected void failOnOverflow(List<E> result) {
+        if (result.size() > MAX_LIST_SIZE) {
             throw Exceptions.handle()
                             .to(Mongo.LOG)
                             .withSystemErrorMessage("More than %s results were loaded into a list by executing: %s",


### PR DESCRIPTION
Up to now if the limit was set to MAX_LIST_SIZE the check of queryList will allow this query.
But if MAX_LIST_SIZE entities where actually selected the last element added to the list will trigger
the failOnOverflow.
- Fixes: SE-4476