### PR TITLE
Apply date ranges correctly

### DIFF
--- a/src/main/java/sirius/db/mixing/DateRange.java
+++ b/src/main/java/sirius/db/mixing/DateRange.java
@@ -9,6 +9,7 @@
 package sirius.db.mixing;
 
 import sirius.db.mixing.query.Query;
+import sirius.db.mixing.query.constraints.Constraint;
 import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nullable;
@@ -236,12 +237,12 @@ public class DateRange {
      * @param field the field to filter on
      * @param qry   the query to expand
      */
-    public void applyTo(String field, Query<?, ?, ?> qry) {
+    public <C extends Constraint> void applyTo(String field, Query<?, ?, C> qry) {
         if (from != null) {
-            ((Query) qry).where(qry.filters().gte(Mapping.named(field), useLocalDate ? from.toLocalDate() : from));
+            qry.where(qry.filters().gte(Mapping.named(field), useLocalDate ? from.toLocalDate() : from));
         }
         if (until != null) {
-            ((Query) qry).where(qry.filters().lte(Mapping.named(field), useLocalDate ? until.toLocalDate() : until));
+            qry.where(qry.filters().lte(Mapping.named(field), useLocalDate ? until.toLocalDate() : until));
         }
     }
 

--- a/src/main/java/sirius/db/mixing/DateRange.java
+++ b/src/main/java/sirius/db/mixing/DateRange.java
@@ -238,10 +238,10 @@ public class DateRange {
      */
     public void applyTo(String field, Query<?, ?, ?> qry) {
         if (from != null) {
-            qry.filters().gte(Mapping.named(field), useLocalDate ? from.toLocalDate() : from);
+            ((Query) qry).where(qry.filters().gte(Mapping.named(field), useLocalDate ? from.toLocalDate() : from));
         }
         if (until != null) {
-            qry.filters().lte(Mapping.named(field), useLocalDate ? until.toLocalDate() : until);
+            ((Query) qry).where(qry.filters().lte(Mapping.named(field), useLocalDate ? until.toLocalDate() : until));
         }
     }
 


### PR DESCRIPTION
The DateRange filter was not applied correctly as the gte/lte call does only return the constraint but does not apply it to the given query. Now the filter gets applied. The casting is needed as otherwise this would not be a valid Java call. Don't ask why ...

Tags: filter, date