### PR TITLE
Separates exists and filled/notFilled logic

### DIFF
--- a/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
@@ -11,9 +11,9 @@ package sirius.db.es.constraints;
 import com.alibaba.fastjson.JSONObject;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticEntity;
-import sirius.db.mixing.properties.StringMapProperty;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.properties.StringMapProperty;
 import sirius.db.mixing.query.QueryField;
 import sirius.db.mixing.query.constraints.CSVFilter;
 import sirius.db.mixing.query.constraints.FilterFactory;
@@ -90,20 +90,49 @@ public class ElasticFilterFactory extends FilterFactory<ElasticConstraint> {
         return rangeFilter(field, orEqual ? "lte" : "lt", value);
     }
 
+    /**
+     * Checks whether the given field is filled which means whether the given field is present, as elastic doesn't index
+     * null-values by default. The field is just not created.
+     *
+     * @param field the field to check
+     * @return the generated constraint
+     */
     @Override
     public ElasticConstraint filled(Mapping field) {
-        return neValue(field, null);
+        return wrap(new JSONObject().fluentPut("exists",
+                                               new JSONObject().fluentPut("field", determineFilterField(field))));
     }
 
+    /**
+     * Checks whether the given field is not filled which means whether the given field is absent, as elastic doesn't index
+     * null-values by default. The field is just not created.
+     *
+     * @param field the field to check
+     * @return the generated constraint
+     */
     @Override
     public ElasticConstraint notFilled(Mapping field) {
         return not(filled(field));
     }
 
-    @Override
+    /**
+     * As elastic doesn't index null-values by default an exists query is basically the same as a {@link #filled(Mapping)} query.
+     *
+     * @param field the field to check
+     * @return the generated constraint
+     */
     public ElasticConstraint exists(Mapping field) {
-        return wrap(new JSONObject().fluentPut("exists",
-                                               new JSONObject().fluentPut("field", determineFilterField(field))));
+        return filled(field);
+    }
+
+    /**
+     * As elastic doesn't index null-values by default a notExists query is basically the same as a {@link #notFilled(Mapping)} query.
+     *
+     * @param field the field to check
+     * @return the generated constraint
+     */
+    public ElasticConstraint notExists(Mapping field) {
+        return notFilled(field);
     }
 
     @Override

--- a/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
@@ -92,13 +92,18 @@ public class ElasticFilterFactory extends FilterFactory<ElasticConstraint> {
 
     @Override
     public ElasticConstraint filled(Mapping field) {
-        return wrap(new JSONObject().fluentPut("exists",
-                                               new JSONObject().fluentPut("field", determineFilterField(field))));
+        return neValue(field, null);
     }
 
     @Override
     public ElasticConstraint notFilled(Mapping field) {
         return not(filled(field));
+    }
+
+    @Override
+    public ElasticConstraint exists(Mapping field) {
+        return wrap(new JSONObject().fluentPut("exists",
+                                               new JSONObject().fluentPut("field", determineFilterField(field))));
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -56,6 +56,7 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
 
     /**
      * Ensures that the given field is neither <tt>NULL</tt> nor an empty string.
+     *
      * @param field the field to check
      * @return a constraint which ensures that the given field contains a non-empty string
      */
@@ -66,6 +67,11 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     @Override
     public SQLConstraint notFilled(Mapping field) {
         return new NotFilled(field);
+    }
+
+    @Override
+    public SQLConstraint exists(Mapping field) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -70,11 +70,6 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     }
 
     @Override
-    public SQLConstraint exists(Mapping field) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     protected SQLConstraint invert(SQLConstraint constraint) {
         return new Not(constraint);
     }

--- a/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
@@ -335,14 +335,6 @@ public abstract class FilterFactory<C extends Constraint> {
     public abstract C notFilled(Mapping field);
 
     /**
-     * Generates a constraint which ensures that the given field exists.
-     *
-     * @param field the field to check
-     * @return the generated constraint
-     */
-    public abstract C exists(Mapping field);
-
-    /**
      * Inverts the given constraint.
      *
      * @param constraint the constraint to invert.

--- a/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
@@ -335,6 +335,14 @@ public abstract class FilterFactory<C extends Constraint> {
     public abstract C notFilled(Mapping field);
 
     /**
+     * Generates a constraint which ensures that the given field exists.
+     *
+     * @param field the field to check
+     * @return the generated constraint
+     */
+    public abstract C exists(Mapping field);
+
+    /**
      * Inverts the given constraint.
      *
      * @param constraint the constraint to invert.

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -82,9 +82,12 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
         return eqValue(field, null);
     }
 
-    @Override
     public MongoConstraint exists(Mapping field) {
         return new MongoConstraint(field.toString(), new Document("$exists", true));
+    }
+
+    public MongoConstraint notExists(Mapping field) {
+        return new MongoConstraint(field.toString(), new Document("$exists", false));
     }
 
     @Override

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -82,10 +82,22 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
         return eqValue(field, null);
     }
 
+    /**
+     * Checks whether the given field is present, independent of the field value (specially 'null').
+     *
+     * @param field the field to filter
+     * @return the generated constraint
+     */
     public MongoConstraint exists(Mapping field) {
         return new MongoConstraint(field.toString(), new Document("$exists", true));
     }
 
+    /**
+     * Checks whether the given field is absent, independent of the field value (specially 'null').
+     *
+     * @param field the field to filter
+     * @return the generated constraint
+     */
     public MongoConstraint notExists(Mapping field) {
         return new MongoConstraint(field.toString(), new Document("$exists", false));
     }

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -74,12 +74,17 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
 
     @Override
     public MongoConstraint filled(Mapping field) {
-        return new MongoConstraint(field.toString(), new Document("$exists", true));
+        return neValue(field, null);
     }
 
     @Override
     public MongoConstraint notFilled(Mapping field) {
-        return new MongoConstraint(field.toString(), new Document("$exists", false));
+        return eqValue(field, null);
+    }
+
+    @Override
+    public MongoConstraint exists(Mapping field) {
+        return new MongoConstraint(field.toString(), new Document("$exists", true));
     }
 
     @Override

--- a/src/test/java/sirius/db/es/properties/ESFilledEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESFilledEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es.properties;
+
+import sirius.db.es.ElasticEntity;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
+
+public class ESFilledEntity extends ElasticEntity {
+
+    public static final Mapping TEST_FIELD = Mapping.named("testField");
+    @NullAllowed
+    private String testField;
+
+    public String getTestField() {
+        return testField;
+    }
+
+    public void setTestField(String testField) {
+        this.testField = testField;
+    }
+}

--- a/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
+++ b/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
@@ -31,33 +31,49 @@ class ESFilledSpec extends BaseSpecification {
         elastic.select(ESFilledEntity.class)
                .eq(ESFilledEntity.TEST_FIELD, null)
                .queryFirst()
-               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                            .eq(ESFilledEntity.TEST_FIELD, null).count() == 1
+               .getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .eq(ESFilledEntity.TEST_FIELD, null)
+               .count() == 1
+
         elastic.select(ESFilledEntity.class)
                .where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD))
                .queryFirst()
-               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                            .where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD)).count() == 1
+               .getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD))
+               .count() == 1
+
         elastic.select(ESFilledEntity.class)
                .where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD))
                .queryFirst()
-               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                            .where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD)).count() == 1
+               .getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD))
+               .count() == 1
 
         elastic.select(ESFilledEntity.class)
                .ne(ESFilledEntity.TEST_FIELD, null)
                .queryFirst()
-               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                         .ne(ESFilledEntity.TEST_FIELD, null).count() == 1
+               .getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .ne(ESFilledEntity.TEST_FIELD, null)
+               .count() == 1
+
         elastic.select(ESFilledEntity.class)
                .where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD))
                .queryFirst()
-               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                         .where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD)).count() == 1
+               .getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD))
+               .count() == 1
+
         elastic.select(ESFilledEntity.class)
                .where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD))
                .queryFirst()
-               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
-                                                                         .where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD)).count() == 1
+               .getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD))
+               .count() == 1
     }
 }

--- a/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
+++ b/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
@@ -28,30 +28,36 @@ class ESFilledSpec extends BaseSpecification {
         elastic.update(fieldNotFilled)
         Wait.seconds(1)
         then:
-        elastic.select(ESFilledEntity.class).
-                eq(ESFilledEntity.TEST_FIELD, null).
-                queryFirst().
-                getIdAsString() == fieldNotFilled.getIdAsString()
-        elastic.select(ESFilledEntity.class).
-                where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD)).
-                queryFirst().
-                getIdAsString() == fieldNotFilled.getIdAsString()
-        elastic.select(ESFilledEntity.class).
-                where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD)).
-                queryFirst().
-                getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .eq(ESFilledEntity.TEST_FIELD, null)
+               .queryFirst()
+               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                            .eq(ESFilledEntity.TEST_FIELD, null).count() == 1
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD))
+               .queryFirst()
+               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                            .where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD)).count() == 1
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD))
+               .queryFirst()
+               .getIdAsString() == fieldNotFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                            .where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD)).count() == 1
 
-        elastic.select(ESFilledEntity.class).
-                ne(ESFilledEntity.TEST_FIELD, null).
-                queryFirst().
-                getIdAsString() == fieldFilled.getIdAsString()
-        elastic.select(ESFilledEntity.class).
-                where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD)).
-                queryFirst().
-                getIdAsString() == fieldFilled.getIdAsString()
-        elastic.select(ESFilledEntity.class).
-                where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD)).
-                queryFirst().
-                getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class)
+               .ne(ESFilledEntity.TEST_FIELD, null)
+               .queryFirst()
+               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                         .ne(ESFilledEntity.TEST_FIELD, null).count() == 1
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD))
+               .queryFirst()
+               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                         .where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD)).count() == 1
+        elastic.select(ESFilledEntity.class)
+               .where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD))
+               .queryFirst()
+               .getIdAsString() == fieldFilled.getIdAsString() && elastic.select(ESFilledEntity.class)
+                                                                         .where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD)).count() == 1
     }
 }

--- a/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
+++ b/src/test/java/sirius/db/es/properties/ESFilledSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es.properties
+
+import sirius.db.es.Elastic
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Wait
+import sirius.kernel.di.std.Part
+
+class ESFilledSpec extends BaseSpecification {
+
+    @Part
+    private static Elastic elastic
+
+    def "filled/notFilled/exists query works"() {
+        setup:
+        ESFilledEntity fieldFilled = new ESFilledEntity()
+        fieldFilled.setTestField("test")
+        ESFilledEntity fieldNotFilled = new ESFilledEntity()
+        when:
+        elastic.update(fieldFilled)
+        elastic.update(fieldNotFilled)
+        Wait.seconds(1)
+        then:
+        elastic.select(ESFilledEntity.class).
+                eq(ESFilledEntity.TEST_FIELD, null).
+                queryFirst().
+                getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class).
+                where(Elastic.FILTERS.notFilled(ESFilledEntity.TEST_FIELD)).
+                queryFirst().
+                getIdAsString() == fieldNotFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class).
+                where(Elastic.FILTERS.notExists(ESFilledEntity.TEST_FIELD)).
+                queryFirst().
+                getIdAsString() == fieldNotFilled.getIdAsString()
+
+        elastic.select(ESFilledEntity.class).
+                ne(ESFilledEntity.TEST_FIELD, null).
+                queryFirst().
+                getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class).
+                where(Elastic.FILTERS.filled(ESFilledEntity.TEST_FIELD)).
+                queryFirst().
+                getIdAsString() == fieldFilled.getIdAsString()
+        elastic.select(ESFilledEntity.class).
+                where(Elastic.FILTERS.exists(ESFilledEntity.TEST_FIELD)).
+                queryFirst().
+                getIdAsString() == fieldFilled.getIdAsString()
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoExistsEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoExistsEntity.java
@@ -1,0 +1,26 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mongo.MongoEntity;
+
+public class MongoExistsEntity extends MongoEntity {
+
+    public static final Mapping TEST_FIELD = Mapping.named("testField");
+    private String testField;
+
+    public String getTestField() {
+        return testField;
+    }
+
+    public void setTestField(String testField) {
+        this.testField = testField;
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties
+
+import sirius.db.KeyGenerator
+import sirius.db.mongo.Doc
+import sirius.db.mongo.Mango
+import sirius.db.mongo.Mongo
+import sirius.db.mongo.MongoEntity
+import sirius.db.mongo.QueryBuilder
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+
+class MongoExistsSpec extends BaseSpecification {
+
+    @Part
+    private static Mango mango
+
+    @Part
+    private static Mongo mongo
+
+    @Part
+    private static KeyGenerator keyGen
+
+    def "exists query works"() {
+        when:
+        Doc fieldMissing = mongo.insert().set(MongoEntity.ID, keyGen.generateId()).into(MongoExistsEntity.class)
+        Doc fieldPresent = mongo.insert().
+                set(MongoEntity.ID, keyGen.generateId()).
+                set(MongoExistsEntity.TEST_FIELD, "test").
+                into(MongoExistsEntity.class)
+        then:
+        mango.select(MongoExistsEntity.class).
+                where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD)).
+                queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID)
+
+        mango.select(MongoExistsEntity.class).
+                where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD)).
+                queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID)
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
@@ -38,31 +38,44 @@ class MongoExistsSpec extends BaseSpecification {
         then:
         mango.select(MongoExistsEntity.class)
              .eq(MongoExistsEntity.TEST_FIELD, null)
-             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .eq(MongoExistsEntity.TEST_FIELD, null).count() == 1
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .eq(MongoExistsEntity.TEST_FIELD, null)
+             .count() == 1
 
         mango.select(MongoExistsEntity.class)
              .ne(MongoExistsEntity.TEST_FIELD, null)
-             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .ne(MongoExistsEntity.TEST_FIELD, null).count() == 1
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .ne(MongoExistsEntity.TEST_FIELD, null)
+             .count() == 1
 
         mango.select(MongoExistsEntity.class)
              .where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD))
+             .count() == 1
 
         mango.select(MongoExistsEntity.class)
              .where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD))
+             .count() == 1
+
         mango.select(MongoExistsEntity.class)
              .where(QueryBuilder.FILTERS.filled(MongoExistsEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .where(QueryBuilder.FILTERS.filled(MongoExistsEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.filled(MongoExistsEntity.TEST_FIELD))
+             .count() == 1
 
         mango.select(MongoExistsEntity.class)
              .where(QueryBuilder.FILTERS.notFilled(MongoExistsEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
-                                                                                             .where(QueryBuilder.FILTERS.notFilled(MongoExistsEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.notFilled(MongoExistsEntity.TEST_FIELD))
+             .count() == 1
     }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoExistsSpec.groovy
@@ -36,12 +36,33 @@ class MongoExistsSpec extends BaseSpecification {
                 set(MongoExistsEntity.TEST_FIELD, "test").
                 into(MongoExistsEntity.class)
         then:
-        mango.select(MongoExistsEntity.class).
-                where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD)).
-                queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .eq(MongoExistsEntity.TEST_FIELD, null)
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .eq(MongoExistsEntity.TEST_FIELD, null).count() == 1
 
-        mango.select(MongoExistsEntity.class).
-                where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD)).
-                queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID)
+        mango.select(MongoExistsEntity.class)
+             .ne(MongoExistsEntity.TEST_FIELD, null)
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .ne(MongoExistsEntity.TEST_FIELD, null).count() == 1
+
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .where(QueryBuilder.FILTERS.exists(MongoExistsEntity.TEST_FIELD)).count() == 1
+
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .where(QueryBuilder.FILTERS.notExists(MongoExistsEntity.TEST_FIELD)).count() == 1
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.filled(MongoExistsEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldPresent.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .where(QueryBuilder.FILTERS.filled(MongoExistsEntity.TEST_FIELD)).count() == 1
+
+        mango.select(MongoExistsEntity.class)
+             .where(QueryBuilder.FILTERS.notFilled(MongoExistsEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldMissing.getString(MongoEntity.ID) && mango.select(MongoExistsEntity.class)
+                                                                                             .where(QueryBuilder.FILTERS.notFilled(MongoExistsEntity.TEST_FIELD)).count() == 1
     }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
+import sirius.db.mongo.MongoEntity;
+
+public class MongoFilledEntity extends MongoEntity {
+
+    public static final Mapping TEST_FIELD = Mapping.named("testField");
+    @NullAllowed
+    private String testField;
+
+    public String getTestField() {
+        return testField;
+    }
+
+    public void setTestField(String testField) {
+        this.testField = testField;
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
@@ -13,8 +13,6 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Strings
 import sirius.kernel.di.std.Part
 
-import java.util.function.Predicate
-
 class MongoFilledSpec extends BaseSpecification {
 
     @Part

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
@@ -34,28 +34,36 @@ class MongoFilledSpec extends BaseSpecification {
         then:
         mango.select(MongoFilledEntity.class)
              .eq(MongoFilledEntity.TEST_FIELD, null)
-             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
-                                                                                     .eq(MongoFilledEntity.TEST_FIELD, null).count() == 1
+             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .eq(MongoFilledEntity.TEST_FIELD, null)
+             .count() == 1
+
         mango.select(MongoFilledEntity.class)
              .ne(MongoFilledEntity.TEST_FIELD, null)
-             .queryFirst().getIdAsString() == fieldFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
-                                                                                  .ne(MongoFilledEntity.TEST_FIELD, null).count() == 1
+             .queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .ne(MongoFilledEntity.TEST_FIELD, null)
+             .count() == 1
 
         mango.select(MongoFilledEntity.class)
              .where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
-                                                                                  .where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD))
+             .count() == 1
 
         mango.select(MongoFilledEntity.class)
              .where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD))
-             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
-                                                                                     .where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD)).count() == 1
+             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD))
+             .count() == 1
 
         mango.select(MongoFilledEntity.class)
              .where(QueryBuilder.FILTERS.exists(MongoFilledEntity.TEST_FIELD))
              .queryList()
              .every({e -> Strings.areEqual(e.getIdAsString(), fieldNotFilled.getIdAsString()) || Strings.areEqual(e.getIdAsString(), fieldFilled.getIdAsString()) })
-
         mango.select(MongoFilledEntity.class)
              .where(QueryBuilder.FILTERS.notExists(MongoFilledEntity.TEST_FIELD)).count() == 0
     }

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties
+
+import sirius.db.mongo.*
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+
+class MongoFilledSpec extends BaseSpecification {
+
+    @Part
+    private static Mango mango
+
+    @Part
+    private static Mongo mongo
+
+    def "filled/notFilled query works"() {
+        setup:
+        MongoFilledEntity fieldFilled = new MongoFilledEntity()
+        fieldFilled.setTestField("test")
+        MongoFilledEntity fieldNotFilled = new MongoFilledEntity()
+        when:
+        mango.update(fieldFilled)
+        mango.update(fieldNotFilled)
+        then:
+        mango.select(MongoFilledEntity.class).ne(MongoFilledEntity.TEST_FIELD, null).
+                queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+
+        mango.select(MongoFilledEntity.class).
+                where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD)).
+                queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+
+        mango.select(MongoFilledEntity.class).eq(MongoFilledEntity.TEST_FIELD, null).
+                queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+
+        mango.select(MongoFilledEntity.class).
+                where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD)).
+                queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledSpec.groovy
@@ -10,7 +10,10 @@ package sirius.db.mongo.properties
 
 import sirius.db.mongo.*
 import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Strings
 import sirius.kernel.di.std.Part
+
+import java.util.function.Predicate
 
 class MongoFilledSpec extends BaseSpecification {
 
@@ -29,18 +32,31 @@ class MongoFilledSpec extends BaseSpecification {
         mango.update(fieldFilled)
         mango.update(fieldNotFilled)
         then:
-        mango.select(MongoFilledEntity.class).ne(MongoFilledEntity.TEST_FIELD, null).
-                queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .eq(MongoFilledEntity.TEST_FIELD, null)
+             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
+                                                                                     .eq(MongoFilledEntity.TEST_FIELD, null).count() == 1
+        mango.select(MongoFilledEntity.class)
+             .ne(MongoFilledEntity.TEST_FIELD, null)
+             .queryFirst().getIdAsString() == fieldFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
+                                                                                  .ne(MongoFilledEntity.TEST_FIELD, null).count() == 1
 
-        mango.select(MongoFilledEntity.class).
-                where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD)).
-                queryFirst().getIdAsString() == fieldFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
+                                                                                  .where(QueryBuilder.FILTERS.filled(MongoFilledEntity.TEST_FIELD)).count() == 1
 
-        mango.select(MongoFilledEntity.class).eq(MongoFilledEntity.TEST_FIELD, null).
-                queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD))
+             .queryFirst().getIdAsString() == fieldNotFilled.getIdAsString() && mango.select(MongoFilledEntity.class)
+                                                                                     .where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD)).count() == 1
 
-        mango.select(MongoFilledEntity.class).
-                where(QueryBuilder.FILTERS.notFilled(MongoFilledEntity.TEST_FIELD)).
-                queryFirst().getIdAsString() == fieldNotFilled.getIdAsString()
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.exists(MongoFilledEntity.TEST_FIELD))
+             .queryList()
+             .every({e -> Strings.areEqual(e.getIdAsString(), fieldNotFilled.getIdAsString()) || Strings.areEqual(e.getIdAsString(), fieldFilled.getIdAsString()) })
+
+        mango.select(MongoFilledEntity.class)
+             .where(QueryBuilder.FILTERS.notExists(MongoFilledEntity.TEST_FIELD)).count() == 0
     }
 }


### PR DESCRIPTION
Adds a new method 'exists' which checks whether a field is present for a document in contrast to
filled/notFilled which checks whether the actual field value is (not) null.