### PR TITLE
Fixes some bugs in the "fields" feature in MongoQuery and SmartQuery

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -35,7 +35,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provides a query DSL which is used to query {@link SQLEntity} instances from the database.
@@ -113,18 +114,25 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
 
     /**
      * Specifies the fields to select, which also have to be <tt>DISTINCT</tt>.
+     * The {@link SQLEntity#ID ID} field is always selected.
      *
      * @param fields the fields to select and to apply a <tt>DISTINCT</tt> filter on.
      * @return the query itself for fluent method calls
      */
     public SmartQuery<E> distinctFields(Mapping... fields) {
-        this.fields = Arrays.asList(fields);
+        if (fields.length > 0) {
+            this.fields =
+                    Stream.concat(Stream.of(SQLEntity.ID), Stream.of(fields)).distinct().collect(Collectors.toList());
+        } else {
+            this.fields = Collections.emptyList();
+        }
         this.distinct = true;
         return this;
     }
 
     /**
      * Specifies which fields to select.
+     * The {@link SQLEntity#ID ID} field is always selected.
      * <p>
      * If no fields are given, <tt>*</tt> is selected
      *
@@ -132,7 +140,12 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * @return the query itself for fluent method calls
      */
     public SmartQuery<E> fields(Mapping... fields) {
-        this.fields = Lists.newArrayList(fields);
+        if (fields.length > 0) {
+            this.fields =
+                    Stream.concat(Stream.of(SQLEntity.ID), Stream.of(fields)).distinct().collect(Collectors.toList());
+        } else {
+            this.fields = Collections.emptyList();
+        }
         return this;
     }
 

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -36,13 +36,14 @@ public class Finder extends QueryBuilder<Finder> {
     }
 
     /**
-     * Limits the fields being returned to the given list.
+     * Limits the fields being returned to the given list. The {@link MongoEntity#ID ID} field is always returned.
      *
      * @param fieldsToReturn specified the list of fields to return
      * @return the builder itself for fluent method calls
      */
     public Finder selectFields(Mapping... fieldsToReturn) {
         fields = new Document();
+        fields.put(MongoEntity.ID.toString(), 1);
         for (Mapping field : fieldsToReturn) {
             fields.put(field.toString(), 1);
         }
@@ -51,13 +52,14 @@ public class Finder extends QueryBuilder<Finder> {
     }
 
     /**
-     * Limits the fields being returned to the given list.
+     * Limits the fields being returned to the given list. The {@link MongoEntity#ID ID} field is always returned.
      *
      * @param fieldsToReturn specified the list of fields to return
      * @return the builder itself for fluent method calls
      */
     public Finder selectFields(String... fieldsToReturn) {
         fields = new Document();
+        fields.put(MongoEntity.ID.toString(), 1);
         for (String field : fieldsToReturn) {
             fields.put(field, 1);
         }

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -165,7 +165,9 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
     @SuppressWarnings("unchecked")
     public static <E extends MongoEntity> E make(EntityDescriptor ed, Doc doc) {
         try {
-            E result = (E) ed.make(Mango.class, null, doc::get);
+            E result = (E) ed.make(Mango.class,
+                                   null,
+                                   key -> doc.getUnderlyingObject().containsKey(key) ? doc.get(key) : null);
             if (ed.isVersioned()) {
                 result.setVersion(doc.get(VERSION).asInt(0));
             }

--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -43,7 +43,7 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
     }
 
     /**
-     * Limits the fields being returned to the given list.
+     * Limits the fields being returned to the given list. The {@link MongoEntity#ID ID} field is always returned.
      *
      * @param fieldsToReturn specified the list of fields to return
      * @return the builder itself for fluent method calls

--- a/src/test/java/sirius/db/jdbc/OMASpec.groovy
+++ b/src/test/java/sirius/db/jdbc/OMASpec.groovy
@@ -91,6 +91,33 @@ class OMASpec extends BaseSpecification {
         readBack.as(TestMixin.class).as(TestMixinMixin.class).getInitial() == "J"
     }
 
+    def "select not all fields"() {
+        given:
+        TestEntity e = new TestEntity()
+        e.setFirstname("Marge")
+        e.setLastname("Simpson")
+        e.setAge(43)
+        when:
+        oma.update(e)
+        and:
+        TestEntity readBack = oma.select(TestEntity.class)
+                                 .eq(TestEntity.ID, e.getId())
+                                 .fields(TestEntity.FIRSTNAME, TestEntity.AGE)
+                                 .queryFirst()
+        then:
+        readBack != null
+        and:
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(TestEntity.ID))
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(TestEntity.FIRSTNAME))
+        !readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(TestEntity.LASTNAME))
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(TestEntity.AGE))
+        and:
+        !readBack.isNew()
+        readBack.getFirstname() == "Marge"
+        readBack.getLastname() == null
+        readBack.getAge() == 43
+    }
+
     def "resolve can resolve an entity by its unique name"() {
         given:
         TestClobEntity test = new TestClobEntity()

--- a/src/test/java/sirius/db/mongo/MangoSpec.groovy
+++ b/src/test/java/sirius/db/mongo/MangoSpec.groovy
@@ -37,6 +37,33 @@ class MangoSpec extends BaseSpecification {
         readBack.getAge() == 12
     }
 
+    def "select not all fields"() {
+        given:
+        MangoTestEntity e = new MangoTestEntity()
+        e.setFirstname("Test2")
+        e.setLastname("Entity2")
+        e.setAge(13)
+        when:
+        mango.update(e)
+        and:
+        MangoTestEntity readBack = mango.select(MangoTestEntity.class)
+                                        .eq(MangoTestEntity.ID, e.getId())
+                                        .fields(MangoTestEntity.FIRSTNAME, MangoTestEntity.AGE)
+                                        .queryFirst()
+        then:
+        readBack != null
+        and:
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(MangoTestEntity.ID))
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(MangoTestEntity.FIRSTNAME))
+        !readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(MangoTestEntity.LASTNAME))
+        readBack.getDescriptor().isFetched(readBack, readBack.getDescriptor().getProperty(MangoTestEntity.AGE))
+        and:
+        !readBack.isNew()
+        readBack.getFirstname() == "Test2"
+        readBack.getLastname() == null
+        readBack.getAge() == 13
+    }
+
     def "delete an entity"() {
         given:
         MangoTestEntity e = new MangoTestEntity()

--- a/src/test/java/sirius/db/mongo/MangoTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoTestEntity.java
@@ -8,12 +8,17 @@
 
 package sirius.db.mongo;
 
+import sirius.db.mixing.Mapping;
+
 public class MangoTestEntity extends MongoEntity {
 
+    public static final Mapping FIRSTNAME = Mapping.named("firstname");
     private String firstname;
 
+    public static final Mapping LASTNAME = Mapping.named("lastname");
     private String lastname;
 
+    public static final Mapping AGE = Mapping.named("age");
     private int age;
 
     public String getFirstname() {


### PR DESCRIPTION
# before

- [EntityDescriptor#isFetched(BaseEntity<?> entity, Property property)](https://github.com/scireum/sirius-db/blob/8c9af4ff7130c8eab031faaea7931e991054e1f2/src/main/java/sirius/db/mixing/EntityDescriptor.java#L276) always returned `true` for `MongoEntity`s
- calling [MongoQuery<E> fields(Mapping... fieldsToReturn)](https://github.com/scireum/sirius-db/blob/8c9af4ff7130c8eab031faaea7931e991054e1f2/src/main/java/sirius/db/mongo/MongoQuery.java#L51), [SmartQuery<E> fields(Mapping... fields)](https://github.com/scireum/sirius-db/blob/8c9af4ff7130c8eab031faaea7931e991054e1f2/src/main/java/sirius/db/jdbc/SmartQuery.java#L134) or [SmartQuery<E> distinctFields(Mapping... fields)](https://github.com/scireum/sirius-db/blob/8c9af4ff7130c8eab031faaea7931e991054e1f2/src/main/java/sirius/db/jdbc/SmartQuery.java#L120) without the ID mapping leaded to strange bugs because the found entities were seen as "new", because the ID was `null`

# after

- tests added
- above bugs fixed