### PR TITLE
Adds support to use ":" within token-values

### DIFF
--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -266,8 +266,38 @@ public abstract class QueryCompiler<C extends Constraint> {
             reader.consume();
             return new FieldValue(result.toString(), true);
         } else {
-            return new FieldValue(readToken().getValue(), false);
+            return new FieldValue(readValue().getValue(), false);
         }
+    }
+
+    private FieldValue readValue() {
+        StringBuilder token = new StringBuilder();
+        boolean inQuotes = reader.current().is('"');
+        if (inQuotes) {
+            reader.consume();
+        }
+        while (continueValue(inQuotes)) {
+            if (reader.current().is('\\')) {
+                reader.consume();
+            }
+            token.append(reader.consume());
+        }
+        if (inQuotes && reader.current().is('"')) {
+            reader.consume();
+        }
+        return new FieldValue(token.toString(), inQuotes);
+    }
+
+    private boolean continueValue(boolean inQuotes) {
+        if (reader.current().isEndOfInput()) {
+            return false;
+        }
+
+        if (inQuotes) {
+            return !reader.current().is('"');
+        }
+
+        return !reader.current().is(')') && !reader.current().isWhitepace();
     }
 
     private FieldValue compileValue(String field, FieldValue value) {

--- a/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
@@ -106,4 +106,16 @@ class SQLQueryCompilerSpec extends BaseSpecification {
         then:
         queryCompiler.compile().toString() == "((firstname = test))"
     }
+
+    def "compiling 'firstname:type:value-123' works"(){
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "firstname:type:value-123",
+                Arrays.asList(QueryField.contains(TestEntity.FIRSTNAME)))
+        then:
+        queryCompiler.compile().toString() == "((firstname = type:value-123))"
+
+    }
 }


### PR DESCRIPTION
Problem was that the compiler interpreted the ":" within the value as the start of a operator.