### PR TITLE
Adds support for elasticsearch suggesters

### DIFF
--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -838,12 +838,17 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                     client.search(indices, elastic.determineTypeName(descriptor), routing, skip, limit, buildPayload());
         }
 
-        return response.getJSONObject(KEY_SUGGEST)
-                       .getJSONArray(name)
-                       .stream()
-                       .map(part -> (JSONObject) part)
-                       .map(SuggestPart::makeSuggestPart)
-                       .collect(Collectors.toList());
+        JSONObject responseSuggestions = response.getJSONObject(KEY_SUGGEST);
+
+        if (responseSuggestions == null) {
+            return Collections.emptyList();
+        }
+
+        return responseSuggestions.getJSONArray(name)
+                                  .stream()
+                                  .map(part -> (JSONObject) part)
+                                  .map(SuggestPart::makeSuggestPart)
+                                  .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -510,11 +510,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      * @return the query itself for fluent method calls
      */
     public ElasticQuery<E> suggest(SuggestBuilder suggestBuilder) {
-        if (this.suggesters == null) {
-            this.suggesters = new HashMap<>();
-        }
-        suggesters.put(suggestBuilder.getName(), suggestBuilder.build());
-        return this;
+        return suggest(suggestBuilder.getName(), suggestBuilder.build());
     }
 
     /**

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -12,6 +12,9 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import sirius.db.es.constraints.BoolQueryBuilder;
 import sirius.db.es.constraints.ElasticConstraint;
+import sirius.db.es.suggest.SuggestBuilder;
+import sirius.db.es.suggest.SuggestOption;
+import sirius.db.es.suggest.SuggestPart;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.DateRange;
 import sirius.db.mixing.EntityDescriptor;
@@ -83,6 +86,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     private static final String KEY_FROM = "from";
     private static final String KEY_TO = "to";
     private static final String KEY_EXPLAIN = "explain";
+    private static final String KEY_SUGGEST = "suggest";
 
     @Part
     private static Elastic elastic;
@@ -109,6 +113,8 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     private boolean unrouted;
 
     private boolean explain;
+
+    private Map<String, JSONObject> suggesters;
 
     private JSONObject response;
 
@@ -484,6 +490,34 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     }
 
     /**
+     * Adds a suggester.
+     *
+     * @param suggest a JSON object describing a suggest requirement
+     * @return the query itself for fluent method calls
+     */
+    public ElasticQuery<E> suggest(String name, JSONObject suggest) {
+        if (this.suggesters == null) {
+            this.suggesters = new HashMap<>();
+        }
+        suggesters.put(name, suggest);
+        return this;
+    }
+
+    /**
+     * Adds a suggester.
+     *
+     * @param suggestBuilder a suggest builder
+     * @return the query itself for fluent method calls
+     */
+    public ElasticQuery<E> suggest(SuggestBuilder suggestBuilder) {
+        if (this.suggesters == null) {
+            this.suggesters = new HashMap<>();
+        }
+        suggesters.put(suggestBuilder.getName(), suggestBuilder.build());
+        return this;
+    }
+
+    /**
      * Specifies the routing value to use.
      * <p>
      * For routed entities it is highly recommended to supply a routing value as it greatly improves the
@@ -547,6 +581,10 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                 collapse.put(KEY_INNER_HITS, collapseByInnerHits);
             }
             payload.put(KEY_COLLAPSE, collapse);
+        }
+
+        if (suggesters != null && !suggesters.isEmpty()) {
+            payload.put(KEY_SUGGEST, new JSONObject().fluentPutAll(suggesters));
         }
 
         return payload;
@@ -771,6 +809,45 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                        .filter(hit -> hit instanceof JSONObject)
                        .map(hit -> (JSONObject) hit)
                        .collect(Collectors.toMap(hit -> hit.getString(Elastic.ID_FIELD), Function.identity()));
+    }
+
+    /**
+     * Returns all suggest options for the suggester with the given name.
+     *
+     * @param name the name of the suggester
+     * @return a list of suggest options
+     */
+    public List<SuggestOption> getSuggestOptions(String name) {
+        return getSuggestParts(name).stream().flatMap(part -> part.getOptions().stream()).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all suggest parts for the suggester with the given name.
+     * <p>
+     * This is mainly used for term suggesters where every term receives their own suggestions.
+     *
+     * @param name the name of the suggester
+     * @return a list of suggest parts
+     */
+    public List<SuggestPart> getSuggestParts(String name) {
+        if (response == null) {
+            checkRouting();
+
+            List<String> indices = determineIndices();
+            if (indices.isEmpty()) {
+                Collections.emptyList();
+            }
+
+            this.response =
+                    client.search(indices, elastic.determineTypeName(descriptor), routing, skip, limit, buildPayload());
+        }
+
+        return response.getJSONObject(KEY_SUGGEST)
+                       .getJSONArray(name)
+                       .stream()
+                       .map(part -> (JSONObject) part)
+                       .map(SuggestPart::makeSuggestPart)
+                       .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
@@ -67,9 +67,7 @@ public class SuggestBuilder {
      */
     public SuggestBuilder on(Mapping field, String text) {
         this.text = text;
-        this.body.put(PARAM_FIELD, field.getName());
-
-        return this;
+        return addBodyParameter(PARAM_FIELD, field.getName());
     }
 
     /**

--- a/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es.suggest;
+
+import com.alibaba.fastjson.JSONObject;
+import sirius.db.es.ElasticQuery;
+import sirius.db.es.constraints.BoolQueryBuilder;
+import sirius.db.mixing.Mapping;
+
+/**
+ * Helper class which generates term and phrase suggesters for elasticsearch which can be used via
+ * {@link ElasticQuery#suggest(SuggestBuilder)}.
+ */
+public class SuggestBuilder {
+
+    public static final String TERM = "term";
+    public static final String PHRASE = "phrase";
+
+    private static final String PARAM_TEXT = "text";
+    private static final String PARAM_FIELD = "field";
+    private static final String PARAM_HIGHLIGHT = "highlight";
+    private static final String PARAM_PRE_TAG = "pre_tag";
+    private static final String PARAM_POST_TAG = "post_tag";
+    private static final String PARAM_COLLATE = "collate";
+    private static final String PARAM_QUERY = "query";
+    private static final String PARAM_PRUNE = "prune";
+    private static final String PARAM_SOURCE = "source";
+
+    private String type;
+    private String name;
+    private String text;
+
+    private JSONObject body = new JSONObject();
+
+    private SuggestBuilder(String type, String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    /**
+     * Creates a new suggest builder.
+     *
+     * @param type the type of the suggester.
+     * @param name the name of the suggester
+     * @return the builder itself for fluent method calls
+     */
+    public static SuggestBuilder create(String type, String name) {
+        return new SuggestBuilder(type, name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the query string to generate suggestions for and the field to generate the suggestions from
+     *
+     * @param field the field to get the suggestions from
+     * @param text  the query to generate suggestions for
+     * @return the builder itself for fluent method calls
+     */
+    public SuggestBuilder on(Mapping field, String text) {
+        this.text = text;
+        this.body.put(PARAM_FIELD, field.getName());
+
+        return this;
+    }
+
+    /**
+     * Adds a parameter to the body of the suggester.
+     *
+     * @param name  the name of the parameter
+     * @param value the value of the parameter
+     * @return the builder itself for fluent method calls
+     */
+    public SuggestBuilder addBodyParameter(String name, Object value) {
+        this.body.put(name, value);
+        return this;
+    }
+
+    /**
+     * Helper method to set the highlighting options for phrase suggesters.
+     *
+     * @param preTag  the tag in front of suggested tokens
+     * @param postTag the tag behind suggested tokens
+     * @return the builder itself for fluent method calls
+     */
+    public SuggestBuilder highlight(String preTag, String postTag) {
+        return addBodyParameter(PARAM_HIGHLIGHT,
+                                new JSONObject().fluentPut(PARAM_PRE_TAG, preTag).fluentPut(PARAM_POST_TAG, postTag));
+    }
+
+    /**
+     * Helper method to set the collate query for phrase suggesters.
+     * <p>
+     * The query is used to check wether at least one document in the index matches the suggestion. The template
+     * parameter <pre>{{suggestion}}</pre> is replaced with the suggested text when checking.
+     *
+     * @param query the {@link BoolQueryBuilder}
+     * @param prune <tt>true</tt> if options that didn't match the given query should remain in the response,
+     *              <tt>false</tt> otherwise
+     * @return the builder itself for fluent method calls
+     * @see SuggestOption#isCollateMatch() for checking if a option matched the query
+     */
+    public SuggestBuilder collate(BoolQueryBuilder query, boolean prune) {
+        return addBodyParameter(PARAM_COLLATE,
+                                new JSONObject().fluentPut(PARAM_QUERY,
+                                                           new JSONObject().fluentPut(PARAM_SOURCE, query.build()))
+                                                .fluentPut(PARAM_PRUNE, prune));
+    }
+
+    /**
+     * Generates a {@link JSONObject} that represents this suggester.
+     *
+     * @return the suggester as a JSON object
+     */
+    public JSONObject build() {
+        return new JSONObject().fluentPut(PARAM_TEXT, text).fluentPut(type, body);
+    }
+}

--- a/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestBuilder.java
@@ -38,20 +38,15 @@ public class SuggestBuilder {
 
     private JSONObject body = new JSONObject();
 
-    private SuggestBuilder(String type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
     /**
      * Creates a new suggest builder.
      *
      * @param type the type of the suggester.
      * @param name the name of the suggester
-     * @return the builder itself for fluent method calls
      */
-    public static SuggestBuilder create(String type, String name) {
-        return new SuggestBuilder(type, name);
+    public SuggestBuilder(String type, String name) {
+        this.type = type;
+        this.name = name;
     }
 
     public String getName() {

--- a/src/main/java/sirius/db/es/suggest/SuggestOption.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestOption.java
@@ -1,0 +1,117 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es.suggest;
+
+import com.alibaba.fastjson.JSONObject;
+
+/**
+ * Represents an option in an Elasticsearch suggest response.
+ */
+public class SuggestOption {
+
+    private static final String PARAM_TEXT = "text";
+    private static final String PARAM_SCORE = "score";
+    private static final String PARAM_HIGHLIGHTED = "highlighted";
+    private static final String PARAM_COLLATE_MATCH = "collate_match";
+
+    private String text;
+    private String highlighted = "";
+    private float score;
+    private boolean collateMatch = true;
+
+    /**
+     * Creates a new suggest option with the suggested text and it's score.
+     *
+     * @param text  the suggested text
+     * @param score the score of the option
+     */
+    public SuggestOption(String text, float score) {
+        this.text = text;
+        this.score = score;
+    }
+
+    /**
+     * Return the suggested text of this option.
+     *
+     * @return the suggested text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Return the highlighted suggested text of this option.
+     *
+     * @return the highlighted suggested text
+     */
+    public String getHighlighted() {
+        return highlighted;
+    }
+
+    /**
+     * Sets the highlighted version of the suggested text.
+     *
+     * @param highlighted the highlighted suggested text
+     * @return the suggest option itself for fluent method calls
+     */
+    public SuggestOption withHighlighted(String highlighted) {
+        this.highlighted = highlighted;
+        return this;
+    }
+
+    /**
+     * Returns the score of this option.
+     *
+     * @return the score
+     */
+    public float getScore() {
+        return score;
+    }
+
+    /**
+     * Returns wether this option is a match to the collate query of a phrase suggester.
+     *
+     * @return <tt>true</tt> if this option matched the collate query, <tt>false</tt> otherwise
+     */
+    public boolean isCollateMatch() {
+        return collateMatch;
+    }
+
+    /**
+     * Sets wether this option matched the collate query.
+     *
+     * @param collateMatch <tt>true</tt> if this option matched the collate query, <tt>false</tt> otherwise
+     * @return the suggest option itself for fluent method calls
+     */
+    public SuggestOption withCollateMatch(boolean collateMatch) {
+        this.collateMatch = collateMatch;
+        return this;
+    }
+
+    /**
+     * Build a suggest option from the given {@link JSONObject}.
+     *
+     * @param option the JSON object
+     * @return the newly created suggest option
+     */
+    public static SuggestOption makeSuggestOption(JSONObject option) {
+        SuggestOption suggestOption =
+                new SuggestOption(option.getString(PARAM_TEXT), option.getFloatValue(PARAM_SCORE));
+
+        if (option.containsKey(PARAM_HIGHLIGHTED)) {
+            suggestOption.withHighlighted(option.getString(PARAM_HIGHLIGHTED));
+        }
+
+        if (option.containsKey(PARAM_COLLATE_MATCH)) {
+            suggestOption.withCollateMatch(option.getBooleanValue(PARAM_COLLATE_MATCH));
+        }
+
+        return suggestOption;
+    }
+}

--- a/src/main/java/sirius/db/es/suggest/SuggestPart.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestPart.java
@@ -10,6 +10,7 @@ package sirius.db.es.suggest;
 
 import com.alibaba.fastjson.JSONObject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -75,6 +76,10 @@ public class SuggestPart {
      * @return a list of {@link SuggestOption}s
      */
     public List<SuggestOption> getOptions() {
+        if (options == null) {
+            return Collections.emptyList();
+        }
+
         return options;
     }
 

--- a/src/main/java/sirius/db/es/suggest/SuggestPart.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestPart.java
@@ -1,0 +1,111 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es.suggest;
+
+import com.alibaba.fastjson.JSONObject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a part in an Elasticsearch suggest response.
+ */
+public class SuggestPart {
+
+    private static final String PARAM_TEXT = "text";
+    private static final String PARAM_OFFSET = "offset";
+    private static final String PARAM_LENGTH = "length";
+    private static final String PARAM_OPTIONS = "options";
+
+    private String text;
+    private int offset;
+    private int length;
+
+    private List<SuggestOption> options;
+
+    /**
+     * Creates a new suggest part with the given original text and position.
+     *
+     * @param text   the original text of this part
+     * @param offset the start of this part
+     * @param length the length of this part
+     */
+    public SuggestPart(String text, int offset, int length) {
+        this.text = text;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    /**
+     * Returns the original text of this part.
+     *
+     * @return the original text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Returns the start of this part.
+     *
+     * @return the start
+     */
+    public int getOffset() {
+        return offset;
+    }
+
+    /**
+     * Returns the length of this part.
+     *
+     * @return the length
+     */
+    public int getLength() {
+        return length;
+    }
+
+    /**
+     * Returns the options given for this part.
+     *
+     * @return a list of {@link SuggestOption}s
+     */
+    public List<SuggestOption> getOptions() {
+        return options;
+    }
+
+    /**
+     * Adds the given {@link SuggestOption}s to this part.
+     *
+     * @param options a list of suggest options to add to this part
+     * @return the suggest part itself for fluent method calls
+     */
+    public SuggestPart withOptions(List<SuggestOption> options) {
+        this.options = options;
+        return this;
+    }
+
+    /**
+     * Build a suggest part from the given {@link JSONObject}.
+     *
+     * @param part the JSON object
+     * @return the newly created suggest part
+     */
+    public static SuggestPart makeSuggestPart(JSONObject part) {
+        SuggestPart suggestPart = new SuggestPart(part.getString(PARAM_TEXT),
+                                                  part.getIntValue(PARAM_OFFSET),
+                                                  part.getIntValue(PARAM_LENGTH));
+
+        suggestPart.withOptions(part.getJSONArray(PARAM_OPTIONS)
+                                    .stream()
+                                    .map(option -> (JSONObject) option)
+                                    .map(SuggestOption::makeSuggestOption)
+                                    .collect(Collectors.toList()));
+
+        return suggestPart;
+    }
+}

--- a/src/test/java/sirius/db/es/SuggestSpec.groovy
+++ b/src/test/java/sirius/db/es/SuggestSpec.groovy
@@ -1,0 +1,126 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es
+
+import com.alibaba.fastjson.JSONObject
+import sirius.db.es.constraints.BoolQueryBuilder
+import sirius.db.es.suggest.SuggestBuilder
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Wait
+import sirius.kernel.di.std.Part
+
+import java.time.Duration
+import java.util.function.Predicate
+
+class SuggestSpec extends BaseSpecification {
+
+    @Part
+    private static Elastic elastic
+
+    def setupSpec() {
+        elastic.getReadyFuture().await(Duration.ofSeconds(60))
+    }
+
+    def "term suggest works"() {
+        when:
+        def entity1 = new SuggestTestEntity()
+        entity1.setContent("HSS drill bit")
+        elastic.update(entity1)
+        and:
+        def entity2 = new SuggestTestEntity()
+        entity2.setContent("Salmon with dill")
+        elastic.update(entity2)
+        and:
+        Wait.seconds(2)
+        def suggestParts = elastic.select(SuggestTestEntity.class)
+                                  .suggest(SuggestBuilder.create(SuggestBuilder.TERM, "test")
+                                                         .on(SuggestTestEntity.CONTENT, "HSS dril bitt"))
+                                  .getSuggestParts("test")
+        then:
+        suggestParts.size() == 3
+        suggestParts.get(0).getOptions().size() == 0
+        suggestParts.get(1).getOptions().size() == 2
+        suggestParts.get(2).getOptions().size() == 1
+        and:
+        suggestParts.get(1).getOptions().stream().anyMatch({ option -> option.getText().equalsIgnoreCase("drill") } as Predicate)
+        suggestParts.get(1).getOptions().stream().anyMatch({ option -> option.getText().equalsIgnoreCase("dill") } as Predicate)
+        suggestParts.get(2).getOptions().get(0).getText().equalsIgnoreCase("bit")
+    }
+
+    def "phrase suggest works"() {
+        when:
+        def entity1 = new SuggestTestEntity()
+        entity1.setContent("HSS drill bit")
+        elastic.update(entity1)
+        and:
+        def entity2 = new SuggestTestEntity()
+        entity2.setContent("Salmon with dill")
+        elastic.update(entity2)
+        and:
+        Wait.seconds(2)
+        def suggestOptions = elastic.select(SuggestTestEntity.class)
+                                    .suggest(SuggestBuilder.create(SuggestBuilder.PHRASE, "test")
+                                                           .on(SuggestTestEntity.CONTENT, "dril potatoes"))
+                                    .getSuggestOptions("test")
+        then:
+        suggestOptions.size() == 2
+        and:
+        suggestOptions.stream().anyMatch({ option -> option.getText().equalsIgnoreCase("drill potatoes") } as Predicate)
+        suggestOptions.stream().anyMatch({ option -> option.getText().equalsIgnoreCase("dill potatoes") } as Predicate)
+    }
+
+    def "phrase suggest with a collate query works"() {
+        when:
+        // Add enough data as the collate query only runs on one shard
+        for (int i = 0; i < 100; i++) {
+            def entity1 = new SuggestTestEntity()
+            entity1.setContent("Salsa Tomaten")
+            entity1.setShop(1)
+            elastic.update(entity1)
+
+            def entity2 = new SuggestTestEntity()
+            entity2.setContent("Kartoffeln mit Salz")
+            entity2.setShop(1)
+            elastic.update(entity2)
+
+            def entity3 = new SuggestTestEntity()
+            entity3.setContent("Kartoffel Sale")
+            entity3.setShop(2)
+            elastic.update(entity3)
+        }
+        and:
+        def matchPhrase = new JSONObject().fluentPut("match",
+                                                     new JSONObject().fluentPut(SuggestTestEntity.CONTENT.getName(),
+                                                                                new JSONObject().fluentPut("query", "{{suggestion}}")
+                                                                                                .fluentPut("operator", "and")))
+
+        def matchShop = Elastic.FILTERS.eq(SuggestTestEntity.SHOP, 1)
+
+
+        and:
+        Wait.seconds(2)
+        def suggestOptions = elastic.select(SuggestTestEntity.class)
+                                    .suggest(SuggestBuilder.create(SuggestBuilder.PHRASE, "test")
+                                                           .on(SuggestTestEntity.CONTENT, "Sals Kartoffeln")
+                                                           .collate(new BoolQueryBuilder().must(matchPhrase)
+                                                                                          .must(matchShop), true))
+                                    .getSuggestOptions("test")
+        then:
+        suggestOptions.size() == 3
+        and:
+        suggestOptions.stream()
+                      .anyMatch({ option -> option.getText().equalsIgnoreCase("Salsa Kartoffeln") && !option.isCollateMatch() } as Predicate)
+
+        suggestOptions.stream()
+                      .anyMatch({ option -> option.getText().equalsIgnoreCase("Sale Kartoffeln") && !option.isCollateMatch() } as Predicate)
+
+        suggestOptions.stream()
+                      .anyMatch({ option -> option.getText().equalsIgnoreCase("Salz Kartoffeln") && option.isCollateMatch() } as Predicate)
+    }
+}

--- a/src/test/java/sirius/db/es/SuggestSpec.groovy
+++ b/src/test/java/sirius/db/es/SuggestSpec.groovy
@@ -39,8 +39,8 @@ class SuggestSpec extends BaseSpecification {
         and:
         Wait.seconds(2)
         def suggestParts = elastic.select(SuggestTestEntity.class)
-                                  .suggest(SuggestBuilder.create(SuggestBuilder.TERM, "test")
-                                                         .on(SuggestTestEntity.CONTENT, "HSS dril bitt"))
+                                  .suggest(new SuggestBuilder(SuggestBuilder.TERM, "test")
+                                                   .on(SuggestTestEntity.CONTENT, "HSS dril bitt"))
                                   .getSuggestParts("test")
         then:
         suggestParts.size() == 3
@@ -65,8 +65,8 @@ class SuggestSpec extends BaseSpecification {
         and:
         Wait.seconds(2)
         def suggestOptions = elastic.select(SuggestTestEntity.class)
-                                    .suggest(SuggestBuilder.create(SuggestBuilder.PHRASE, "test")
-                                                           .on(SuggestTestEntity.CONTENT, "dril potatoes"))
+                                    .suggest(new SuggestBuilder(SuggestBuilder.PHRASE, "test")
+                                                     .on(SuggestTestEntity.CONTENT, "dril potatoes"))
                                     .getSuggestOptions("test")
         then:
         suggestOptions.size() == 2
@@ -106,10 +106,10 @@ class SuggestSpec extends BaseSpecification {
         and:
         Wait.seconds(2)
         def suggestOptions = elastic.select(SuggestTestEntity.class)
-                                    .suggest(SuggestBuilder.create(SuggestBuilder.PHRASE, "test")
-                                                           .on(SuggestTestEntity.CONTENT, "Sals Kartoffeln")
-                                                           .collate(new BoolQueryBuilder().must(matchPhrase)
-                                                                                          .must(matchShop), true))
+                                    .suggest(new SuggestBuilder(SuggestBuilder.PHRASE, "test")
+                                                     .on(SuggestTestEntity.CONTENT, "Sals Kartoffeln")
+                                                     .collate(new BoolQueryBuilder().must(matchPhrase)
+                                                                                    .must(matchShop), true))
                                     .getSuggestOptions("test")
         then:
         suggestOptions.size() == 3

--- a/src/test/java/sirius/db/es/SuggestTestEntity.java
+++ b/src/test/java/sirius/db/es/SuggestTestEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es;
+
+import sirius.db.es.annotations.Analyzed;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
+
+public class SuggestTestEntity extends ElasticEntity {
+
+    public static final Mapping CONTENT = Mapping.named("content");
+    @Analyzed(analyzer = Analyzed.ANALYZER_WHITESPACE, indexOptions = Analyzed.IndexOption.POSITIONS)
+    private String content;
+
+    public static final Mapping SHOP = Mapping.named("shop");
+    @NullAllowed
+    private Long shop;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Long getShop() {
+        return shop;
+    }
+
+    public void setShop(long shop) {
+        this.shop = shop;
+    }
+}


### PR DESCRIPTION
Different to sirius-search, suggesters can be added to any query. This allows to fetch suggestions without the need for additional requests.