### PR TITLE
Allows to customize the query compilation in a more fine grained fashion

### DIFF
--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -199,14 +199,26 @@ public abstract class QueryCompiler<C extends Constraint> {
         if (isAtOperator()) {
             String field = token.getValue().toString();
             Property property = resolveProperty(field);
-            if (property != null) {
-                return parseOperation(property, field);
-            } else if (!skipped) {
-                token = treatOperatorAsTokenPart(token);
+
+            C constraint = compileContraint(property, token, skipped);
+            if (constraint != null) {
+                return constraint;
             }
         }
 
         return compileDefaultSearch(searchFields, token);
+    }
+
+    protected C compileContraint(Property property, FieldValue token, boolean skipped) {
+        if (property != null) {
+            return parseOperation(property, token.getValue().toString());
+        }
+
+        if (!skipped) {
+            return compileDefaultSearch(searchFields, treatOperatorAsTokenPart(token));
+        }
+
+        return null;
     }
 
     /**
@@ -334,7 +346,7 @@ public abstract class QueryCompiler<C extends Constraint> {
         return !reader.current().is(')') && !reader.current().isWhitepace();
     }
 
-    private FieldValue compileValue(Property property, FieldValue value) {
+    protected FieldValue compileValue(Property property, FieldValue value) {
         if (!value.isExact() && "-".equals(value.getValue())) {
             return new FieldValue(null, false);
         }

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -200,10 +200,7 @@ public abstract class QueryCompiler<C extends Constraint> {
             String field = token.getValue().toString();
             Property property = resolveProperty(field);
 
-            C constraint = compileContraint(property, token, skipped);
-            if (constraint != null) {
-                return constraint;
-            }
+            return compileContraint(property, token, skipped);
         }
 
         return compileDefaultSearch(searchFields, token);
@@ -218,7 +215,7 @@ public abstract class QueryCompiler<C extends Constraint> {
             return compileDefaultSearch(searchFields, treatOperatorAsTokenPart(token));
         }
 
-        return null;
+        return compileDefaultSearch(searchFields, token);
     }
 
     /**

--- a/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
@@ -8,8 +8,11 @@
 
 package sirius.db.jdbc
 
+import sirius.db.jdbc.constraints.SQLConstraint
 import sirius.db.jdbc.constraints.SQLQueryCompiler
 import sirius.db.mixing.Mixing
+import sirius.db.mixing.Property
+import sirius.db.mixing.query.QueryCompiler
 import sirius.db.mixing.query.QueryField
 import sirius.kernel.BaseSpecification
 import sirius.kernel.di.std.Part
@@ -152,6 +155,26 @@ class SQLQueryCompilerSpec extends BaseSpecification {
                 Arrays.asList(QueryField.contains(TestEntity.FIRSTNAME)))
         then:
         queryCompiler.compile().toString() == "((((LOWER(firstname) LIKE '%hello%')) AND ((LOWER(firstname) LIKE '%world%'))))"
+    }
 
+    def "customizing constraint compilation works"(){
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "is:chat",
+                Arrays.asList(QueryField.contains(TestEntity.FIRSTNAME))) {
+            @Override
+            protected SQLConstraint compileContraint(Property property, QueryCompiler.FieldValue token, boolean skipped) {
+                return parseOperation(property, token.getValue().toString())
+            }
+            @Override
+            protected QueryCompiler.FieldValue compileValue(Property property, QueryCompiler.FieldValue value) {
+                return value
+            }
+
+        }
+        then:
+        queryCompiler.compile().toString() == "((is = chat))"
     }
 }


### PR DESCRIPTION
E.g. parseOperation() can be called for non-property tag values.