### PR TITLE
No longer allow negative skip values

### DIFF
--- a/src/main/java/sirius/db/mixing/query/BaseQuery.java
+++ b/src/main/java/sirius/db/mixing/query/BaseQuery.java
@@ -100,7 +100,7 @@ public abstract class BaseQuery<Q, E extends BaseEntity<?>> {
      */
     @SuppressWarnings("unchecked")
     public Q skip(int skip) {
-        this.skip = skip;
+        this.skip = skip > 0 ? skip : this.skip;
         return (Q) this;
     }
 


### PR DESCRIPTION
No longer allows for users to input negative skip values. In Elasticsearch queries we already depend on this documented behaviour. 