### PR TITLE
Fixes a bug that caused an "unkown translation error" when an illegal…

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -515,10 +515,9 @@ public abstract class Property {
      */
     protected HandledException illegalFieldValue(Value value) {
         return Exceptions.createHandled()
-                         .withNLSKey(NLS.fmtr("Property.illegalValue")
-                                        .set("property", getLabel())
-                                        .set("value", NLS.toUserString(value.get()))
-                                        .format())
+                         .withNLSKey("Property.illegalValue")
+                         .set("property", getLabel())
+                         .set("value", NLS.toUserString(value.get()))
                          .handle();
     }
 


### PR DESCRIPTION
… field value occurs

# before 

`Missing translations found: Ungültiger Wert '2345234' im Feld 'Betriebskalender'.`