### PR TITLE
Fixes the transformation of nested objets in StringNestedMapProperty

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/StringNestedMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringNestedMapProperty.java
@@ -89,7 +89,7 @@ public class StringNestedMapProperty extends BaseMapProperty {
         for (Map.Entry<String, Nested> entry : ((Map<String, Nested>) object).entrySet()) {
             Document inner = new Document();
             for (Property property : getNestedDescriptor().getProperties()) {
-                inner.put(property.getPropertyName(), property.getValue(entry.getValue()));
+                inner.put(property.getPropertyName(), property.getValueForDatasource(Mango.class, entry.getValue()));
             }
             result.put(entry.getKey(), inner);
         }

--- a/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapEntity.java
@@ -13,18 +13,20 @@ import sirius.db.mixing.Nested;
 import sirius.db.mixing.types.StringNestedMap;
 import sirius.db.mongo.MongoEntity;
 
+import java.time.LocalDateTime;
+
 public class MongoStringNestedMapEntity extends MongoEntity {
 
     public static class NestedEntity extends Nested {
 
         private String value1;
-        private String value2;
+        private LocalDateTime value2;
 
         public String getValue1() {
             return value1;
         }
 
-        public String getValue2() {
+        public LocalDateTime getValue2() {
             return value2;
         }
 
@@ -33,7 +35,7 @@ public class MongoStringNestedMapEntity extends MongoEntity {
             return this;
         }
 
-        public NestedEntity withValue2(String value) {
+        public NestedEntity withValue2(LocalDateTime value) {
             this.value2 = value;
             return this;
         }

--- a/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapPropertySpec.groovy
@@ -13,6 +13,8 @@ import sirius.db.mongo.Mongo
 import sirius.kernel.BaseSpecification
 import sirius.kernel.di.std.Part
 
+import java.time.LocalDateTime
+
 class MongoStringNestedMapPropertySpec extends BaseSpecification {
 
     @Part
@@ -24,7 +26,8 @@ class MongoStringNestedMapPropertySpec extends BaseSpecification {
     def "reading and writing works"() {
         when:
         def test = new MongoStringNestedMapEntity()
-        test.getMap().put("X", new MongoStringNestedMapEntity.NestedEntity().withValue1("Y").withValue2("Z"))
+        def timestamp = LocalDateTime.now().minusDays(2)
+        test.getMap().put("X", new MongoStringNestedMapEntity.NestedEntity().withValue1("Y").withValue2(timestamp))
         mango.update(test)
         def resolved = mango.refreshOrFail(test)
         then:
@@ -32,7 +35,7 @@ class MongoStringNestedMapPropertySpec extends BaseSpecification {
         and:
         resolved.getMap().containsKey("X")
         resolved.getMap().get("X").get().getValue1() == "Y"
-        resolved.getMap().get("X").get().getValue2() == "Z"
+        resolved.getMap().get("X").get().getValue2() == timestamp
 
         when:
         resolved.getMap().modify().get("X").withValue1("ZZZ")


### PR DESCRIPTION
# before

```
11:05:56.092 ERROR [main|15ms] mixing - Ein Fehler ist aufgetreten: Unable to UPDATE new MongoStringNestedMapEntity (MongoStringNestedMapEntity): Can't find a codec for class java.time.LocalDateTime. (org.bson.codecs.configuration.CodecConfigurationException)
```

# after

complex objets that need transformation work in StringNestedMapProperty
