### PR TITLE
change elasticsearch image to official elastic docker image

### DIFF
--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -27,11 +27,11 @@ services:
     - "9000"
     hostname: clickhouse
   elasticsearch:
-    image: elasticsearch:5.6.8
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.14
     ports:
     - "9200"
     environment:
     - xpack.security.enabled=false
     - script.inline=true
-    - ES_JAVA_OPTS=-Xms32M -Xmx128M
+    - ES_JAVA_OPTS=-Xms128M -Xmx128M
     hostname: es


### PR DESCRIPTION
elastic has abandoned hub.docker.com. it uses now it's own docker
registry. the old docker image uses uid 102 to run elasticsearch.

the new image from elastic registry runs elasticsearch as uid 1000.

bump xms to the same value as xmx:

https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html

Set the minimum heap size (Xms) and maximum heap size (Xmx) to be equal to each other.