### PR TITLE
Alias & Reindex for elastic

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -64,6 +64,11 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
      */
     public static final ElasticFilterFactory FILTERS = new ElasticFilterFactory();
 
+    /**
+     * The suffix of the alias which resolves the currently active index for a {@link EntityDescriptor}.
+     */
+    public static final String ACTIVE_ALIAS = "-active";
+
     private static final String CONTEXT_ROUTING = "routing";
 
     private static final String RESPONSE_VERSION = "_version";
@@ -350,6 +355,16 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
         }
 
         return indexNaming.determineIndexName(ed);
+    }
+
+    /**
+     * Determines the alias for the currently active index for the given {@link EntityDescriptor}.
+     *
+     * @param ed the descriptor
+     * @return the alias of the currently active index
+     */
+    protected String determineAlias(EntityDescriptor ed) {
+        return ed.getRelationName() + ACTIVE_ALIAS;
     }
 
     /**

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -679,7 +679,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     }
 
     /**
-     * Determines which indices top search in.
+     * Determines which indices to search in.
      *
      * @return the list of indices to search in
      */
@@ -693,7 +693,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                         ExecutionPoint.snapshot());
             }
 
-            return Collections.singletonList(elastic.determineIndex(descriptor, null));
+            return Collections.singletonList(elastic.determineAlias(descriptor));
         } else {
             if (years == null || years.isEmpty()) {
                 Elastic.LOG.WARN(

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -8,13 +8,16 @@
 
 package sirius.db.es;
 
+import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import org.apache.http.HttpEntity;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.OptimisticLockException;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 
 import javax.annotation.Nullable;
@@ -29,9 +32,19 @@ import java.util.stream.Collectors;
  */
 public class LowLevelClient {
 
+    private static final String API_REINDEX = "/_reindex?pretty";
+    private static final String API_ALIAS = "/_alias";
+    private static final String API_ALIASES = "/_aliases";
     private static final String API_SEARCH = "/_search";
     private static final String API_DELETE_BY_QUERY = "/_delete_by_query";
+
+    private static final String PARAM_INDEX = "index";
+    private static final String PARAM_TYPE = "type";
+
     private RestClient restClient;
+
+    @Part
+    private static Elastic elastic;
 
     /**
      * Creates a new client based on the given REST client which handle load balancing and connection management.
@@ -193,6 +206,94 @@ public class LowLevelClient {
                            .data(query)
                            .execute(Strings.join(indices, ",") + "/" + type + API_SEARCH)
                            .response();
+    }
+
+    /**
+     * Executes a reindex request.
+     *
+     * @param ed           the current entitydescriptor that should be reindexd
+     * @param newIndexName the name of the index in which the documents shoulds be reindex
+     * @return the response of the call
+     */
+    public JSONObject reindex(EntityDescriptor ed, String newIndexName) {
+        return performPost().data(new JSONObject().fluentPut("source",
+                                                             new JSONObject().fluentPut(PARAM_INDEX,
+                                                                                        elastic.determineAlias(ed))
+                                                                             .fluentPut(PARAM_TYPE,
+                                                                                        elastic.determineTypeName(ed)))
+                                                  .fluentPut("dest",
+                                                             new JSONObject().fluentPut(PARAM_INDEX, newIndexName)
+                                                                             .fluentPut(PARAM_TYPE,
+                                                                                        elastic.determineTypeName(ed))))
+
+                            .execute(API_REINDEX).response();
+    }
+
+    /**
+     * Adds an alias to a given index.
+     *
+     * @param indexName the name of the index which should be aliased
+     * @param alias     the alias to apply
+     * @return the response of the call
+     */
+    public JSONObject addAlias(String indexName, String alias) {
+        return performPut().execute("/" + indexName + API_ALIAS + "/" + alias).response();
+    }
+
+    /**
+     * Returns the names of the indexed which are aliased with the given alias.
+     *
+     * @param alias the given alias
+     * @return a list of indexes which are aliased with the given alias
+     */
+    public boolean aliasExists(String alias) {
+        try {
+            return restClient.performRequest("HEAD", API_ALIAS + "/" + alias).getStatusLine().getStatusCode() == 200;
+        } catch (ResponseException e) {
+            throw Exceptions.handle()
+                            .to(Elastic.LOG)
+                            .error(e)
+                            .withSystemErrorMessage("An error occurred when checking for alias '%s': %s (%s)", alias)
+                            .handle();
+        } catch (IOException e) {
+            throw Exceptions.handle()
+                            .to(Elastic.LOG)
+                            .error(e)
+                            .withSystemErrorMessage("An IO error occurred when checking for index '%s': %s (%s)", alias)
+                            .handle();
+        }
+    }
+
+    /**
+     * Performs an atomic move operation where the alias, which marks the currently active index (see {@link Elastic#ACTIVE_ALIAS}),
+     * for the given descriptor is transferred to the given destination.
+     *
+     * @param ed          the entity descriptor
+     * @param destination the index that should be marked with the given alias
+     * @return the reponse of the call
+     */
+    public JSONObject moveActiveAlias(EntityDescriptor ed, String destination) {
+        String alias = elastic.determineAlias(ed);
+
+        if (!indexExists(alias)) {
+            throw Exceptions.handle()
+                            .withSystemErrorMessage("There exists no index which holds the alias '%s'", alias)
+                            .handle();
+        }
+
+        if (!indexExists(destination)) {
+            throw Exceptions.handle()
+                            .withSystemErrorMessage("There exists no index with name '%s'", destination)
+                            .handle();
+        }
+
+        JSONObject remove =
+                new JSONObject().fluentPut(PARAM_INDEX, elastic.determineAlias(ed)).fluentPut("alias", alias);
+        JSONObject add = new JSONObject().fluentPut(PARAM_INDEX, destination).fluentPut("alias", alias);
+        JSONArray actions = new JSONArray().fluentAdd(new JSONObject().fluentPut("add", add))
+                                           .fluentAdd(new JSONObject().fluentPut("remove", remove));
+
+        return performPost().data(new JSONObject().fluentPut("actions", actions)).execute(API_ALIASES).response();
     }
 
     /**

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -290,8 +290,8 @@ public class LowLevelClient {
         JSONObject remove =
                 new JSONObject().fluentPut(PARAM_INDEX, elastic.determineAlias(ed)).fluentPut("alias", alias);
         JSONObject add = new JSONObject().fluentPut(PARAM_INDEX, destination).fluentPut("alias", alias);
-        JSONArray actions = new JSONArray().fluentAdd(new JSONObject().fluentPut("add", add))
-                                           .fluentAdd(new JSONObject().fluentPut("remove", remove));
+        JSONArray actions = new JSONArray().fluentAdd(new JSONObject().fluentPut("remove", remove))
+                                           .fluentAdd(new JSONObject().fluentPut("add", add));
 
         return performPost().data(new JSONObject().fluentPut("actions", actions)).execute(API_ALIASES).response();
     }


### PR DESCRIPTION
- Adds an alias to the currently active index for each mapping
   - For existing indexes the alias is just attached at the first startup
   - For new indexes it is attached after creation
- Makes the "createMapping" method public so that it can be used in sirius-biz to support a reindex job which needs to setup a new index
- Adds a method for reindexing indexes
- Adds methods to add/move aliases 