### PR TITLE
Limits the log entry of "slow queries" as well as debug logs.

### DIFF
--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -268,6 +268,7 @@ public class LowLevelClient {
     /**
      * Returns all indices which hold the {@link Elastic#ACTIVE_ALIAS} for the given {@link EntityDescriptor}.
      *
+     * @param ed the entity descriptor to check
      * @return a list of all indices which hold the {@link Elastic#ACTIVE_ALIAS} for the given {@link EntityDescriptor}
      */
     public List<String> getIndicesForAlias(EntityDescriptor ed) {
@@ -423,7 +424,7 @@ public class LowLevelClient {
     public JSONObject createIndex(String index, int numberOfShards, int numberOfReplicas) {
         JSONObject indexObj = new JSONObject().fluentPut("number_of_shards", numberOfShards)
                                               .fluentPut("number_of_replicas", numberOfReplicas);
-        JSONObject settingsObj = new JSONObject().fluentPut("index", indexObj);
+        JSONObject settingsObj = new JSONObject().fluentPut(PARAM_INDEX, indexObj);
         JSONObject input = new JSONObject().fluentPut("settings", settingsObj);
         return performPut().data(input).execute(index).response();
     }

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -46,7 +46,7 @@ class RequestBuilder {
     private static final String PARAM_ROUTING = "routing";
     private static final String PARAM_VERSION = "version";
     private static final String PARAM_ERROR = "error";
-    private static final int MAX_CONTET_LONG_LENGTH = 256;
+    private static final int MAX_CONTENT_LONG_LENGTH = 256;
 
     private String method;
     private RestClient restClient;
@@ -105,7 +105,7 @@ class RequestBuilder {
         try (Operation op = new Operation(() -> "Elastic: " + method + " " + uri, Duration.ofSeconds(30))) {
             if (Elastic.LOG.isFINE()) {
                 Elastic.LOG.FINE(method + " " + uri + ": " + Strings.limit(buildContent().orElse("-"),
-                                                                           MAX_CONTET_LONG_LENGTH));
+                                                                           MAX_CONTENT_LONG_LENGTH));
             }
 
             NStringEntity requestContent =
@@ -133,7 +133,7 @@ class RequestBuilder {
                 DB.SLOW_DB_LOG.INFO("A slow Elasticsearch query was executed (%s): %s\n%s\n%s",
                                     w.duration(),
                                     method + ": " + uri,
-                                    Strings.limit(buildContent().orElse("no content"), MAX_CONTET_LONG_LENGTH),
+                                    Strings.limit(buildContent().orElse("no content"), MAX_CONTENT_LONG_LENGTH),
                                     ExecutionPoint.snapshot().toString());
             }
         }

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -106,7 +106,7 @@ public abstract class SQLEntity extends BaseEntity<Long> {
         if (other == null) {
             return false;
         }
-        if (!(other.getClass().equals(getClass()))) {
+        if (other.getClass() != this.getClass()) {
             return false;
         }
         SQLEntity otherEntity = (SQLEntity) other;

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -24,6 +24,7 @@ import sirius.db.mixing.annotations.Versioned;
 import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.kernel.Sirius;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.MultiMap;
 import sirius.kernel.commons.PriorityCollector;
 import sirius.kernel.commons.Strings;
@@ -45,6 +46,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -833,6 +835,8 @@ public class EntityDescriptor {
      * @param composite the composite type to check for
      * @return <tt>true</tt> if one or more composites of the given type are present, <tt>false</tt> otherwise
      */
+    @SuppressWarnings("squid:S2175")
+    @Explain("False positive detected by sonarlint")
     public boolean hasComposite(Class<? extends Composite> composite) {
         return composites.contains(composite);
     }
@@ -843,7 +847,7 @@ public class EntityDescriptor {
      * @return a collection containing all mixin classes affecting the described entity
      */
     public Collection<Class<? extends Mixable>> getMixins() {
-        return mixins;
+        return Collections.unmodifiableSet(mixins);
     }
 
     /**


### PR DESCRIPTION
This is essential when logging bulk inserts as otherwise, the
generated log messages will be very large.

Fixes: SIRI.24