### PR TITLE
Disables dynamic mappings

### DIFF
--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -163,6 +163,7 @@ public class IndexMappings implements Startable {
     public void createMapping(EntityDescriptor ed, String indexName) {
         JSONObject mapping = new JSONObject();
         JSONObject properties = new JSONObject();
+        mapping.put("dynamic", "strict");
         mapping.put("properties", properties);
 
         List<String> excludes = ed.getProperties()


### PR DESCRIPTION
This is useless for us as we always provide a precise schema for our mappings.