### PR TITLE
Uses a correct label for the "Max Memory" metric of redis.

### DIFF
--- a/src/main/java/sirius/db/redis/RedisMetricProvider.java
+++ b/src/main/java/sirius/db/redis/RedisMetricProvider.java
@@ -49,7 +49,7 @@ public class RedisMetricProvider implements MetricProvider {
                              Value.of(redis.getInfo().get(INFO_USED_MEMORY)).asLong(0) / 1024d / 1024d,
                              "MB");
             collector.metric("redis_max_memory",
-                             "Redis Memory Usage",
+                             "Redis Max Memory",
                              Value.of(redis.getInfo().get(INFO_MAXMEMORY)).asLong(0) / 1024d / 1024d,
                              "MB",
                              MetricState.GRAY);


### PR DESCRIPTION
Note that this reports 0 unless a max value is set in the redis config.
We configured our grafana to fallback to 1024 (=1GB) in that case.