### PR TITLE
Sets the dynamic mapping setting to the provided mode for nested objects

### DIFF
--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -14,6 +14,8 @@ import sirius.db.es.annotations.RoutedBy;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixing;
 import sirius.db.mixing.Property;
+import sirius.db.mixing.properties.BaseMapProperty;
+import sirius.db.mixing.properties.NestedListProperty;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
 import sirius.kernel.di.std.Part;
@@ -207,6 +209,9 @@ public class IndexMappings implements Startable {
             } else {
                 JSONObject propertyInfo = new JSONObject();
                 ((ESPropertyInfo) property).describeProperty(propertyInfo);
+                if (property instanceof BaseMapProperty || property instanceof NestedListProperty) {
+                    propertyInfo.put("dynamic", mode.toString());
+                }
                 properties.put(property.getPropertyName(), propertyInfo);
             }
         }

--- a/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
@@ -245,6 +245,5 @@ public class NestedListProperty extends Property implements ESPropertyInfo {
             }
         }
         description.put("properties", properties);
-        description.put("dynamic", false);
     }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
@@ -125,6 +125,5 @@ public class StringBooleanMapProperty extends BaseMapProperty implements ESPrope
                        new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, IndexMappings.MAPPING_TYPE_KEWORD));
         properties.put(StringMapProperty.VALUE, new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, "boolean"));
         description.put("properties", properties);
-        description.put("dynamic", false);
     }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
@@ -155,6 +155,5 @@ public class StringLocalDateTimeMapProperty extends BaseMapProperty implements E
                        new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, IndexMappings.MAPPING_TYPE_KEWORD));
         properties.put(StringMapProperty.VALUE, new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, "date"));
         description.put("properties", properties);
-        description.put("dynamic", false);
     }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
@@ -127,6 +127,5 @@ public class StringMapProperty extends BaseMapProperty implements ESPropertyInfo
         properties.put(VALUE,
                        new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, IndexMappings.MAPPING_TYPE_KEWORD));
         description.put("properties", properties);
-        description.put("dynamic", false);
     }
 }


### PR DESCRIPTION
This is already done for the general setting of the index but also needs to be done for nested objects.