### PR TITLE
Only apply an index defined by a superclass if none of the subclasses…

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/Schema.java
+++ b/src/main/java/sirius/db/jdbc/schema/Schema.java
@@ -251,7 +251,12 @@ public class Schema implements Startable, Initializable {
                 key.addColumn(i, name);
             }
             key.setUnique(index.unique());
-            table.getKeys().add(key);
+
+            // Only add the key if the name isn't occupied already (indices are inherited from parent classes).
+            // Using this approach, indices can be "overwritten" by subclasses.
+            if (table.getKeys().stream().map(Key::getName).noneMatch(name -> Strings.areEqual(name, key.getName()))) {
+                table.getKeys().add(key);
+            }
         });
     }
 


### PR DESCRIPTION
… defines it.

For each entity we inherit all index definitions from all superclasses.
To permit a concrete entity type to overwrite the index defined by one
of its superclasses, we only apply the index if no other index with
the same name already exists.

As we iterate from bottom up (starting at the concrete class and walk
up to each superclass), this check is sufficient and gives priority
to the concrete implementations.