### PR TITLE
We need to set the closed connection to null in order to create a new…

### DIFF
--- a/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
@@ -226,6 +226,8 @@ public abstract class BatchQuery<E extends SQLEntity> {
                       .error(e)
                       .withSystemErrorMessage("An error occured while closing a prepared statement: %s (%s)")
                       .handle();
+        } finally {
+            stmt = null;
         }
     }
 


### PR DESCRIPTION
… one

If we do not reset the stmt variable we will run into an error after the connection was closed.
This might happen whenever an sqlException is thrown. The connection is closed but we are not able
to recover it because the object is not null and our build sql function requires a null variable to
create a new connection