### PR TITLE
Fixes the OneInField constraint for MongoDB queries

### DIFF
--- a/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
@@ -14,6 +14,7 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.query.constraints.OneInField;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -49,6 +50,7 @@ class MongoOneInField extends OneInField<MongoConstraint> {
         }
 
         clauses.add(factory.notFilled(field));
+        clauses.add(factory.eq(field, Collections.emptyList()));
 
         return factory.or(clauses);
     }

--- a/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
+++ b/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
@@ -21,8 +21,10 @@ class MongoFilterFactorySpec extends BaseSpecification {
         setup:
         MongoStringListEntity entity = new MongoStringListEntity()
         entity.getList().modify().addAll(["1", "2", "3"])
+        MongoStringListEntity entityEmpty = new MongoStringListEntity()
         when:
         mango.update(entity)
+        mango.update(entityEmpty)
         then:
         mango.select(MongoStringListEntity.class)
              .eq(MongoEntity.ID, entity.getId())
@@ -38,6 +40,11 @@ class MongoFilterFactorySpec extends BaseSpecification {
              .eq(MongoEntity.ID, entity.getId())
              .where(QueryBuilder.FILTERS.oneInField(MongoStringListEntity.LIST, ["4", "5", "6"]).build())
              .count() == 0
+        then:
+        mango.select(MongoStringListEntity.class)
+             .eq(MongoEntity.ID, entityEmpty.getId())
+             .where(QueryBuilder.FILTERS.oneInField(MongoStringListEntity.LIST, ["4", "5", "6"]).orEmpty().build())
+             .queryOne().getId() == entityEmpty.getId()
     }
 
     def "noneInField query works"() {


### PR DESCRIPTION
Previously, it did not match empty lists even with orEmpty(), because "field: {$eq: null}" does not match "field: []"