### PR TITLE
Allows to import LocalDate, LocalDateTime and LocalTime directly

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
@@ -68,6 +68,15 @@ public class LocalDateProperty extends Property implements ESPropertyInfo, SQLPr
     }
 
     @Override
+    protected Object transformValueFromImport(Value value) {
+        if (value.is(LocalDate.class)) {
+            return value.get();
+        }
+
+        return transformValue(value);
+    }
+
+    @Override
     protected Object transformFromJDBC(Value data) {
         Object object = data.get();
         if (object == null) {

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -69,6 +69,15 @@ public class LocalDateTimeProperty extends Property implements ESPropertyInfo, S
     }
 
     @Override
+    protected Object transformValueFromImport(Value value) {
+        if (value.is(LocalDateTime.class)) {
+            return value.get();
+        }
+
+        return transformValue(value);
+    }
+
+    @Override
     protected Object transformFromJDBC(Value object) {
         Object data = object.get();
         if (data == null) {

--- a/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
@@ -61,6 +61,15 @@ public class LocalTimeProperty extends Property implements SQLPropertyInfo {
     }
 
     @Override
+    protected Object transformValueFromImport(Value value) {
+        if (value.is(LocalTime.class)) {
+            return value.get();
+        }
+
+        return transformValue(value);
+    }
+
+    @Override
     protected Object transformFromJDBC(Value data) {
         Object object = data.get();
 


### PR DESCRIPTION
It was not possible to directly set these types into the import context, as the asString in transformValue returns a machine string which can't be parsed by parseUserString.