### PR TITLE
Makes batch updates really work.

### DIFF
--- a/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
@@ -91,6 +91,7 @@ public abstract class BatchQuery<E extends SQLEntity> {
             try {
                 Watch w = Watch.start();
                 stmt.executeBatch();
+                stmt.getConnection().commit();
                 avarage.addValues(batchBacklog, w.elapsedMillis());
                 batchBacklog = 0;
             } catch (SQLException e) {

--- a/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
@@ -69,6 +69,7 @@ public class CustomQuery extends BatchQuery<SQLEntity> {
     @Nullable
     public Row executeUpdate() throws SQLException {
         prepareStmt().executeUpdate();
+        prepareStmt().getConnection().commit();
         if (fetchId) {
             return dbs.fetchGeneratedKeys(stmt);
         } else {

--- a/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
@@ -75,6 +75,7 @@ public class DeleteQuery<E extends SQLEntity> extends BatchQuery<E> {
                 addBatch();
             } else {
                 stmt.executeUpdate();
+                stmt.getConnection().commit();
                 avarage.addValue(w.elapsedMillis());
             }
 

--- a/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
@@ -79,6 +79,7 @@ public class InsertQuery<E extends SQLEntity> extends BatchQuery<E> {
                 addBatch();
             } else {
                 stmt.executeUpdate();
+                stmt.getConnection().commit();
                 if (fetchId) {
                     Row keys = dbs.fetchGeneratedKeys(stmt);
                     OMA.loadCreatedId(entity, keys);

--- a/src/main/java/sirius/db/jdbc/batch/UpdateQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/UpdateQuery.java
@@ -104,6 +104,7 @@ public class UpdateQuery<E extends SQLEntity> extends BatchQuery<E> {
                 addBatch();
             } else {
                 stmt.executeUpdate();
+                stmt.getConnection().commit();
                 avarage.addValue(w.elapsedMillis());
                 if (descriptor.isVersioned()) {
                     entity.setVersion(entity.getVersion() + 1);

--- a/src/test/java/sirius/db/jdbc/batch/BatchContextSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/batch/BatchContextSpec.groovy
@@ -172,7 +172,7 @@ class BatchContextSpec extends BaseSpecification {
         ctx.close()
     }
 
-    def "delete update works"() {
+    def "delete in batch works"() {
         setup:
         TestEntity e = new TestEntity()
         e.setFirstname("BatchDelete")


### PR DESCRIPTION
One has to disable autoCommit for connections when using a batch statement.
We do this now and immediately issue a direct commit() for non-batch statements.