### PR TITLE
Also sets limit and skip in the Query itself when it is updated

### DIFF
--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -106,6 +106,8 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
      * @return the builder itself for fluent method calls
      */
     public MongoQuery<E> limit(int skip, int limit) {
+        this.skip = skip;
+        this.limit = limit;
         finder.limit(skip, limit);
 
         return this;
@@ -113,14 +115,15 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
 
     @Override
     public MongoQuery<E> skip(int skip) {
+        this.skip = skip;
         finder.skip(skip);
         return this;
     }
 
     @Override
     public MongoQuery<E> limit(int limit) {
+        this.limit = limit;
         finder.limit(limit);
-
         return this;
     }
 


### PR DESCRIPTION
Fixes an error where randomList() or queryList() tried to check the limit of the query for error purposes, but the limit is only set in the finder, and the limit in the query itself was always 0.