### PR TITLE
Applies the access path before handing the entity over to an internal…

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -99,7 +99,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
 
     @Override
     public Object getValueAsCopy(Object entity) {
-        return getEntityRefList(entity).copyList();
+        return getEntityRefList(accessPath.apply(entity)).copyList();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
… method,

Otherwise entity ref lists wouldn't work in composites and mixins.