### PR TITLE
Do the renamings defined in the legacy-info of an entity again

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/Schema.java
+++ b/src/main/java/sirius/db/jdbc/schema/Schema.java
@@ -213,6 +213,7 @@ public class Schema implements Startable, Initializable {
 
         collectColumns(table, ed);
         collectKeys(table, ed);
+        applyColumnRenamings(table);
 
         return table;
     }


### PR DESCRIPTION
By calling "applyColumnRenamings" again, which was unused before