### PR TITLE
SIRI-79: Allows null default values for boolean properties to be transformed c…

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -60,6 +60,14 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
 
     @Override
     public Object transformValue(Value value) {
+        if (defaultValue == null) {
+            if (value.isNull() || value.isEmptyString()) {
+                return null;
+            } else {
+                return value.asBoolean();
+            }
+        }
+
         return value.asBoolean(NLS.parseMachineString(Boolean.class, defaultValue));
     }
 


### PR DESCRIPTION
…orrectly

This prevents an unboxing exception when calling value.asBoolean(null)
- Fixes: SIRI-79