### PR TITLE
Fixes a race condition.

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -372,8 +372,12 @@ public class EntityDescriptor {
 
     private List<Consumer<Object>> getSortedBeforeSaveHandlers() {
         if (sortedBeforeSaveHandlers == null) {
-            sortedBeforeSaveHandlers = beforeSaveHandlerCollector.getData();
-            beforeSaveHandlerCollector = null;
+            synchronized (this) {
+                if (beforeSaveHandlerCollector != null) {
+                    sortedBeforeSaveHandlers = beforeSaveHandlerCollector.getData();
+                    beforeSaveHandlerCollector = null;
+                }
+            }
         }
 
         return sortedBeforeSaveHandlers;


### PR DESCRIPTION
PriorityCollector.getData() performs a sort
on its internal data structure which might yield
a ConcurrentModificationException when invoked
in parallel.