### PR TITLE
Fixes reading out the existing default value for comparing schemas

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -416,5 +418,10 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
      */
     protected int getConstraintCharacterLimit() {
         return DEFAULT_MAX_CONSTRAINT_NAME_LENGTH;
+    }
+
+    @Override
+    public String getDefaultValue(ResultSet rs) throws SQLException {
+        return rs.getString("COLUMN_DEF");
     }
 }

--- a/src/main/java/sirius/db/jdbc/schema/DatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/DatabaseDialect.java
@@ -9,6 +9,8 @@
 package sirius.db.jdbc.schema;
 
 import javax.annotation.Nullable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 
@@ -196,4 +198,13 @@ public interface DatabaseDialect {
      * @return the effective name for the key
      */
     String getEffectiveKeyName(Table targetTable, Key key);
+
+    /**
+     * Determines the default value for the given column
+     *
+     * @param rs the result set of the column
+     * @return the default value, can be <tt>null</tt>
+     * @throws SQLException in case of a database error
+     */
+    String getDefaultValue(ResultSet rs) throws SQLException;
 }

--- a/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
@@ -10,6 +10,8 @@ package sirius.db.jdbc.schema;
 
 import sirius.kernel.di.std.Register;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.text.MessageFormat;
 import java.util.Collections;
@@ -128,5 +130,16 @@ public class MySQLDatabaseDialect extends BasicDatabaseDialect {
     @Override
     protected int getConstraintCharacterLimit() {
         return 64;
+    }
+
+    @Override
+    public String getDefaultValue(ResultSet rs) throws SQLException {
+        String defaultValue = super.getDefaultValue(rs);
+
+        if ("NULL".equals(defaultValue)) {
+            return null;
+        }
+
+        return defaultValue;
     }
 }

--- a/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
+++ b/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
@@ -152,20 +152,10 @@ public class SchemaTool {
             column.setLength(rs.getInt("COLUMN_SIZE"));
             column.setPrecision(rs.getInt("COLUMN_SIZE"));
             column.setScale(rs.getInt("DECIMAL_DIGITS"));
-            column.setDefaultValue(getDefaultValue(rs));
+            column.setDefaultValue(dialect.getDefaultValue(rs));
             table.getColumns().add(column);
         }
         rs.close();
-    }
-
-    private String getDefaultValue(ResultSet rs) throws SQLException {
-        String defaultValue = rs.getString("COLUMN_DEF");
-
-        if ("NULL".equals(defaultValue)) {
-            return null;
-        }
-
-        return defaultValue;
     }
 
     /**

--- a/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
+++ b/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
@@ -152,10 +152,20 @@ public class SchemaTool {
             column.setLength(rs.getInt("COLUMN_SIZE"));
             column.setPrecision(rs.getInt("COLUMN_SIZE"));
             column.setScale(rs.getInt("DECIMAL_DIGITS"));
-            column.setDefaultValue(rs.getString("COLUMN_DEF"));
+            column.setDefaultValue(getDefaultValue(rs));
             table.getColumns().add(column);
         }
         rs.close();
+    }
+
+    private String getDefaultValue(ResultSet rs) throws SQLException {
+        String defaultValue = rs.getString("COLUMN_DEF");
+
+        if ("NULL".equals(defaultValue)) {
+            return null;
+        }
+
+        return defaultValue;
     }
 
     /**


### PR DESCRIPTION
MySQL wrongly returns null when the default value is "NULL". MariaDB follows the documentation and returns the string "NULL".