### PR TITLE
Allows open date ranges to work in MongoDB aggregations

### DIFF
--- a/src/main/java/sirius/db/mixing/DateRange.java
+++ b/src/main/java/sirius/db/mixing/DateRange.java
@@ -194,7 +194,7 @@ public class DateRange {
     public static DateRange beforeThisYear() {
         return new DateRange("beforeThisYear",
                              NLS.get("DateRange.beforeThisYear"),
-                             null,
+                             LocalDate.of(1900, 01, 01).atStartOfDay(),
                              LocalDate.now().withDayOfYear(1).atStartOfDay());
     }
 
@@ -206,7 +206,7 @@ public class DateRange {
     public static DateRange beforeLastYear() {
         return new DateRange("beforeLastYear",
                              NLS.get("DateRange.beforeLastYear"),
-                             null,
+                             LocalDate.of(1900, 01, 01).atStartOfDay(),
                              LocalDate.now().minusYears(1).withDayOfYear(1).atStartOfDay());
     }
 


### PR DESCRIPTION
MongoDb does not allow to mix types of buckets of an aggregations so it fails if one of the boundaries is provided as null.
So instead we provide a very low value as the lower date bound for the "open" date ranges.