### PR TITLE
Aha/field lookup cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>13.2</sirius.kernel>
+        <sirius.kernel>13.6</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -19,6 +19,7 @@ import sirius.db.es.constraints.ElasticFilterFactory;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.ContextInfo;
 import sirius.db.mixing.EntityDescriptor;
+import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.kernel.async.ExecutionPoint;
@@ -507,5 +508,10 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     @Override
     public FilterFactory<ElasticConstraint> filters() {
         return FILTERS;
+    }
+
+    @Override
+    public Value fetchField(Class<? extends ElasticEntity> type, Object id, Mapping field) throws Exception {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/sirius/db/jdbc/OMA.java
+++ b/src/main/java/sirius/db/jdbc/OMA.java
@@ -15,11 +15,13 @@ import sirius.db.jdbc.schema.Schema;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.EntityDescriptor;
+import sirius.db.mixing.Mapping;
 import sirius.db.mixing.OptimisticLockException;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.kernel.async.Future;
 import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
@@ -387,5 +389,19 @@ public class OMA extends BaseMapper<SQLEntity, SQLConstraint, SmartQuery<? exten
     @Override
     protected <E extends SQLEntity> Optional<E> findEntity(E entity) {
         return find((Class<E>) entity.getClass(), entity.getId());
+    }
+
+    @Override
+    public Value fetchField(Class<? extends SQLEntity> type, Object id, Mapping field) throws Exception {
+        if (Strings.isEmpty(id)) {
+            return Value.EMPTY;
+        }
+
+        return select(type).fields(field)
+                           .limit(1)
+                           .eq(SQLEntity.ID, id)
+                           .asSQLQuery()
+                           .queryFirst()
+                           .getValue(field.toString());
     }
 }

--- a/src/main/java/sirius/db/mixing/BaseMapper.java
+++ b/src/main/java/sirius/db/mixing/BaseMapper.java
@@ -13,6 +13,7 @@ import sirius.db.mixing.annotations.Versioned;
 import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.db.mixing.query.constraints.FilterFactory;
+import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
@@ -447,4 +448,18 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
      * @return the filter factory used by this mapper
      */
     public abstract FilterFactory<C> filters();
+
+    /**
+     * Provides the most efficient way of retrieving the field value of the requested entity.
+     * <p>
+     * Note that it is probably advisable to not call this method directly but rather
+     * {@link FieldLookupCache#lookup(BaseEntityRef, String)} which provides a cache.
+     *
+     * @param type  the type of the entity
+     * @param id    the id of the entity
+     * @param field the field to resolve
+     * @return the field value
+     * @throws Exception in case of an error during a lookup
+     */
+    public abstract Value fetchField(Class<? extends B> type, Object id, Mapping field) throws Exception;
 }

--- a/src/main/java/sirius/db/mixing/FieldLookupCache.java
+++ b/src/main/java/sirius/db/mixing/FieldLookupCache.java
@@ -1,0 +1,116 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.mixing.types.BaseEntityRef;
+import sirius.kernel.cache.Cache;
+import sirius.kernel.cache.CacheManager;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+
+import javax.annotation.Nullable;
+
+/**
+ * Provides a global cache for field values.
+ * <p>
+ * This can be used to quickly resolve IDs into names / label when rendering tables of items.
+ * Note that the cache isn't invalidated automatically but rather short lived.
+ */
+@Register(classes = FieldLookupCache.class)
+public class FieldLookupCache {
+
+    private Cache<String, Value> cache = CacheManager.createLocalCache("mixing-field-lookup");
+
+    @Part
+    private Mixing mixing;
+
+    private <E extends BaseEntity<?>> Value load(Class<E> type, @Nullable Object id, Mapping field) throws Exception {
+        return mixing.getDescriptor(type).getMapper().fetchField(type, id, field);
+    }
+
+    /**
+     * Provides the value of the given entity and field.
+     * <p>
+     * Note that this gracefully handles both, empty IDs as well as IDs of nonexistent entities by simply returning
+     * an empty value.
+     *
+     * @param type  the type of the entity to resolve
+     * @param id    the id of the entity to resolve
+     * @param field the field to resolve
+     * @param <E>   the generic type of the entitiy
+     * @return the value of the field or an empty value if either the field is empty or the given ID was <tt>null</tt>
+     */
+    public <E extends BaseEntity<?>> Value lookup(Class<E> type, Object id, Mapping field) {
+        if (Strings.isEmpty(id)) {
+            return Value.EMPTY;
+        }
+
+        try {
+            String cacheKey = Mixing.getUniqueName(type, id) + "-" + field;
+            Value result = cache.get(cacheKey);
+            if (result == null) {
+                result = load(type, id, field);
+                cache.put(cacheKey, result);
+            }
+
+            return result;
+        } catch (Exception e) {
+            Exceptions.handle()
+                      .to(Mixing.LOG)
+                      .error(e)
+                      .withSystemErrorMessage(
+                              "An error occurred when performing a lookup on field %s for entity %s of type %s: %s (%s)",
+                              field,
+                              id,
+                              type)
+                      .handle();
+            return Value.EMPTY;
+        }
+    }
+
+    /**
+     * Provides the value of the given entity and field.
+     *
+     * @param type  the type of the entity to resolve
+     * @param id    the id of the entity to resolve
+     * @param field the field to resolve
+     * @param <E>   the generic type of the entitiy
+     * @return the value of the field or an empty value if either the field is empty or the given ID was <tt>null</tt>
+     */
+    public <E extends BaseEntity<?>> Value lookup(Class<E> type, Object id, String field) {
+        return lookup(type, id, Mapping.named(field));
+    }
+
+    /**
+     * Provides the value of the field for the entity in the given reference.
+     *
+     * @param ref   the reference which points to the entity to resolve
+     * @param field the field to resolve
+     * @param <E>   the generic type of the entitiy
+     * @return the value of the field or an empty value if either the field is empty or if the given reference was empty
+     */
+    public <E extends BaseEntity<?>> Value lookup(BaseEntityRef<?, E> ref, String field) {
+        return lookup(ref.getType(), ref.getId(), field);
+    }
+
+    /**
+     * Provides the value of the field for the entity in the given reference.
+     *
+     * @param ref   the reference which points to the entity to resolve
+     * @param field the field to resolve
+     * @param <E>   the generic type of the entitiy
+     * @return the value of the field or an empty value if either the field is empty or if the given reference was empty
+     */
+    public <E extends BaseEntity<?>> Value lookup(BaseEntityRef<?, E> ref, Mapping field) {
+        return lookup(ref.getType(), ref.getId(), field);
+    }
+}

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -18,6 +18,16 @@ product {
     }
 }
 
+cache {
+
+    # Controls the size of the lookup cache used by the FieldLookupCache.
+    mixing-field-lookup {
+        maxSize = 16384
+        ttl = 1 minute
+    }
+
+}
+
 # Configures the system health monitoring
 health {
 

--- a/src/test/java/sirius/db/jdbc/FieldLookupCacheSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/FieldLookupCacheSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc
+
+import sirius.db.mixing.FieldLookupCache
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+
+class FieldLookupCacheSpec extends BaseSpecification {
+
+    @Part
+    private static OMA oma
+
+    @Part
+    private static FieldLookupCache lookupCache
+
+    def "lookup works"() {
+        given:
+        SmartQueryTestEntity entity = new SmartQueryTestEntity()
+        entity.setValue("Cache Test")
+        entity.setTestNumber(12345)
+        oma.update(entity)
+        when:
+        def value1 = lookupCache.lookup(SmartQueryTestEntity.class, entity.getId(), SmartQueryTestEntity.VALUE)
+        def value2 = lookupCache.lookup(SmartQueryTestEntity.class, entity.getId(), SmartQueryTestEntity.TEST_NUMBER)
+        def value3 = lookupCache.lookup(SmartQueryTestEntity.class, entity.getId(), SmartQueryTestEntity.VALUE)
+        then:
+        value1.asString() == "Cache Test"
+        value2.asInt(0) == 12345
+        value3.asString() == "Cache Test"
+    }
+
+}


### PR DESCRIPTION
A query generated by this framework looks like: 
`SELECT e.value FROM smartquerytestentity e WHERE e.id= ? LIMIT 1`