### PR TITLE
Fixes MongoDateRangeFacets

### DIFF
--- a/src/main/java/sirius/db/mongo/facets/MongoDateRangeFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoDateRangeFacet.java
@@ -107,9 +107,7 @@ public class MongoDateRangeFacet extends MongoFacet {
         AtomicInteger indexCounter = new AtomicInteger();
         for (Tuple<DateRange, Integer> range : ranges) {
             Optional<Document> match = getRangeBucket(result.getList(name + indexCounter.getAndIncrement()));
-            match.ifPresent(document -> {
-                range.setSecond(document.getInteger("count", 0));
-            });
+            match.ifPresent(document -> range.setSecond(document.getInteger("count", 0)));
         }
 
         if (completionCallback != null) {

--- a/src/test/java/sirius/db/mongo/FacetSpec.groovy
+++ b/src/test/java/sirius/db/mongo/FacetSpec.groovy
@@ -61,7 +61,8 @@ class FacetSpec extends BaseSpecification {
                                                                                              DateRange.yesterday().
                                                                                                      getFrom(),
                                                                                              DateRange.today().
-                                                                                                     getUntil())))
+                                                                                                     getUntil()),
+                                                                               DateRange.beforeLastYear()))
         when:
         mango.select(MangoTestEntity.class)
              .eq(MangoTestEntity.AGE, 999)
@@ -88,6 +89,7 @@ class FacetSpec extends BaseSpecification {
         datesFacet.getRanges().get(0).getSecond() == 1
         datesFacet.getRanges().get(1).getSecond() == 1
         datesFacet.getRanges().get(2).getSecond() == 2
+        datesFacet.getRanges().get(3).getSecond() == 0
         and:
         superPowersFacet.getValues().get(0).getFirst() == "Flying"
         superPowersFacet.getValues().get(0).getSecond() == 3
@@ -96,6 +98,4 @@ class FacetSpec extends BaseSpecification {
         superPowersFacet.getValues().get(2).getFirst() == "Time travel"
         superPowersFacet.getValues().get(2).getSecond() == 1
     }
-
-
 }


### PR DESCRIPTION
When the Field-Value of the Document is not within the boundaries, it is counted to the default bucket. When there is not a single result, there is only the default bucket and "findFirst" returned the default bucket and in there the "count" was the number of all documents matching the query.

So all DateRanges without a single match were set to the total count of documents.
