### PR TITLE
Skips deletes of non existing entities

### DIFF
--- a/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
@@ -44,6 +44,10 @@ public class DeleteQuery<E extends SQLEntity> extends BatchQuery<E> {
     @SuppressWarnings("unchecked")
     public void delete(@Nonnull E example, boolean invokeChecks, boolean addBatch) {
         try {
+            if (example.isNew()) {
+                return;
+            }
+
             if (this.type == null) {
                 this.type = (Class<E>) example.getClass();
             }


### PR DESCRIPTION
This is analog to the oma.delete logic
If we don't skip it the version check would throw an exception for every versioned entity