### PR TITLE
Don't use FixedString for enums in Clickhouse by default

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
@@ -121,7 +121,7 @@ public class ClickhouseDatabaseDialect extends BasicDatabaseDialect {
     /**
      * Determines the type for string columns.
      * <p>
-     * {@link EnumProperty enum properties} should use the type <tt>String</tt>. Only if the length is explicitly
+     * {@link EnumProperty Enum properties} should use the type <tt>String</tt>. Only if the length is explicitly
      * given via the {@link Length} annotation we use <tt>FixedString</tt>.
      *
      * @param column the table column

--- a/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
@@ -8,6 +8,8 @@
 
 package sirius.db.jdbc.schema;
 
+import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.properties.EnumProperty;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
@@ -116,7 +118,22 @@ public class ClickhouseDatabaseDialect extends BasicDatabaseDialect {
                                                          column.getSource()));
     }
 
+    /**
+     * Determines the type for string columns.
+     * <p>
+     * {@link EnumProperty enum properties} should use the type <tt>String</tt>. Only if the length is explicitly
+     * given via the {@link Length} annotation we use <tt>FixedString</tt>.
+     *
+     * @param column the table column
+     * @return the clickhouse type
+     */
     private String getStringType(TableColumn column) {
+        if (column.getSource() instanceof EnumProperty && !column.getSource()
+                                                                 .getField()
+                                                                 .isAnnotationPresent(Length.class)) {
+            return "String";
+        }
+
         if (column.getLength() == 0) {
             return "String";
         } else {

--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -19,6 +19,7 @@ import sirius.db.mixing.AccessPath;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixable;
+import sirius.db.mixing.Mixing;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
 import sirius.db.mixing.annotations.Ordinal;
@@ -77,8 +78,24 @@ public class EnumProperty extends Property implements SQLPropertyInfo, ESPropert
     @SuppressWarnings("unchecked")
     @Override
     protected void determineLengths() {
+        super.determineLengths();
+
+        int maxLength = 0;
+
         for (Enum<?> e : ((Class<Enum<?>>) field.getType()).getEnumConstants()) {
-            this.length = Math.max(this.length, e.name().length());
+            maxLength = Math.max(maxLength, e.name().length());
+        }
+
+        if (this.length == 0) {
+            this.length = maxLength;
+        }
+
+        if (maxLength > this.length) {
+            Mixing.LOG.SEVERE(Strings.apply(
+                    "Length of enum property '%s' (from '%s') isn't large enough to fit maximum size %s",
+                    getName(),
+                    getDefinition(),
+                    maxLength));
         }
     }
 

--- a/src/test/java/sirius/db/jdbc/DataTypesEntity.java
+++ b/src/test/java/sirius/db/jdbc/DataTypesEntity.java
@@ -20,7 +20,7 @@ import java.time.LocalTime;
 public class DataTypesEntity extends SQLEntity {
 
     public enum TestEnum {
-        Test1, Test2
+        Test1, TestTest, Test2
     }
 
     @DefaultValue("100")
@@ -56,6 +56,10 @@ public class DataTypesEntity extends SQLEntity {
     @DefaultValue("Test2")
     @NullAllowed
     private TestEnum enumValue;
+
+    @NullAllowed
+    @Length(10)
+    private TestEnum enumValueFixedLength;
 
     private int intValue2 = 5;
 

--- a/src/test/java/sirius/db/jdbc/DataTypesSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/DataTypesSpec.groovy
@@ -98,4 +98,12 @@ class DataTypesSpec extends BaseSpecification {
         test.getLocalDateValue().getDayOfMonth() == 1
         test.getTestEnum() == DataTypesEntity.TestEnum.Test2
     }
+
+    def "determining the length of enums work"() {
+        when:
+        DataTypesEntity test = new DataTypesEntity()
+        then:
+        test.getDescriptor().getProperty("enumValue").getLength() == 8
+        test.getDescriptor().getProperty("enumValueFixedLength").getLength() == 10
+    }
 }

--- a/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseSpec.groovy
@@ -43,6 +43,7 @@ class ClickhouseSpec extends BaseSpecification {
         e.setaBooleanSetToTrue(true)
         e.setaBooleanSetToFalse(false)
         e.getStringList().add("string1").add("string2")
+        e.setEnumValue(ClickhouseTestEntity.EnumTest.TEST2)
         when:
         oma.update(e)
         then:
@@ -61,6 +62,7 @@ class ClickhouseSpec extends BaseSpecification {
         readBack.getDate() == LocalDate.now()
         readBack.getDateTime() == now
         readBack.getStringList().data() == ["string1", "string2"]
+        readBack.getEnumValue() == ClickhouseTestEntity.EnumTest.TEST2
     }
 
     def "batch insert into clickhouse works"() {
@@ -81,6 +83,7 @@ class ClickhouseSpec extends BaseSpecification {
             e.setString("Test")
             e.setFixedString("B")
             e.setInt8WithDefault(0)
+            e.setEnumValue(ClickhouseTestEntity.EnumTest.TEST1)
             insert.insert(e, true, true)
         }
         and:

--- a/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
@@ -22,6 +22,10 @@ import java.time.LocalDate;
 @Realm("clickhouse")
 public class ClickhouseTestEntity extends SQLEntity {
 
+    public enum EnumTest {
+        TEST1, TEST2
+    }
+
     public static final Mapping DATE_TIME = Mapping.named("dateTime");
     private Instant dateTime;
 
@@ -68,6 +72,10 @@ public class ClickhouseTestEntity extends SQLEntity {
     public static final Mapping NULLABLE = Mapping.named("nullable");
     @NullAllowed
     private Long nullable = null;
+
+    public static final Mapping ENUM_VALUE = Mapping.named("enumValue");
+    @NullAllowed
+    private EnumTest enumValue = null;
 
     public Instant getDateTime() {
         return dateTime;
@@ -167,5 +175,13 @@ public class ClickhouseTestEntity extends SQLEntity {
 
     public void setNullable(Long nullable) {
         this.nullable = nullable;
+    }
+
+    public EnumTest getEnumValue() {
+        return enumValue;
+    }
+
+    public void setEnumValue(EnumTest enumValue) {
+        this.enumValue = enumValue;
     }
 }


### PR DESCRIPTION
Instead String is used. This is necessary, because the length can't be easily changed after the table is created. If the length is set via `@Length` fall back to FixedString in order to be backward compatible.