### PR TITLE
Uses a proper name for the test enum.

### DIFF
--- a/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseSpec.groovy
@@ -43,7 +43,7 @@ class ClickhouseSpec extends BaseSpecification {
         e.setaBooleanSetToTrue(true)
         e.setaBooleanSetToFalse(false)
         e.getStringList().add("string1").add("string2")
-        e.setEnumValue(ClickhouseTestEntity.EnumTest.TEST2)
+        e.setEnumValue(ClickhouseTestEntity.TestEnum.Test2)
         when:
         oma.update(e)
         then:
@@ -62,7 +62,7 @@ class ClickhouseSpec extends BaseSpecification {
         readBack.getDate() == LocalDate.now()
         readBack.getDateTime() == now
         readBack.getStringList().data() == ["string1", "string2"]
-        readBack.getEnumValue() == ClickhouseTestEntity.EnumTest.TEST2
+        readBack.getEnumValue() == ClickhouseTestEntity.TestEnum.Test2
     }
 
     def "batch insert into clickhouse works"() {
@@ -83,7 +83,7 @@ class ClickhouseSpec extends BaseSpecification {
             e.setString("Test")
             e.setFixedString("B")
             e.setInt8WithDefault(0)
-            e.setEnumValue(ClickhouseTestEntity.EnumTest.TEST1)
+            e.setEnumValue(ClickhouseTestEntity.TestEnum.Test1)
             insert.insert(e, true, true)
         }
         and:

--- a/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
@@ -22,8 +22,8 @@ import java.time.LocalDate;
 @Realm("clickhouse")
 public class ClickhouseTestEntity extends SQLEntity {
 
-    public enum EnumTest {
-        TEST1, TEST2
+    public enum TestEnum {
+        Test1, Test2
     }
 
     public static final Mapping DATE_TIME = Mapping.named("dateTime");
@@ -75,7 +75,7 @@ public class ClickhouseTestEntity extends SQLEntity {
 
     public static final Mapping ENUM_VALUE = Mapping.named("enumValue");
     @NullAllowed
-    private EnumTest enumValue = null;
+    private TestEnum enumValue = null;
 
     public Instant getDateTime() {
         return dateTime;
@@ -177,11 +177,11 @@ public class ClickhouseTestEntity extends SQLEntity {
         this.nullable = nullable;
     }
 
-    public EnumTest getEnumValue() {
+    public TestEnum getEnumValue() {
         return enumValue;
     }
 
-    public void setEnumValue(EnumTest enumValue) {
+    public void setEnumValue(TestEnum enumValue) {
         this.enumValue = enumValue;
     }
 }


### PR DESCRIPTION
All classes ending with "*Test" or "*Spec" aren't re-exported in the test jar.
Therefore this broke the build of all subsequent libraries