### PR TITLE
Upgrading com.alibaba.fastjson 1.2.47 -> 1.2.62

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.47</version>
+            <version>1.2.62</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Already in use by other sirius modules, but maven not always decides for the newest version.
Upgrade required in order to call `JSON.valid()`