### PR TITLE
Don't log length exception

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -123,14 +123,12 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
     @Override
     public void onBeforeSaveChecks(Object entity) {
         String value = (String) getValue(entity);
-        if (trim) {
-            if (value != null) {
-                value = value.trim();
-                if (value.isEmpty()) {
-                    value = null;
-                }
-                setValue(entity, value);
+        if (trim && value != null) {
+            value = value.trim();
+            if (value.isEmpty()) {
+                value = null;
             }
+            setValue(entity, value);
         }
         super.onBeforeSaveChecks(entity);
 

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -71,15 +71,6 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
 
     @Override
     protected Object transformToDatasource(Class<? extends BaseMapper<?, ?, ?>> mapperType, Object object) {
-        if (length > 0 && !lob && object != null && ((String) object).length() > length) {
-            throw Exceptions.createHandled()
-                            .withNLSKey("StringProperty.dataTruncation")
-                            .set("value", Strings.limit(object, 30))
-                            .set("field", getFullLabel())
-                            .set("length", ((String) object).length())
-                            .set("maxLength", length)
-                            .handle();
-        }
         return object;
     }
 
@@ -131,8 +122,8 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
 
     @Override
     public void onBeforeSaveChecks(Object entity) {
+        String value = (String) getValue(entity);
         if (trim) {
-            String value = (String) getValue(entity);
             if (value != null) {
                 value = value.trim();
                 if (value.isEmpty()) {
@@ -142,6 +133,16 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
             }
         }
         super.onBeforeSaveChecks(entity);
+
+        if (length > 0 && value != null && value.length() > length) {
+            throw Exceptions.createHandled()
+                            .withNLSKey("StringProperty.dataTruncation")
+                            .set("value", Strings.limit(value, 30))
+                            .set("field", getFullLabel())
+                            .set("length", value.length())
+                            .set("maxLength", length)
+                            .handle();
+        }
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -72,8 +72,7 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
     @Override
     protected Object transformToDatasource(Class<? extends BaseMapper<?, ?, ?>> mapperType, Object object) {
         if (length > 0 && !lob && object != null && ((String) object).length() > length) {
-            throw Exceptions.handle()
-                            .to(Mixing.LOG)
+            throw Exceptions.createHandled()
                             .withNLSKey("StringProperty.dataTruncation")
                             .set("value", Strings.limit(object, 30))
                             .set("field", getFullLabel())


### PR DESCRIPTION
This happens usually when the user inputs data which is too long for the field.
We should show an exception but we do not need to log it
- Fixes: SE-8900