### PR TITLE
Properly logs a warning when linking a reference property runs into a…

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -194,21 +194,29 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
     public void link() {
         super.link();
 
-        BaseEntityRef.OnDelete deleteHandler = getReferenceEntityRefList().getDeleteHandler();
-        if (deleteHandler != BaseEntityRef.OnDelete.IGNORE) {
-            if (!BaseEntityRefProperty.ensureProperReferenceType(this, getReferencedDescriptor())) {
-                return;
+        try {
+            BaseEntityRef.OnDelete deleteHandler = getReferenceEntityRefList().getDeleteHandler();
+            if (deleteHandler != BaseEntityRef.OnDelete.IGNORE) {
+                if (!BaseEntityRefProperty.ensureProperReferenceType(this, getReferencedDescriptor())) {
+                    return;
+                }
+
+                BaseEntityRefProperty.ensureLabelsArePresent(this, referencedDescriptor, deleteHandler);
             }
 
-            BaseEntityRefProperty.ensureLabelsArePresent(this, referencedDescriptor, deleteHandler);
-        }
-
-        if (deleteHandler == BaseEntityRef.OnDelete.CASCADE) {
-            getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteCascade);
-        } else if (deleteHandler == BaseEntityRef.OnDelete.SET_NULL) {
-            getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteSetNull);
-        } else if (deleteHandler == BaseEntityRef.OnDelete.REJECT) {
-            getReferencedDescriptor().addBeforeDeleteHandler(this::onDeleteReject);
+            if (deleteHandler == BaseEntityRef.OnDelete.CASCADE) {
+                getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteCascade);
+            } else if (deleteHandler == BaseEntityRef.OnDelete.SET_NULL) {
+                getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteSetNull);
+            } else if (deleteHandler == BaseEntityRef.OnDelete.REJECT) {
+                getReferencedDescriptor().addBeforeDeleteHandler(this::onDeleteReject);
+            }
+        } catch (Exception e) {
+            Mixing.LOG.WARN("Error when linking property %s of %s: %s (%s)",
+                            this,
+                            getDescriptor(),
+                            e.getMessage(),
+                            e.getClass().getSimpleName());
         }
     }
 

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -215,6 +215,10 @@ public abstract class BaseEntityRefProperty<I, E extends BaseEntity<I>, R extend
                     Mixing.LOG.WARN("Error in property %s of %s: The field is not marked as NullAllowed,"
                                     + " therefore SET_NULL is not a valid delete handler!", this, getDescriptor());
                 }
+                if (entityRef.hasWriteOnceSemantics()) {
+                    Mixing.LOG.WARN("Error in property %s of %s. The field has write once semantics,"
+                                    + " therefore SET_NULL is not a valid delete handler!", this, getDescriptor());
+                }
 
                 getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteSetNull);
             } else if (deleteHandler == BaseEntityRef.OnDelete.REJECT) {


### PR DESCRIPTION
…n error.

This commonly happens if an entity from a disabled framework is referenced.
We now output the property and descriptor of the entity which caused the error
instead of just outputting the name of the missing entity type.