### PR TITLE
Adds support for Elasticsearch 7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>7.4.0</version>
+            <version>7.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/src/main/java/sirius/db/es/BulkContext.java
+++ b/src/main/java/sirius/db/es/BulkContext.java
@@ -137,7 +137,6 @@ public class BulkContext implements Closeable {
 
         entity.setId(elastic.determineId(entity));
         meta.put(KEY_INDEX, elastic.determineAlias(ed));
-        meta.put(KEY_TYPE, elastic.determineTypeName(ed));
         meta.put(KEY_ID, entity.getId());
 
         String routing = elastic.determineRouting(ed, entity);
@@ -173,7 +172,6 @@ public class BulkContext implements Closeable {
 
         entity.setId(elastic.determineId(entity));
         meta.put(KEY_INDEX, elastic.determineAlias(ed));
-        meta.put(KEY_TYPE, elastic.determineTypeName(ed));
         meta.put(KEY_ID, entity.getId());
 
         String routing = elastic.determineRouting(ed, entity);

--- a/src/main/java/sirius/db/es/BulkContext.java
+++ b/src/main/java/sirius/db/es/BulkContext.java
@@ -41,9 +41,9 @@ public class BulkContext implements Closeable {
     private static final int DEFAULT_BATCH_SIZE = 256;
 
     private static final String KEY_INDEX = "_index";
-    private static final String KEY_TYPE = "_type";
     private static final String KEY_ID = "_id";
-    private static final String KEY_VERSION = "_version";
+    private static final String KEY_PRIMARY_TERM = "if_primary_term";
+    private static final String KEY_SEQ_NO = "if_seq_no";
     private static final String KEY_ROUTING = "_routing";
     private static final String KEY_ERROR = "error";
     private static final String KEY_ITEMS = "items";
@@ -132,7 +132,8 @@ public class BulkContext implements Closeable {
         JSONObject meta = new JSONObject();
 
         if (!force && !entity.isNew() && ed.isVersioned()) {
-            meta.put(KEY_VERSION, entity.getVersion());
+            meta.put(KEY_PRIMARY_TERM, entity.getPrimaryTerm());
+            meta.put(KEY_SEQ_NO, entity.getSeqNo());
         }
 
         entity.setId(elastic.determineId(entity));
@@ -167,7 +168,8 @@ public class BulkContext implements Closeable {
         JSONObject meta = new JSONObject();
 
         if (!force && ed.isVersioned()) {
-            meta.put(KEY_VERSION, entity.getVersion());
+            meta.put(KEY_PRIMARY_TERM, entity.getPrimaryTerm());
+            meta.put(KEY_SEQ_NO, entity.getSeqNo());
         }
 
         entity.setId(elastic.determineId(entity));

--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -146,12 +146,12 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
                     requestConfigBuilder -> requestConfigBuilder.setConnectionRequestTimeout(0);
 
             HttpHost[] httpHosts = Arrays.stream(this.hosts.split(","))
-                                     .map(String::trim)
-                                     .map(host -> Strings.splitAtLast(host, ":"))
-                                     .map(this::parsePort)
-                                     .map(this::mapPort)
-                                     .map(this::makeHttpHost)
-                                     .toArray(size -> new HttpHost[size]);
+                                         .map(String::trim)
+                                         .map(host -> Strings.splitAtLast(host, ":"))
+                                         .map(this::parsePort)
+                                         .map(this::mapPort)
+                                         .map(this::makeHttpHost)
+                                         .toArray(size -> new HttpHost[size]);
             client = new LowLevelClient(RestClient.builder(httpHosts).setRequestConfigCallback(configCallback).build());
 
             // If we're using a docker container (most probably for testing), we give ES some time
@@ -219,12 +219,8 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
         toJSON(ed, entity, data);
 
         String id = determineId(entity);
-        JSONObject response = getLowLevelClient().index(determineAlias(ed),
-                                                        determineTypeName(ed),
-                                                        id,
-                                                        determineRouting(ed, entity),
-                                                        null,
-                                                        data);
+        JSONObject response =
+                getLowLevelClient().index(determineAlias(ed), id, determineRouting(ed, entity), null, data);
         entity.setId(id);
         if (ed.isVersioned()) {
             entity.setVersion(response.getInteger(RESPONSE_VERSION));
@@ -259,7 +255,6 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
         }
 
         JSONObject response = getLowLevelClient().index(determineAlias(ed),
-                                                        determineTypeName(ed),
                                                         determineId(entity),
                                                         determineRouting(ed, entity),
                                                         determineVersion(force, ed, entity),
@@ -368,7 +363,6 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     @Override
     protected void deleteEntity(ElasticEntity entity, boolean force, EntityDescriptor ed) throws Exception {
         getLowLevelClient().delete(determineAlias(ed),
-                                   determineTypeName(ed),
                                    entity.getId(),
                                    determineRouting(ed, entity),
                                    determineVersion(force, ed, entity));
@@ -428,8 +422,7 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
                      ExecutionPoint.snapshot());
         }
 
-        JSONObject obj =
-                getLowLevelClient().get(determineAlias(ed), determineTypeName(ed), id.toString(), routing, true);
+        JSONObject obj = getLowLevelClient().get(determineAlias(ed), id.toString(), routing, true);
 
         if (obj == null || !Boolean.TRUE.equals(obj.getBoolean(RESPONSE_FOUND))) {
             return Optional.empty();

--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -17,6 +17,7 @@ import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.kernel.di.std.Part;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -39,6 +40,12 @@ public abstract class ElasticEntity extends BaseEntity<String> {
     public static final Mapping ID = Mapping.named("id");
     @NullAllowed
     private String id;
+
+    @Transient
+    protected long primaryTerm = 0;
+
+    @Transient
+    protected long seqNo = 0;
 
     @Transient
     private Set<String> matchedQueries;
@@ -83,7 +90,7 @@ public abstract class ElasticEntity extends BaseEntity<String> {
      * @return the list of named queries which matched this entity.
      */
     public Set<String> getMatchedQueries() {
-        return matchedQueries;
+        return Collections.unmodifiableSet(matchedQueries);
     }
 
     /**
@@ -95,7 +102,7 @@ public abstract class ElasticEntity extends BaseEntity<String> {
      * @param matchedQueries the list of named queries which matched this entity
      */
     protected void setMatchedQueries(Set<String> matchedQueries) {
-        this.matchedQueries = matchedQueries;
+        this.matchedQueries = Collections.unmodifiableSet(matchedQueries);
     }
 
     /**
@@ -110,5 +117,21 @@ public abstract class ElasticEntity extends BaseEntity<String> {
         }
 
         return matchedQueries.contains(queryName);
+    }
+
+    public long getPrimaryTerm() {
+        return primaryTerm;
+    }
+
+    public void setPrimaryTerm(long primaryTerm) {
+        this.primaryTerm = primaryTerm;
+    }
+
+    public long getSeqNo() {
+        return seqNo;
+    }
+
+    public void setSeqNo(long seqNo) {
+        this.seqNo = seqNo;
     }
 }

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -618,7 +618,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
         checkRouting();
 
         JSONObject countResponse = client.count(elastic.determineAlias(descriptor),
-                                                elastic.determineTypeName(descriptor),
                                                 routing,
                                                 buildSimplePayload());
         return countResponse.getLong(KEY_COUNT);
@@ -651,7 +650,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
         checkRouting();
 
         JSONObject existsResponse = client.exists(elastic.determineAlias(descriptor),
-                                                  elastic.determineTypeName(descriptor),
                                                   routing,
                                                   buildSimplePayload());
         return existsResponse.getJSONObject(KEY_HITS).getInteger(KEY_TOTAL) >= 1;
@@ -667,12 +665,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
 
         checkRouting();
 
-        this.response = client.search(elastic.determineAlias(descriptor),
-                                      elastic.determineTypeName(descriptor),
-                                      routing,
-                                      skip,
-                                      limit,
-                                      buildPayload());
+        this.response = client.search(elastic.determineAlias(descriptor), routing, skip, limit, buildPayload());
         for (Object obj : this.response.getJSONObject(KEY_HITS).getJSONArray(KEY_HITS)) {
             if (!handler.apply((E) Elastic.make(descriptor, (JSONObject) obj))) {
                 return;
@@ -706,12 +699,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                             .handle();
         }
 
-        this.response = client.search(elastic.determineAlias(descriptor),
-                                      elastic.determineTypeName(descriptor),
-                                      routing,
-                                      skip,
-                                      limit,
-                                      buildPayload());
+        this.response = client.search(elastic.determineAlias(descriptor), routing, skip, limit, buildPayload());
     }
 
     /**
@@ -829,12 +817,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
         if (response == null) {
             checkRouting();
 
-            this.response = client.search(elastic.determineAlias(descriptor),
-                                          elastic.determineTypeName(descriptor),
-                                          routing,
-                                          skip,
-                                          limit,
-                                          buildPayload());
+            this.response = client.search(elastic.determineAlias(descriptor), routing, skip, limit, buildPayload());
         }
 
         JSONObject responseSuggestions = response.getJSONObject(KEY_SUGGEST);
@@ -867,7 +850,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
             checkRouting();
 
             JSONObject scrollResponse = client.createScroll(elastic.determineAlias(descriptor),
-                                                            elastic.determineTypeName(descriptor),
                                                             routing,
                                                             0,
                                                             routing == null ?
@@ -969,7 +951,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     public void truncate() {
         elastic.getLowLevelClient()
                .deleteByQuery(elastic.determineAlias(descriptor),
-                              elastic.determineTypeName(descriptor),
                               routing,
                               buildSimplePayload());
     }

--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -226,7 +226,7 @@ public class IndexMappings implements Startable {
                          mappingName,
                          ed.getType().getSimpleName(),
                          indexName);
-        elastic.getLowLevelClient().putMapping(indexName, mappingName, mapping);
+        elastic.getLowLevelClient().putMapping(indexName, mapping);
     }
 
     private boolean isExcludeFromSource(Property p) {

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -106,20 +106,27 @@ public class LowLevelClient {
     /**
      * Tells Elasticsearch to create or update the given document with the given data.
      *
-     * @param index   the target index
-     * @param id      the ID to use
-     * @param routing the routing to use
-     * @param version the version to use for optimistic locking during the update
-     * @param data    the actual payload to store
+     * @param index       the target index
+     * @param id          the ID to use
+     * @param routing     the routing to use
+     * @param primaryTerm the primaryTerm to use for optimistic locking during the update
+     * @param seqNo       the seqNo to use for optimistic locking during the update
+     * @param data        the actual payload to store
      * @return the response of the call
      * @throws OptimisticLockException in case of an optimistic locking error (wrong version provided)
      */
     public JSONObject index(String index,
                             String id,
                             @Nullable String routing,
-                            @Nullable Integer version,
+                            @Nullable Long primaryTerm,
+                            @Nullable Long seqNo,
                             JSONObject data) throws OptimisticLockException {
-        return performPut().routing(routing).version(version).data(data).tryExecute(index + "/_doc/" + id).response();
+        return performPut().routing(routing)
+                           .primaryTerm(primaryTerm)
+                           .seqNo(seqNo)
+                           .data(data)
+                           .tryExecute(index + "/_doc/" + id)
+                           .response();
     }
 
     /**
@@ -142,15 +149,21 @@ public class LowLevelClient {
     /**
      * Deletes the given document.
      *
-     * @param index   the target index
-     * @param id      the ID to use
-     * @param routing the routing to use
-     * @param version the version to use for optimistic locking during the update
+     * @param index       the target index
+     * @param id          the ID to use
+     * @param routing     the routing to use
+     * @param primaryTerm the primaryTerm to use for optimistic locking during the delete
+     * @param seqNo       the seqNo to use for optimistic locking during the delete
      * @return the response of the call
      * @throws OptimisticLockException in case of an optimistic locking error (wrong version provided)
      */
-    public JSONObject delete(String index, String id, String routing, Integer version) throws OptimisticLockException {
-        return performDelete().routing(routing).version(version).tryExecute(index + "/_doc/" + id).response();
+    public JSONObject delete(String index, String id, String routing, Long primaryTerm, Long seqNo)
+            throws OptimisticLockException {
+        return performDelete().routing(routing)
+                              .primaryTerm(primaryTerm)
+                              .seqNo(seqNo)
+                              .tryExecute(index + "/_doc/" + id)
+                              .response();
     }
 
     protected HttpEntity handleNotFoundAsResponse(ResponseException e) {

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -47,7 +47,8 @@ class RequestBuilder {
     private static final String PARAM_REASON = "reason";
     private static final String PARAM_TYPE = "type";
     private static final String PARAM_ROUTING = "routing";
-    private static final String PARAM_VERSION = "version";
+    private static final String PARAM_IF_PRIMARY_TERM = "if_primary_term";
+    private static final String PARAM_IF_SEQ_NO = "if_seq_no";
     private static final String PARAM_ERROR = "error";
     private static final int MAX_CONTENT_LONG_LENGTH = 256;
 
@@ -99,8 +100,12 @@ class RequestBuilder {
         return withParam(PARAM_ROUTING, routing);
     }
 
-    protected RequestBuilder version(Object version) {
-        return withParam(PARAM_VERSION, version);
+    protected RequestBuilder primaryTerm(Object primaryTerm) {
+        return withParam(PARAM_IF_PRIMARY_TERM, primaryTerm);
+    }
+
+    protected RequestBuilder seqNo(Object seqNo) {
+        return withParam(PARAM_IF_SEQ_NO, seqNo);
     }
 
     protected RequestBuilder tryExecute(String uri) throws OptimisticLockException {

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -45,6 +45,9 @@ public abstract class SQLEntity extends BaseEntity<Long> {
     protected long id = NON_PERSISTENT_ENTITY_ID;
 
     @Transient
+    protected int version = 0;
+
+    @Transient
     protected Row fetchRow;
 
     @Override
@@ -78,6 +81,24 @@ public abstract class SQLEntity extends BaseEntity<Long> {
      */
     public void setId(long id) {
         this.id = id;
+    }
+
+    /**
+     * Returns the version of the entity.
+     *
+     * @return the version of the entity
+     */
+    public int getVersion() {
+        return version;
+    }
+
+    /**
+     * Note that only the framework must use this to specify the version of the entity.
+     *
+     * @param version the version of this entity
+     */
+    public void setVersion(int version) {
+        this.version = version;
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -45,9 +45,6 @@ public abstract class BaseEntity<I> extends Mixable {
     protected static Mixing mixing;
 
     @Transient
-    protected int version = 0;
-
-    @Transient
     protected Map<Property, Object> persistedData = Maps.newHashMap();
 
     /**
@@ -277,24 +274,6 @@ public abstract class BaseEntity<I> extends Mixable {
      */
     public boolean isAnyMappingChanged() {
         return getDescriptor().getProperties().stream().anyMatch(property -> getDescriptor().isChanged(this, property));
-    }
-
-    /**
-     * Returns the version of the entity.
-     *
-     * @return the version of the entity
-     */
-    public int getVersion() {
-        return version;
-    }
-
-    /**
-     * Note that only the framework must use this to specify the version of the entity.
-     *
-     * @param version the version of this entity
-     */
-    public void setVersion(int version) {
-        this.version = version;
     }
 
     /**

--- a/src/main/java/sirius/db/mongo/MongoEntity.java
+++ b/src/main/java/sirius/db/mongo/MongoEntity.java
@@ -14,6 +14,7 @@ import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.NullAllowed;
+import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.kernel.di.std.Part;
@@ -32,6 +33,9 @@ public abstract class MongoEntity extends BaseEntity<String> {
     public static final Mapping ID = Mapping.named("id");
     @NullAllowed
     protected String id;
+
+    @Transient
+    protected int version = 0;
 
     @Part
     protected static Mongo mongo;
@@ -76,5 +80,23 @@ public abstract class MongoEntity extends BaseEntity<String> {
      */
     protected String generateId() {
         return keyGen.generateId();
+    }
+
+    /**
+     * Returns the version of the entity.
+     *
+     * @return the version of the entity
+     */
+    public int getVersion() {
+        return version;
+    }
+
+    /**
+     * Note that only the framework must use this to specify the version of the entity.
+     *
+     * @param version the version of this entity
+     */
+    public void setVersion(int version) {
+        this.version = version;
     }
 }

--- a/src/test/java/TestSuite.java
+++ b/src/test/java/TestSuite.java
@@ -24,6 +24,7 @@ import sirius.kernel.Scope;
         scope = Scope.SCOPE_NIGHTLY)
 @Scenario(file = "test-redis-latest.conf", includes = "sirius\\.db\\.redis.*", scope = Scope.SCOPE_NIGHTLY)
 @Scenario(file = "test-mongo-latest.conf", includes = "sirius\\.db\\.mongo.*", scope = Scope.SCOPE_NIGHTLY)
+@Scenario(file = "test-es-sellsite.conf", includes = "sirius\\.db\\.es.*", scope = Scope.SCOPE_NIGHTLY)
 public class TestSuite {
 
 }

--- a/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
@@ -47,7 +47,7 @@ class ElasticQuerySpec extends BaseSpecification {
         and:
         Strings.isFilled(entities.get(0).getId())
         and:
-        entities.get(0).getVersion() == 1
+        entities.get(0).getSeqNo() == 0
         and:
         entities.get(0).getValue() == "SELECT"
         when:

--- a/src/test/java/sirius/db/es/ElasticSpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticSpec.groovy
@@ -60,7 +60,7 @@ class ElasticSpec extends BaseSpecification {
         RoutedTestEntity notLoaded = elastic.find(
                 RoutedTestEntity.class,
                 entity.getId(),
-                Elastic.routedBy("badRouting")).orElse(null)
+                Elastic.routedBy("XX_badRouting")).orElse(null)
         then:
         loaded.getFirstname() == "Hello"
         loaded.getLastname() == "World"

--- a/src/test/java/sirius/db/es/LowLevelClientSpec.groovy
+++ b/src/test/java/sirius/db/es/LowLevelClientSpec.groovy
@@ -37,7 +37,7 @@ class LowLevelClientSpec extends BaseSpecification {
         elastic.getLowLevelClient().createIndex("test1", 1, 1)
         when:
         elastic.getLowLevelClient().
-                index("test1", "TEST", null, null, new JSONObject().fluentPut("Hello", "World"))
+                index("test1", "TEST", null, null, null, new JSONObject().fluentPut("Hello", "World"))
         then:
         def data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
         and:
@@ -45,7 +45,7 @@ class LowLevelClientSpec extends BaseSpecification {
         data._source.Hello == 'World'
 
         when:
-        elastic.getLowLevelClient().delete("test1", "TEST", null, null)
+        elastic.getLowLevelClient().delete("test1", "TEST", null, null, null)
         and:
         data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
         then:

--- a/src/test/java/sirius/db/es/LowLevelClientSpec.groovy
+++ b/src/test/java/sirius/db/es/LowLevelClientSpec.groovy
@@ -37,17 +37,17 @@ class LowLevelClientSpec extends BaseSpecification {
         elastic.getLowLevelClient().createIndex("test1", 1, 1)
         when:
         elastic.getLowLevelClient().
-                index("test1", "lltest", "TEST", null, null, new JSONObject().fluentPut("Hello", "World"))
+                index("test1", "TEST", null, null, new JSONObject().fluentPut("Hello", "World"))
         then:
-        def data = elastic.getLowLevelClient().get("test1", "lltest", "TEST", null, true)
+        def data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
         and:
         data.found
         data._source.Hello == 'World'
 
         when:
-        elastic.getLowLevelClient().delete("test1", "lltest", "TEST", null, null)
+        elastic.getLowLevelClient().delete("test1", "TEST", null, null)
         and:
-        data = elastic.getLowLevelClient().get("test1", "lltest", "TEST", null, true)
+        data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
         then:
         !data.found
     }

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -27,11 +27,10 @@ services:
     - "9000"
     hostname: clickhouse
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.14
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
     ports:
     - "9200"
     environment:
-    - xpack.security.enabled=false
-    - script.inline=true
     - ES_JAVA_OPTS=-Xms128M -Xmx128M
+    - discovery.type=single-node
     hostname: es

--- a/src/test/resources/docker-es-sellsite.yml
+++ b/src/test/resources/docker-es-sellsite.yml
@@ -1,0 +1,36 @@
+version: "2"
+
+services:
+  redis:
+    image: redis:3.2
+    ports:
+    - "6379"
+    hostname: redis
+
+  mongo:
+    image: mongo:3.6.4
+    ports:
+    - "27017"
+    hostname: mongo
+
+  mysql:
+    image: mysql:5.5
+    ports:
+    - "3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    hostname: mysql
+  clickhouse:
+    image: yandex/clickhouse-server
+    ports:
+    - "8123"
+    - "9000"
+    hostname: clickhouse
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    ports:
+    - "9200"
+    environment:
+    - ES_JAVA_OPTS=-Xms128M -Xmx128M
+    - discovery.type=single-node
+    hostname: es

--- a/src/test/resources/test-es-sellsite.conf
+++ b/src/test/resources/test-es-sellsite.conf
@@ -1,0 +1,61 @@
+docker.file = "src/test/resources/docker-es-sellsite.yml"
+
+jdbc {
+
+    database {
+        test {
+            profile = "mysql"
+            user = "root"
+            password = "root"
+            database = "test"
+        }
+        clickhouse {
+            profile = "clickhouse"
+            user = ""
+            password = ""
+            database = "test"
+        }
+    }
+
+}
+
+mixing {
+    legacy {
+        LegacyEntity {
+            tableName = "banana"
+            alias {
+                firstname : name1
+                lastname : name2
+                composite_street : street
+            }
+        }
+    }
+
+    jdbc {
+        mixing {
+            dialect = "mysql"
+            database = "test"
+            secondaryDatabase = "test"
+            secondaryEnabled = true
+            initSql = "CREATE DATABASE IF NOT EXISTS test"
+        }
+        clickhouse {
+            dialect = "clickhouse"
+            database = "clickhouse"
+            initSql = "CREATE DATABASE IF NOT EXISTS test"
+        }
+    }
+}
+
+mongo {
+    databases.mixing {
+        hosts: "localhost"
+        db: "test"
+    }
+}
+
+elasticsearch {
+    hosts = "localhost"
+}
+
+redis.pools.system.host = "localhost"


### PR DESCRIPTION
For this the following changes had to be made:

- Removal of doc types for queries and mappings as ES 7 only supports a single doc type per index
- Replacing the version field with the new primary term and sequence number fields for optimistic lockings

https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html

Fixes: OX-5554

**Warning:** this means ES 6 and lower is not supported anymore