### PR TITLE
Generates long (fully qualified foreign key names again).

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
 public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity, SQLEntityRef<SQLEntity>>
         implements SQLPropertyInfo, ESPropertyInfo {
 
-    private static final int MAX_FOREIGN_KEY_NAME_LENGTH = 32;
+    private static final int MAX_FOREIGN_KEY_NAME_LENGTH = 60;
 
     @Part
     private static OMA oma;
@@ -85,7 +85,10 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
         if (SQLEntity.class.isAssignableFrom(getReferencedType()) && Strings.areEqual(getDescriptor().getRealm(),
                                                                                       getReferencedDescriptor().getRealm())) {
             ForeignKey fk = new ForeignKey();
-            fk.setName(Strings.limit("fk_" + getPropertyName(), MAX_FOREIGN_KEY_NAME_LENGTH, false));
+            fk.setName(Strings.limit("fk_"
+                                     + descriptor.getRelationName()
+                                     + "_"
+                                     + getPropertyName(), MAX_FOREIGN_KEY_NAME_LENGTH, false));
             fk.setForeignTable(getReferencedDescriptor().getRelationName());
             fk.addForeignColumn(1, SQLEntity.ID.getName());
             fk.addColumn(1, getPropertyName());


### PR DESCRIPTION
An FK has to be GLOBALLY unique - not just within the table
(when using MariaDB). Therefore we add the table name and still
apply the limit to prevent the original problem of "too long FK names".

Note that the hard limit is 64 - so we stay a bit away from that by
limiting the result to 60 characters.