### PR TITLE
Reverts the change which shortened foreign key names.

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -73,7 +73,6 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
         }
     }
 
-    @SuppressWarnings("unchecked")
     protected SQLEntityRefProperty(EntityDescriptor descriptor, AccessPath accessPath, Field field) {
         super(descriptor, accessPath, field);
     }

--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -85,15 +85,29 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
         if (SQLEntity.class.isAssignableFrom(getReferencedType()) && Strings.areEqual(getDescriptor().getRealm(),
                                                                                       getReferencedDescriptor().getRealm())) {
             ForeignKey fk = new ForeignKey();
-            fk.setName(Strings.limit("fk_"
-                                     + descriptor.getRelationName()
-                                     + "_"
-                                     + getPropertyName(), MAX_FOREIGN_KEY_NAME_LENGTH, false));
+            fk.setName(computeForeignKeyName());
             fk.setForeignTable(getReferencedDescriptor().getRelationName());
             fk.addForeignColumn(1, SQLEntity.ID.getName());
             fk.addColumn(1, getPropertyName());
             table.getForeignKeys().add(fk);
         }
+    }
+
+    private String computeForeignKeyName() {
+        String result = "fk_"
+                        + descriptor.getRelationName()
+                        + "_"
+                        + getPropertyName()
+                        + "_"
+                        + referencedDescriptor.getRelationName();
+
+        if (result.length() < MAX_FOREIGN_KEY_NAME_LENGTH) {
+            return result;
+        }
+
+        return Strings.limit("fk_" + descriptor.getRelationName() + "_" + getPropertyName(),
+                             MAX_FOREIGN_KEY_NAME_LENGTH,
+                             false);
     }
 
     @Override


### PR DESCRIPTION
We now generate the "classic" FKS names as long as these are
less than 60 chars long (64 is the hard limit). If a key name is too
long, we generate a shorter name and also limit this to 60 chars.

The prevents us from re-generating lots of FKs which is quite an
intense task.