### PR TITLE
Fixes exception handling.

### DIFF
--- a/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
@@ -144,6 +144,8 @@ public class InsertQuery<E extends SQLEntity> extends BatchQuery<E> {
             if (!addBatch) {
                 avarage.addValue(w.elapsedMillis());
             }
+        } catch (SQLIntegrityConstraintViolationException e) {
+            throw e;
         } catch (SQLException e) {
             context.safeClose();
             throw Exceptions.handle()


### PR DESCRIPTION
Re-throws the SQLIntegrityConstraintViolationException so that it
isn't caught by the SQLException catch block. That is the whole
point of the optimisticInsert method to no catch this exception at all.