### PR TITLE
Makes the schema sync more robust.

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/Schema.java
+++ b/src/main/java/sirius/db/jdbc/schema/Schema.java
@@ -195,7 +195,7 @@ public class Schema implements Startable, Initializable {
                                                                       new ArrayList<>(target.getValue()),
                                                                       true));
                 }
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 Exceptions.handle(OMA.LOG, e);
             }
         }


### PR DESCRIPTION
Clickhouse loves to throw non SQLExceptions which screws up the whole
Schema-Sync at startup as well as the whole initialization of OMA. Therefore
we catch all kinds of exceptions here and try to recover when trying to sync
the next database.

The schema synchronization can still be invoked manually in the administration
UI.