### PR TITLE
Builds the routing table independent of the mapping generation.

### DIFF
--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -92,8 +92,13 @@ public class IndexMappings implements Startable {
             return;
         }
 
+        computeRoutingTable();
         checkAndUpdateIndices();
         elastic.readyFuture.success();
+    }
+
+    private void computeRoutingTable() {
+        mixing.getDesciptors().forEach(this::determineRouting);
     }
 
     protected void checkAndUpdateIndices() {
@@ -122,7 +127,6 @@ public class IndexMappings implements Startable {
     protected boolean setupEntity(EntityDescriptor ed) {
         try {
             boolean addedAlias = setupAlias(ed);
-            determineRouting(ed);
 
             Elastic.LOG.FINE("Updating mapping %s for %s...",
                              elastic.determineTypeName(ed),

--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -98,7 +98,11 @@ public class IndexMappings implements Startable {
     }
 
     private void computeRoutingTable() {
-        mixing.getDesciptors().forEach(this::determineRouting);
+        mixing.getDesciptors().stream().filter(this::isElasticEntity).forEach(this::determineRouting);
+    }
+
+    private boolean isElasticEntity(EntityDescriptor ed) {
+        return ElasticEntity.class.isAssignableFrom(ed.getType());
     }
 
     protected void checkAndUpdateIndices() {
@@ -112,7 +116,7 @@ public class IndexMappings implements Startable {
         int numSuccess = 0;
         int numFailed = 0;
         for (EntityDescriptor ed : mixing.getDesciptors()) {
-            if (ElasticEntity.class.isAssignableFrom(ed.getType())) {
+            if (isElasticEntity(ed)) {
                 if (setupEntity(ed)) {
                     numSuccess++;
                 } else {

--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -98,7 +98,7 @@ public class IndexMappings implements Startable {
     }
 
     private void computeRoutingTable() {
-        mixing.getDesciptors().stream().filter(this::isElasticEntity).forEach(this::determineRouting);
+        mixing.getDescriptors().stream().filter(this::isElasticEntity).forEach(this::determineRouting);
     }
 
     private boolean isElasticEntity(EntityDescriptor ed) {
@@ -115,7 +115,7 @@ public class IndexMappings implements Startable {
 
         int numSuccess = 0;
         int numFailed = 0;
-        for (EntityDescriptor ed : mixing.getDesciptors()) {
+        for (EntityDescriptor ed : mixing.getDescriptors()) {
             if (isElasticEntity(ed)) {
                 if (setupEntity(ed)) {
                     numSuccess++;

--- a/src/main/java/sirius/db/jdbc/schema/Schema.java
+++ b/src/main/java/sirius/db/jdbc/schema/Schema.java
@@ -177,7 +177,7 @@ public class Schema implements Startable, Initializable {
      */
     public void computeRequiredSchemaChanges() {
         MultiMap<String, Table> targetByRealm = MultiMap.create();
-        for (EntityDescriptor ed : mixing.getDesciptors()) {
+        for (EntityDescriptor ed : mixing.getDescriptors()) {
             if (SQLEntity.class.isAssignableFrom(ed.getType()) && databases.containsKey(ed.getRealm())) {
                 targetByRealm.put(ed.getRealm(), createTable(ed));
             }
@@ -339,7 +339,7 @@ public class Schema implements Startable, Initializable {
         databases.clear();
         requiredSchemaChanges.clear();
 
-        Set<String> realms = mixing.getDesciptors()
+        Set<String> realms = mixing.getDescriptors()
                                    .stream()
                                    .filter(ed -> SQLEntity.class.isAssignableFrom(ed.getType()))
                                    .map(EntityDescriptor::getRealm)

--- a/src/main/java/sirius/db/mixing/Mixing.java
+++ b/src/main/java/sirius/db/mixing/Mixing.java
@@ -231,7 +231,7 @@ public class Mixing implements Initializable {
      *
      * @return an unmodifyable list of all known descriptors
      */
-    public Collection<EntityDescriptor> getDesciptors() {
+    public Collection<EntityDescriptor> getDescriptors() {
         return descriptorsByType.values();
     }
 

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -242,7 +242,7 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
             return;
         }
 
-        IntSummaryStatistics createdIndices = mixing.getDesciptors()
+        IntSummaryStatistics createdIndices = mixing.getDescriptors()
                                                     .stream()
                                                     .filter(ed -> MongoEntity.class.isAssignableFrom(ed.getType()))
                                                     .mapToInt(this::createIndices)


### PR DESCRIPTION
Otherwise, nodes which do not update the mappings, will have no
routing information and generate invalid data and queries.

Fixes: SIRI-173