### PR TITLE
Fixes to proper evaluate PrefixSearchContent in sirius-biz

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -95,4 +95,12 @@ public class MultiLanguageStringProperty extends BaseMapProperty {
         });
         return texts;
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Object getValueFromField(Object target) {
+        MultiLanguageString value = new MultiLanguageString();
+        value.setData((Map<String, String>) super.getValueFromField(target));
+        return value;
+    }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
@@ -115,4 +115,12 @@ public class StringMapProperty extends BaseMapProperty implements ESPropertyInfo
                        new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, IndexMappings.MAPPING_TYPE_KEWORD));
         description.put("properties", properties);
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Object getValueFromField(Object target) {
+        StringMap value = new StringMap();
+        value.setData((Map<String, String>) super.getValueFromField(target));
+        return value;
+    }
 }


### PR DESCRIPTION
These methods are called from sirius-biz in order process the `@PrefixSearchContent` Annotation.
For MultiLanguageStrings, we want to be able to index the text of every language.

In addition, a similar code is fixing StringMap so it's handled properly