### PR TITLE
Properly usage of searchable prefixes in StringMap and MultiLanguageString

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -449,6 +449,19 @@ public abstract class Property extends Composable {
     }
 
     /**
+     * Obtains the field value from the given entity for indexing purposes.
+     * <p>
+     * Defaults to {@link #getValue(Object)}, but can be overriden in order to deliver different
+     * contents to index (e.g. only the values of a {@link java.util.Map} without its keys.
+     *
+     * @param entity the entity to fetch the value from
+     * @return the value which is currently stored in the field
+     */
+    public Object getValueToIndex(Object entity) {
+        return getValue(entity);
+    }
+
+    /**
      * For modifyable datatypes like collections, this returns the value as copy so that further modifications
      * will not change the returned value.
      *

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -15,6 +15,7 @@ import sirius.db.mixing.Mixing;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
 import sirius.db.mixing.types.MultiLanguageString;
+import sirius.db.mixing.types.StringList;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 
@@ -94,5 +95,13 @@ public class MultiLanguageStringProperty extends BaseMapProperty {
             }
         });
         return texts;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object getValueToIndex(Object entity) {
+        StringList textsToIndex = new StringList();
+        ((Map<String, String>) getValue(entity)).forEach((language, text) -> textsToIndex.add(text));
+        return textsToIndex;
     }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
@@ -115,4 +115,12 @@ public class StringMapProperty extends BaseMapProperty implements ESPropertyInfo
                        new JSONObject().fluentPut(IndexMappings.MAPPING_TYPE, IndexMappings.MAPPING_TYPE_KEWORD));
         description.put("properties", properties);
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object getValueToIndex(Object entity) {
+        StringMap mapToIndex = new StringMap();
+        mapToIndex.setData((Map<String, String>) getValue(entity));
+        return mapToIndex;
+    }
 }


### PR DESCRIPTION
by adds a new method to return values to be indexed where a different format is needed or values are to be skipped.

Usage: see https://github.com/scireum/sirius-biz/blob/master/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java#L74
where `getValue` will be replaced by `getValueToIndex`

Fixes: SIRI-171