### PR TITLE
Improves the performance of "SmartQuery.exists"

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -177,7 +177,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
 
     @Override
     public boolean exists() {
-        return count() > 0;
+        return fields(SQLEntity.ID).first().isPresent();
     }
 
     @Override


### PR DESCRIPTION
Instead of letting the DB count all matching rows,
we simply request the ID of the first match. This
should be handled with a single index lookup instead
of a full index scan and therefore quite a bit cheaper.