### PR TITLE
Makes forceEmpty in MongoOneInField work with list fields

### DIFF
--- a/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
@@ -29,13 +29,10 @@ class MongoOneInField extends OneInField<MongoConstraint> {
     public MongoConstraint build() {
         if (values.isEmpty()) {
             if (forceEmpty) {
-                List<MongoConstraint> clauses = new ArrayList<>();
-                clauses.add(factory.notFilled(field));
-                clauses.add(factory.isEmptyArray(field));
 
-                return factory.or(clauses);
+                return factory.or(factory.notFilled(field), factory.isEmptyArray(field));
             }
-
+            
             return null;
         }
 

--- a/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
@@ -14,7 +14,6 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.query.constraints.OneInField;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,7 +29,11 @@ class MongoOneInField extends OneInField<MongoConstraint> {
     public MongoConstraint build() {
         if (values.isEmpty()) {
             if (forceEmpty) {
-                return factory.notFilled(field);
+                List<MongoConstraint> clauses = new ArrayList<>();
+                clauses.add(factory.notFilled(field));
+                clauses.add(factory.isEmptyArray(field));
+
+                return factory.or(clauses);
             }
 
             return null;
@@ -50,7 +53,7 @@ class MongoOneInField extends OneInField<MongoConstraint> {
         }
 
         clauses.add(factory.notFilled(field));
-        clauses.add(factory.eq(field, Collections.emptyList()));
+        clauses.add(factory.isEmptyArray(field));
 
         return factory.or(clauses);
     }

--- a/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
@@ -29,10 +29,8 @@ class MongoOneInField extends OneInField<MongoConstraint> {
     public MongoConstraint build() {
         if (values.isEmpty()) {
             if (forceEmpty) {
-
                 return factory.or(factory.notFilled(field), factory.isEmptyArray(field));
             }
-            
             return null;
         }
 

--- a/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
+++ b/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
@@ -186,6 +186,8 @@ class MongoFilterFactorySpec extends BaseSpecification {
     }
 
     def "automatic 'and' works for fields"() {
+        setup:
+        mango.select(MangoTestEntity.class).delete()
         when:
         MangoTestEntity e1 = new MangoTestEntity()
         e1.setFirstname("AND")
@@ -242,5 +244,41 @@ class MongoFilterFactorySpec extends BaseSpecification {
              .where(QueryBuilder.FILTERS.and(QueryBuilder.FILTERS.eq(MangoTestEntity.LASTNAME, "WORKS1"),
                                              QueryBuilder.FILTERS.eq(MangoTestEntity.FIRSTNAME, "AND1")))
              .countIn(MangoTestEntity.class) == 1
+    }
+
+    def "isEmptyArray works on List fields"() {
+        setup:
+        mango.select(MangoTestEntity.class).delete()
+        when:
+        MangoTestEntity e1 = new MangoTestEntity()
+        e1.setFirstname("Peter")
+        e1.setLastname("Parker")
+        mango.update(e1)
+        MangoTestEntity e2 = new MangoTestEntity()
+        e2.setFirstname("Spider")
+        e2.setLastname("Man")
+        e2.getSuperPowers().add("Wallcrawling")
+        mango.update(e2)
+        then:
+        mango.select(MangoTestEntity.class)
+             .where(QueryBuilder.FILTERS.isEmptyArray(MangoTestEntity.SUPER_POWERS)).count() == 1
+    }
+
+    def "forceEmpty works on List fields"() {
+        setup:
+        mango.select(MangoTestEntity.class).delete()
+        when:
+        MangoTestEntity e1 = new MangoTestEntity()
+        e1.setFirstname("Peter")
+        e1.setLastname("Parker")
+        mango.update(e1)
+        MangoTestEntity e2 = new MangoTestEntity()
+        e2.setFirstname("Spider")
+        e2.setLastname("Man")
+        e2.getSuperPowers().add("Wallcrawling")
+        mango.update(e2)
+        then:
+        mango.select(MangoTestEntity.class)
+             .where(QueryBuilder.FILTERS.oneInField(MangoTestEntity.SUPER_POWERS, Collections.emptyList()).forceEmpty().build()).count() == 1
     }
 }


### PR DESCRIPTION
As the field is not null, but an empty Array we need to check for either of one,
just as it already the case in orEmpty

This only changes this:
```
oneInField(field, emptyList).forceEmpty().build()  -> $eq: null
```
to
```
oneInField(field, emptyList).forceEmpty().build()  -> $or: $eq null, $eq []
```

oneInFields with filled lists or without forceEmpty are unchanged