### PR TITLE
Adds 'wasCreated' method into BaseEntity to be called after save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-15.1</sirius.kernel>
+        <sirius.kernel>dev-15.2</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -33,11 +33,10 @@ public abstract class ElasticEntity extends BaseEntity<String> {
     protected static Elastic elastic;
 
     /**
-     * Contains the ID which is auto-generated when inserting a new entity into Elasticsearch.
+     * Contains the {@link #ID} which is auto-generated when inserting a new entity into Elasticsearch.
      * <p>
      * It is {@link NullAllowed} as it is filled during the update but after the save checkes have completed.
      */
-    public static final Mapping ID = Mapping.named("id");
     @NullAllowed
     private String id;
 

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -33,13 +33,13 @@ public abstract class SQLEntity extends BaseEntity<Long> {
     protected static OMA oma;
 
     /**
-     * Contains the unique ID of the entity.
+     * Contains the unique {@link #ID} of the entity.
      * <p>
      * This is automatically assigned by the database. Never assign manually a value unless you are totally aware
      * of what you're doing. Also you should not use this ID for external purposes (e.g. as customer number or
      * invoice number) as it cannot be changed.
+     * <p>
      */
-    public static final Mapping ID = Mapping.named("id");
     protected long id = NON_PERSISTENT_ENTITY_ID;
 
     @Transient

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -38,7 +38,6 @@ public abstract class SQLEntity extends BaseEntity<Long> {
      * This is automatically assigned by the database. Never assign manually a value unless you are totally aware
      * of what you're doing. Also you should not use this ID for external purposes (e.g. as customer number or
      * invoice number) as it cannot be changed.
-     * <p>
      */
     protected long id = NON_PERSISTENT_ENTITY_ID;
 

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -38,8 +38,6 @@ public abstract class SQLEntity extends BaseEntity<Long> {
      * This is automatically assigned by the database. Never assign manually a value unless you are totally aware
      * of what you're doing. Also you should not use this ID for external purposes (e.g. as customer number or
      * invoice number) as it cannot be changed.
-     * <p>
-     * This field is marked as transient as this column is automatically managed by the framework.
      */
     public static final Mapping ID = Mapping.named("id");
     protected long id = NON_PERSISTENT_ENTITY_ID;

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -269,6 +269,18 @@ public abstract class BaseEntity<I> extends Mixable {
     }
 
     /**
+     * Determines if the entity has just been created.
+     * <p>
+     * This only works if called from a {@link sirius.db.mixing.annotations.AfterSave} handler, as moments later the persisted
+     * data gets updated.
+     *
+     * @return <tt>true</tt> if the entity has just been written to the database, <tt>false</tt> otherwise
+     */
+    public boolean wasCreated() {
+        return isChanged(ID);
+    }
+
+    /**
      * Provides a boilerplate way of only executing a lambda if the referenced mapping has changed.
      * <p>
      * This is most probably useful for deciding if a check in a {@link sirius.db.mixing.annotations.BeforeSave}

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -52,7 +52,7 @@ public abstract class BaseEntity<I> extends Mixable {
     /**
      * Contains the unique id of the entity.
      * <p>
-     * Subclasses need to create a field with the name {@code id} and the type {@code <I>}.
+     * The actual {@code id} field with corresponding {@code <I>} type is defined by the underlying implementations.
      */
     public static final Mapping ID = Mapping.named("id");
 

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -82,6 +82,8 @@ public abstract class BaseEntity<I> extends Mixable {
 
     /**
      * Determines if the entity is new (not yet written to the database).
+     * <p>
+     * This wont work in {@link sirius.db.mixing.annotations.AfterSave} handlers - use {@link #wasCreated()} instead.
      *
      * @return <tt>true</tt> if the entity has not been written to the database yes, <tt>false</tt> otherwise
      */

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -50,6 +50,13 @@ public abstract class BaseEntity<I> extends Mixable {
     protected Map<Property, Object> persistedData = Maps.newHashMap();
 
     /**
+     * Contains the unique id of the entity.
+     * <p>
+     * Subclasses need to create a field with the name {@code id} and the type {@code <I>}.
+     */
+    public static final Mapping ID = Mapping.named("id");
+
+    /**
      * Contains the constant used to mark a new (unsaved) entity.
      */
     public static final String NEW = "new";

--- a/src/main/java/sirius/db/mixing/annotations/AfterSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterSave.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mixing.annotations;
 
+import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Mixable;
 
 import java.lang.annotation.ElementType;
@@ -17,6 +18,8 @@ import java.lang.annotation.Target;
 
 /**
  * Used to mark methods in {@link Mixable}s which will be called once an entity was saved.
+ * <p>
+ * If you need different logic for updated and newly created entities, use {@link BaseEntity#wasCreated()} in your method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/src/main/java/sirius/db/mixing/annotations/AfterSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterSave.java
@@ -17,7 +17,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to mark methods in {@link Mixable}s which will be called once an entity was saved.
+ * Used to mark methods in {@link Mixable mixables} which will be called once an entity was saved.
  * <p>
  * If you need different logic for updated and newly created entities, use {@link BaseEntity#wasCreated()} in your method.
  */

--- a/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mixing.annotations;
 
+import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Mixable;
 import sirius.kernel.di.std.Priorized;
 
@@ -18,6 +19,8 @@ import java.lang.annotation.Target;
 
 /**
  * Used to mark methods in {@link Mixable}s which will be called before an entity is saved.
+ * <p>
+ * If you need different logic for updated and newly created entities, use {@link BaseEntity#isNew()} in your method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/src/main/java/sirius/db/mongo/MongoEntity.java
+++ b/src/main/java/sirius/db/mongo/MongoEntity.java
@@ -26,11 +26,10 @@ import sirius.kernel.di.std.Part;
 public abstract class MongoEntity extends BaseEntity<String> {
 
     /**
-     * Contains the id of the entity.
+     * Contains the {@link #ID} of the entity.
      * <p>
      * This is declared as null allowed, as the id is generated after the before save checks have been executed.
      */
-    public static final Mapping ID = Mapping.named("id");
     @NullAllowed
     protected String id;
 

--- a/src/test/java/sirius/db/es/ElasticSpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticSpec.groovy
@@ -9,6 +9,7 @@
 package sirius.db.es
 
 import sirius.db.mixing.OptimisticLockException
+import sirius.db.mongo.MangoWasCreatedTestEntity
 import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Wait
 import sirius.kernel.di.std.Part
@@ -116,4 +117,17 @@ class ElasticSpec extends BaseSpecification {
         notFound == null
     }
 
+    def "wasCreated() works in elastic"() {
+        given:
+        ElasticWasCreatedTestEntity e = new ElasticWasCreatedTestEntity()
+        e.setValue("test123")
+        when:
+        elastic.update(e)
+        then:
+        e.hasJustBeenCreated()
+        and:
+        elastic.update(e)
+        then:
+        !e.hasJustBeenCreated()
+    }
 }

--- a/src/test/java/sirius/db/es/ElasticWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/es/ElasticWasCreatedTestEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es;
+
+import sirius.db.es.ElasticEntity;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.AfterSave;
+import sirius.db.mixing.annotations.Transient;
+
+public class ElasticWasCreatedTestEntity extends ElasticEntity {
+
+    public static final Mapping VALUE = Mapping.named("value");
+    private String value;
+
+    @Transient
+    private boolean wasCreatedIndicator;
+
+    @AfterSave
+    protected void checkIfCreated() {
+        wasCreatedIndicator = wasCreated();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean hasJustBeenCreated() {
+        return wasCreatedIndicator;
+    }
+}

--- a/src/test/java/sirius/db/jdbc/OMASpec.groovy
+++ b/src/test/java/sirius/db/jdbc/OMASpec.groovy
@@ -12,7 +12,6 @@ import sirius.db.mixing.IntegrityConstraintFailedException
 import sirius.db.mixing.OptimisticLockException
 import sirius.kernel.BaseSpecification
 import sirius.kernel.di.std.Part
-import spock.lang.Stepwise
 
 import java.time.Duration
 
@@ -221,6 +220,20 @@ class OMASpec extends BaseSpecification {
         oma.tryUpdate(conflictingEntity)
         then:
         thrown(IntegrityConstraintFailedException)
+    }
+
+    def "wasCreated() works in OMA"() {
+        given:
+        SQLWasCreatedTestEntity e = new SQLWasCreatedTestEntity()
+        e.setValue("test123")
+        when:
+        oma.update(e)
+        then:
+        e.hasJustBeenCreated()
+        and:
+        oma.update(e)
+        then:
+        !e.hasJustBeenCreated()
     }
 
 }

--- a/src/test/java/sirius/db/jdbc/SQLWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLWasCreatedTestEntity.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.AfterSave;
+import sirius.db.mixing.annotations.Transient;
+
+public class SQLWasCreatedTestEntity extends SQLEntity {
+    public static final Mapping VALUE = Mapping.named("value");
+    private String value;
+
+    @Transient
+    private boolean wasCreatedIndicator;
+
+    @AfterSave
+    protected void checkIfCreated() {
+        wasCreatedIndicator = wasCreated();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean hasJustBeenCreated() {
+        return wasCreatedIndicator;
+    }
+}

--- a/src/test/java/sirius/db/mongo/MangoSpec.groovy
+++ b/src/test/java/sirius/db/mongo/MangoSpec.groovy
@@ -152,4 +152,17 @@ class MangoSpec extends BaseSpecification {
         thrown(HandledException)
     }
 
+    def "wasCreated() works in mango"() {
+        given:
+        MangoWasCreatedTestEntity e = new MangoWasCreatedTestEntity()
+        e.setValue("test123")
+        when:
+        mango.update(e)
+        then:
+        e.hasJustBeenCreated()
+        and:
+        mango.update(e)
+        then:
+        !e.hasJustBeenCreated()
+    }
 }

--- a/src/test/java/sirius/db/mongo/MangoWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoWasCreatedTestEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.AfterSave;
+import sirius.db.mixing.annotations.Transient;
+
+public class MangoWasCreatedTestEntity extends MongoEntity {
+
+    public static final Mapping VALUE = Mapping.named("value");
+    private String value;
+
+    @Transient
+    private boolean wasCreatedIndicator;
+
+    @AfterSave
+    protected void checkIfCreated() {
+        wasCreatedIndicator = wasCreated();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean hasJustBeenCreated() {
+        return wasCreatedIndicator;
+    }
+}


### PR DESCRIPTION
As the correct way to check this at this point is not obvious.
Without this the most obvious but faulty way was to use 'isNew()' here - but this would always return false as the id is already set at this point. The persistedData of the entity is not yet updated so we can check if the ID has been changed.
All provided tests would fail with 'isNew()' in the after save handler.