### PR TITLE
Permits to distinguish the routing suppressions for the read and the …

### DIFF
--- a/src/main/java/sirius/db/es/BulkContext.java
+++ b/src/main/java/sirius/db/es/BulkContext.java
@@ -150,7 +150,7 @@ public class BulkContext implements Closeable {
         meta.put(KEY_INDEX, elastic.determineWriteAlias(ed));
         meta.put(KEY_ID, entity.getId());
 
-        String routing = elastic.determineRouting(ed, entity);
+        String routing = elastic.determineRouting(ed, entity, Elastic.RoutingAccessMode.WRITE);
         if (routing != null) {
             meta.put(KEY_ROUTING, routing);
         }

--- a/src/main/java/sirius/db/es/ESIndexCommand.java
+++ b/src/main/java/sirius/db/es/ESIndexCommand.java
@@ -124,7 +124,7 @@ public class ESIndexCommand implements Command {
             output.blankLine();
         } else if (args.length() == 4) {
             EnumSet<Elastic.RoutingAccessMode> modes = EnumSet.noneOf(Elastic.RoutingAccessMode.class);
-            if ("Y".equals(args.at(3).asString())) {
+            if ("Y".equals(args.at(2).asString())) {
                 modes.add(Elastic.RoutingAccessMode.READ);
             }
             if ("Y".equals(args.at(4).asString())) {

--- a/src/main/java/sirius/db/es/ESIndexCommand.java
+++ b/src/main/java/sirius/db/es/ESIndexCommand.java
@@ -127,7 +127,7 @@ public class ESIndexCommand implements Command {
             if ("Y".equals(args.at(2).asString())) {
                 modes.add(Elastic.RoutingAccessMode.READ);
             }
-            if ("Y".equals(args.at(4).asString())) {
+            if ("Y".equals(args.at(3).asString())) {
                 modes.add(Elastic.RoutingAccessMode.WRITE);
             }
             elastic.updateRoutingSuppression(descriptor, modes);

--- a/src/main/java/sirius/db/es/ESIndexCommand.java
+++ b/src/main/java/sirius/db/es/ESIndexCommand.java
@@ -18,6 +18,7 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.console.Command;
 
 import javax.annotation.Nonnull;
+import java.util.EnumSet;
 
 /**
  * Provides a tool which helps with managing Elasticsearch indices and our mapping of {@link ElasticEntity entities}.
@@ -94,8 +95,50 @@ public class ESIndexCommand implements Command {
             return true;
         }
 
+        if ("suppress-routing".equals(subCommand)) {
+            handleRoutingSuppression(output, args);
+            return true;
+        }
+
         output.apply("Unknown sub-command: %s", subCommand);
         return false;
+    }
+
+    private void handleRoutingSuppression(Output output, Values args) {
+        EntityDescriptor descriptor = mixing.getDescriptor(args.at(1).asString());
+
+        if (args.length() == 2) {
+            output.line("Usage:");
+            output.line("Output suppressions:");
+            output.line("es-index suppress-routing <Entity>");
+            output.blankLine();
+            output.line("Update suppressions (read and write):");
+            output.line("es-index suppress-routing <Entity> <Y/N> <Y/N>");
+            output.blankLine();
+            output.line("Reset suppressions to default:");
+            output.line("es-index suppress-routing <Entity> \"-\"");
+            output.blankLine();
+        } else if ("-".equals(args.at(2).asString())) {
+            elastic.updateRoutingSuppression(descriptor, null);
+            output.apply("Default suppression of %s has been restored...", descriptor.getType());
+            output.blankLine();
+        } else if (args.length() == 4) {
+            EnumSet<Elastic.RoutingAccessMode> modes = EnumSet.noneOf(Elastic.RoutingAccessMode.class);
+            if ("Y".equals(args.at(3).asString())) {
+                modes.add(Elastic.RoutingAccessMode.READ);
+            }
+            if ("Y".equals(args.at(4).asString())) {
+                modes.add(Elastic.RoutingAccessMode.WRITE);
+            }
+            elastic.updateRoutingSuppression(descriptor, modes);
+            output.apply("Suppression of %s has been updated...", descriptor.getType());
+            output.blankLine();
+        }
+
+        output.apply("Suppression of %s: READ: %s WRITE: %s",
+                     descriptor.getType(),
+                     elastic.isRoutingSuppressed(descriptor, Elastic.RoutingAccessMode.READ),
+                     elastic.isRoutingSuppressed(descriptor, Elastic.RoutingAccessMode.WRITE));
     }
 
     private void outputIndexInfos(Output output) {


### PR DESCRIPTION
…write index.

With the previous changes we introduced the possibility to redirect all writes for
and entity into a new index. We now also support to enable and disable the
routing suppression of both indices independent of each other.

This can be achieved using the "es-index" command. Using this facility one can
migrate from an unrouted index to a routed one an vice versa.