### PR TITLE
Permits to resolve enum constants by their toString representation in…

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -75,6 +75,28 @@ public class EnumProperty extends Property implements SQLPropertyInfo, ESPropert
         return Value.of(defaultValue).asEnum((Class<Enum>) field.getType());
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    protected Object transformValueFromImport(Value value) {
+        if (value.isFilled()) {
+            // If a value is present, we check if any constant name or its translation matches...
+            String stringValue = value.asString().trim();
+            for (Enum enumValue : ((Class<Enum>) field.getType()).getEnumConstants()) {
+                // Check for a match of the constant...
+                if (Strings.equalIgnoreCase(enumValue.name(), stringValue)) {
+                    return enumValue;
+                }
+
+                // Check of a match of the translation...
+                if (Strings.equalIgnoreCase(enumValue.toString(), stringValue)) {
+                    return enumValue;
+                }
+            }
+        }
+
+        return super.transformValueFromImport(value);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     protected void determineLengths() {

--- a/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
@@ -21,7 +21,12 @@ import java.time.LocalDateTime;
 public class ESDataTypesEntity extends ElasticEntity {
 
     public enum TestEnum {
-        Test1, Test2
+        Test1, Test2;
+
+        @Override
+        public String toString() {
+            return name() + name().length();
+        }
     }
 
     private static final Mapping LONG_VALUE = Mapping.named("longValue");

--- a/src/test/java/sirius/db/mixing/properties/EnumPropertySpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/EnumPropertySpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing.properties
+
+import sirius.db.es.properties.ESDataTypesEntity
+import sirius.db.mixing.Mixing
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Value
+import sirius.kernel.di.std.Part
+
+class EnumPropertySpec extends BaseSpecification {
+
+    @Part
+    private static Mixing mixing
+
+    def "resolving via enum constants and translations works"() {
+        given:
+        def property = mixing.getDescriptor(ESDataTypesEntity.class).findProperty("enumValue")
+        and:
+        ESDataTypesEntity entity = new ESDataTypesEntity();
+        when: // An enum constant can be resolved by its name...
+        property.parseValueFromImport(entity, Value.of("Test1"))
+        then:
+        entity.getTestEnum() == ESDataTypesEntity.TestEnum.Test1
+
+        when: // An enum constant can be resolved by its name in lowercase...
+        property.parseValueFromImport(entity, Value.of("test1"))
+        then:
+        entity.getTestEnum() == ESDataTypesEntity.TestEnum.Test1
+
+        when: // Invalid values become nulll
+        property.parseValueFromImport(entity, Value.of("test0"))
+        then:
+        entity.getTestEnum() == null
+        when: // Enum constants can be resolved by their "toString" representation...
+        property.parseValueFromImport(entity, Value.of("test25"))
+        then:
+        entity.getTestEnum() == ESDataTypesEntity.TestEnum.Test2
+
+    }
+
+}


### PR DESCRIPTION
… imports.

When importing data, we're now a bit more generous and permit to import
case insensitively using the enum constant name or also via the toString
representation (which is most probably the translated name).