### PR TITLE
Adds support for transferring after keys as compound strings.

### DIFF
--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -8,6 +8,7 @@
 
 package sirius.db.es;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import sirius.db.es.constraints.ElasticConstraint;
@@ -15,7 +16,10 @@ import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -114,6 +118,7 @@ public class AggregationBuilder {
     private static final String OFFSET = "offset";
     private static final String INTERVAL = "interval";
     private static final String MIN_DOC_COUNT = "min_doc_count";
+    private static final String AFTER = "after";
 
     private String name;
     private String type;
@@ -261,6 +266,25 @@ public class AggregationBuilder {
      */
     public AggregationBuilder addTermSourceAggregation(Mapping field) {
         return addSourceAggregation(AggregationBuilder.createTerms(field).size(-1));
+    }
+
+    /**
+     * Installs an "after key" which is used to perform pagination.
+     * <p>
+     * The key is produced by {@link AggregationResult#getCompoundAfterKey()} and can be passed into this method
+     * to access the "next page".
+     *
+     * @param afterKey the compond after key to parse and install
+     * @return the aggregation builder itself for fluent methdo calls
+     */
+    public AggregationBuilder withCompoundAfterKey(@Nullable String afterKey) {
+        if (Strings.isFilled(afterKey)) {
+            JSONObject afterKeyObject =
+                    JSON.parseObject(new String(Base64.getDecoder().decode(afterKey), StandardCharsets.UTF_8));
+            addBodyParameter(AFTER, afterKeyObject);
+        }
+
+        return this;
     }
 
     /**

--- a/src/main/java/sirius/db/es/AggregationResult.java
+++ b/src/main/java/sirius/db/es/AggregationResult.java
@@ -16,7 +16,9 @@ import sirius.kernel.commons.Value;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -122,6 +124,34 @@ public class AggregationResult {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Obtains the after key which is created by a {@link AggregationBuilder#COMPOSITE} aggregation to support
+     * pagination.
+     *
+     * @return the after key object or an empty optional if the end of the aggregation has been reached
+     */
+    public Optional<JSONObject> getAfterKey() {
+        return Optional.ofNullable(data.getJSONObject("after_key"));
+    }
+
+    /**
+     * Returns the after key in a single string.
+     * <p>
+     * This can later be put into {@link AggregationBuilder#withCompoundAfterKey(String)} to fetch the next
+     * page.
+     *
+     * @return the after key as compound / single string.
+     */
+    @Nullable
+    public String getCompoundAfterKey() {
+        JSONObject afterKey = getAfterKey().orElse(null);
+        if (afterKey == null) {
+            return null;
+        }
+
+        return Base64.getEncoder().encodeToString(afterKey.toJSONString().getBytes(StandardCharsets.UTF_8));
     }
 
     /**


### PR DESCRIPTION
Using a single string which can be sent to the frontend and
received back to the server simplifies handling these inner
objects.