### PR TITLE
Makes two constructors accept a Stream instead of an array or list.

### DIFF
--- a/src/main/java/sirius/db/text/PatternExtractProcessor.java
+++ b/src/main/java/sirius/db/text/PatternExtractProcessor.java
@@ -9,11 +9,11 @@
 package sirius.db.text;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Extracts sub-tokens based on regular expressions.
@@ -54,9 +54,19 @@ public class PatternExtractProcessor extends ChainableTokenProcessor {
      *                     captured groups where 0 is the token itself.
      */
     public PatternExtractProcessor(Pattern pattern, String... replacements) {
+        this(pattern, Stream.of(replacements));
+    }
+
+    /**
+     * Creates a new processor.
+     *
+     * @param pattern      the pattern to match
+     * @param replacements the tokens to emit if the given pattern matches. Using {0}...{N} one can reference to the
+     *                     captured groups where 0 is the token itself.
+     */
+    public PatternExtractProcessor(Pattern pattern, Stream<String> replacements) {
         this.pattern = pattern;
-        this.replacements =
-                Arrays.stream(replacements).map(this::compileReplacementPattern).collect(Collectors.toList());
+        this.replacements = replacements.map(this::compileReplacementPattern).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/sirius/db/text/PipelineProcessor.java
+++ b/src/main/java/sirius/db/text/PipelineProcessor.java
@@ -8,10 +8,11 @@
 
 package sirius.db.text;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Permits to combine several chainable token processors into a single one.
@@ -23,10 +24,19 @@ public class PipelineProcessor extends ChainableTokenProcessor {
     /**
      * Creates a new processor.
      *
-     * @param processors the internal processors that chain together to form the desired pipeline
+     * @param processors the internal processors to chain together to form the desired pipeline
      */
     public PipelineProcessor(List<ChainableTokenProcessor> processors) {
-        this.processors = Collections.synchronizedList(processors);
+        this(processors.stream());
+    }
+
+    /**
+     * Creates a new processor.
+     *
+     * @param processorsStream the internal processors to chain together to form the desired pipeline
+     */
+    public PipelineProcessor(Stream<ChainableTokenProcessor> processorsStream) {
+        this.processors = processorsStream.filter(Objects::nonNull).collect(Collectors.toList());
         for (int i = 0; i < processors.size() - 1; i++) {
             processors.get(i).chain(processors.get(i + 1));
         }
@@ -35,10 +45,10 @@ public class PipelineProcessor extends ChainableTokenProcessor {
     /**
      * Creates a new processor.
      *
-     * @param processors the internal processors the chain together to form the desired pipeline
+     * @param processors the internal processors to chain together to form the desired pipeline
      */
     public PipelineProcessor(ChainableTokenProcessor... processors) {
-        this(Arrays.asList(processors));
+        this(Stream.of(processors));
     }
 
     @Override


### PR DESCRIPTION
This prevents us from generating unused intermediate data structures.