### PR TITLE
Logs more than 256 characters of the ES request content

### DIFF
--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -52,7 +52,7 @@ class RequestBuilder {
     private static final String PARAM_IF_PRIMARY_TERM = "if_primary_term";
     private static final String PARAM_IF_SEQ_NO = "if_seq_no";
     private static final String PARAM_ERROR = "error";
-    private static final int MAX_CONTENT_LONG_LENGTH = 256;
+    private static final int MAX_CONTENT_LONG_LENGTH = 1024;
 
     private String method;
     private RestClient restClient;


### PR DESCRIPTION
This is the query sent to ES either when logging slow queries or all queries if the logger is set to FINE.
The previous length restriction often did cut slow queries way too soon.

Fixes: OX-6086