### PR TITLE
Rejects illegal (unknown) ID types.

### DIFF
--- a/src/test/java/sirius/db/mixing/fieldlookup/NameFieldsTestComposite.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/NameFieldsTestComposite.java
@@ -10,13 +10,16 @@ package sirius.db.mixing.fieldlookup;
 
 import sirius.db.mixing.Composite;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.Length;
 
 public class NameFieldsTestComposite extends Composite {
 
     public static final Mapping FIRSTNAME = Mapping.named("firstname");
+    @Length(100)
     private String firstname;
 
     public static final Mapping LASTNAME = Mapping.named("lastname");
+    @Length(100)
     private String lastname;
 
     public String getFirstname() {

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
@@ -10,6 +10,7 @@ package sirius.db.mixing.fieldlookup;
 
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.StringList;
 
@@ -31,6 +32,7 @@ public class SQLFieldLookUpTestEntity extends SQLEntity {
     private LocalDateTime birthday;
 
     public static final Mapping SUPER_POWERS = Mapping.named("superPowers");
+    @Length(100)
     private final StringList superPowers = new StringList();
 
     public int getAge() {

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
@@ -10,6 +10,7 @@ package sirius.db.mixing.fieldlookup;
 
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixable;
+import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.Mixin;
 import sirius.db.mixing.types.StringList;
 
@@ -20,6 +21,7 @@ public class SQLSuperHeroTestMixin extends Mixable {
     private final NameFieldsTestComposite heroNames = new NameFieldsTestComposite();
 
     public static final Mapping SUPER_POWERS = Mapping.named("superPowers");
+    @Length(100)
     private final StringList superPowers = new StringList();
 
     public NameFieldsTestComposite getHeroNames() {


### PR DESCRIPTION
As we accept "object", it is quite easy to put a completely invalid value
in as ID (like an Optional). Therefore we thrown an explicit exception in
this case.