### PR TITLE
Moves filtering of null values in MLS from database to object 

### DIFF
--- a/src/main/java/sirius/db/mixing/OptimisticLockException.java
+++ b/src/main/java/sirius/db/mixing/OptimisticLockException.java
@@ -9,17 +9,17 @@
 package sirius.db.mixing;
 
 /**
- * Signals that a concurrent modification occured on an versioned entity which supports <tt>optimistic locking</tt>.
+ * Signals that a concurrent modification occurred on an versioned entity which supports <tt>optimistic locking</tt>.
  * <p>
  * In contrast to <tt>pessimistic locking</tt>, <tt>optimistic locking</tt> does not acquire any locks or perform
- * other measures to quarantee mutual exclusion. Rather it keepts track of the entity version it last read from
+ * other measures to guarantee mutual exclusion. Rather it keeps track of the entity version it last read from
  * the database and upon a modification, it expects the entity version in the database to remain the same.
  * <p>
  * Once a modification is performed, the version is then incremented. If the expected version does not match
  * the actual version, the operation is aborted and an {@link OptimisticLockException} is thrown.
  * <p>
- * This yields is a highly performant and highly scaleble system as long as concurrent modifications are rare. The
- * downsice of this approach is, that modification have to be retried once an error is detected. However most of the
+ * This yields is a highly performant and highly scalable system as long as concurrent modifications are rare. The
+ * downside of this approach is, that modification have to be retried once an error is detected. However most of the
  * time this overhead is quite bearable.
  */
 public class OptimisticLockException extends Exception {

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -67,8 +67,8 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
                            Consumer<Property> propertyConsumer) {
             if (!Modifier.isFinal(field.getModifiers())) {
                 Mixing.LOG.WARN("Field %s in %s is not final! This will probably result in errors.",
-                                field.getName(),
-                                field.getDeclaringClass().getName());
+                        field.getName(),
+                        field.getDeclaringClass().getName());
             }
 
             propertyConsumer.accept(new MultiLanguageStringProperty(descriptor, accessPath, field));
@@ -87,11 +87,11 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             }
             if (supportedLanguages != null && !supportedLanguages.contains(language)) {
                 throw Exceptions.createHandled()
-                                .withNLSKey("MultiLanguageString.invalidLanguage")
-                                .set("language", language)
-                                .set("text", text)
-                                .set("field", getField().getName())
-                                .handle();
+                        .withNLSKey("MultiLanguageString.invalidLanguage")
+                        .set("language", language)
+                        .set("text", text)
+                        .set("field", getField().getName())
+                        .handle();
             }
         });
 
@@ -124,12 +124,10 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
 
         List<Document> texts = new ArrayList<>();
         ((Map<String, String>) object).forEach((language, text) -> {
-            if (text != null) {
-                Document doc = new Document();
-                doc.put(LANGUAGE_PROPERTY, language);
-                doc.put(TEXT_PROPERTY, text);
-                texts.add(doc);
-            }
+            Document doc = new Document();
+            doc.put(LANGUAGE_PROPERTY, language);
+            doc.put(TEXT_PROPERTY, text);
+            texts.add(doc);
         });
         return texts;
     }
@@ -156,11 +154,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
         }
 
         JSONObject texts = new JSONObject();
-        ((Map<String, String>) object).forEach((language, text) -> {
-            if (text != null) {
-                texts.fluentPut(language, text);
-            }
-        });
+        ((Map<String, String>) object).forEach(texts::fluentPut);
         return texts;
     }
 

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -53,6 +53,8 @@ public class MultiLanguageString extends SafeMap<String, String> {
 
     /**
      * Adds a new text using the language defined by {@link NLS#getCurrentLang()}.
+     * <p>
+     * Empty texts will be ignored.
      *
      * @param text the text associated with the language
      * @return the object itself for fluent method calls
@@ -64,6 +66,8 @@ public class MultiLanguageString extends SafeMap<String, String> {
 
     /**
      * Adds a new text for the given language.
+     * <p>
+     * Empty texts will be ignored.
      *
      * @param language the language code
      * @param text     the text associated with the language
@@ -71,12 +75,16 @@ public class MultiLanguageString extends SafeMap<String, String> {
      * @throws sirius.kernel.health.HandledException if the provided language code is invalid
      */
     public MultiLanguageString addText(String language, String text) {
-        put(language, text);
+        if (text != null) {
+            put(language, text);
+        }
         return this;
     }
 
     /**
      * Adds the given text as a fallback to the map.
+     * <p>
+     * Empty texts will be ignored.
      *
      * @param text the text to be used as fallback
      * @return the object itself for fluent method calls

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -54,7 +54,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text using the language defined by {@link NLS#getCurrentLang()}.
      * <p>
-     * Empty texts will be ignored.
+     * Null texts will be ignored.
      *
      * @param text the text associated with the language
      * @return the object itself for fluent method calls
@@ -67,7 +67,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text for the given language.
      * <p>
-     * Empty texts will be ignored.
+     * Null texts will be ignored.
      *
      * @param language the language code
      * @param text     the text associated with the language
@@ -84,7 +84,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds the given text as a fallback to the map.
      * <p>
-     * Empty texts will be ignored.
+     * Null texts will be ignored.
      *
      * @param text the text to be used as fallback
      * @return the object itself for fluent method calls

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -8,6 +8,7 @@
 
 package sirius.db.mongo.properties
 
+import sirius.db.mixing.types.MultiLanguageString
 import sirius.db.mongo.Mango
 import sirius.db.mongo.Mongo
 import sirius.kernel.BaseSpecification
@@ -33,6 +34,21 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
 
         then:
         thrown(HandledException)
+    }
+
+    def "Comparing persisted data with null keys works as expected"() {
+        given:
+        def entity = new MongoMultiLanguageStringEntity()
+        entity.getMultiLangText().addText("de", null)
+        mango.update(entity)
+        when:
+        entity = mango.tryRefresh(entity)
+        entity.getMultiLangText().addText("de", null)
+        mango.update(entity)
+        then:
+        noExceptionThrown()
+        and:
+        entity.getMultiLangText() == new MultiLanguageString()
     }
 
     def "store retrieve and validate"() {


### PR DESCRIPTION
As the filtering that late could lead to inconsistent results when trying to compare data that has not been saved yet with the already persisted data, as these null values were only omitted in objects that already have been saved to the DB once.

Fixes: SIRI-271