### PR TITLE
Improved grouping in microtiming

### DIFF
--- a/src/main/java/sirius/db/jdbc/DeleteStatement.java
+++ b/src/main/java/sirius/db/jdbc/DeleteStatement.java
@@ -25,7 +25,7 @@ import java.sql.SQLException;
  */
 public class DeleteStatement extends GeneratedStatement<DeleteStatement> {
 
-    private static final String MICROTIMING_KEY = "SQL-DELETE";
+    private static final String MICROTIMING_KEY = "DELETE";
 
     protected DeleteStatement(EntityDescriptor descriptor, Database db) {
         super(descriptor, db);

--- a/src/main/java/sirius/db/jdbc/GeneratedStatement.java
+++ b/src/main/java/sirius/db/jdbc/GeneratedStatement.java
@@ -202,7 +202,7 @@ abstract class GeneratedStatement<S extends GeneratedStatement<S>> {
                 return stmt.executeUpdate();
             }
         } finally {
-            watch.submitMicroTiming("SQL", microtimingKey()+": "+ sql);
+            watch.submitMicroTiming("SQL", microtimingKey() + ": " + sql);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/GeneratedStatement.java
+++ b/src/main/java/sirius/db/jdbc/GeneratedStatement.java
@@ -202,7 +202,7 @@ abstract class GeneratedStatement<S extends GeneratedStatement<S>> {
                 return stmt.executeUpdate();
             }
         } finally {
-            watch.submitMicroTiming(microtimingKey(), sql);
+            watch.submitMicroTiming("SQL", microtimingKey()+": "+ sql);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/SQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/SQLQuery.java
@@ -46,7 +46,7 @@ public class SQLQuery extends BaseSQLQuery {
      */
     public static final int DEFAULT_FETCH_SIZE = 1000;
 
-    private static final String MICROTIMING_KEY = "SQL-QUERY";
+    private static final String MICROTIMING_KEY = "SQL";
     private final Database ds;
     private final String sql;
     private Context params = Context.create();
@@ -116,7 +116,7 @@ public class SQLQuery extends BaseSQLQuery {
                 applyFetchSize(stmt, effectiveLimit);
 
                 try (ResultSet rs = stmt.executeQuery()) {
-                    w.submitMicroTiming(MICROTIMING_KEY, sql);
+                    w.submitMicroTiming(MICROTIMING_KEY, "ITERATE: " + sql);
                     TaskContext tc = TaskContext.get();
                     processResultSet(handler, effectiveLimit, rs, tc);
                 }
@@ -179,7 +179,7 @@ public class SQLQuery extends BaseSQLQuery {
                 return stmt.executeUpdate();
             }
         } finally {
-            w.submitMicroTiming(MICROTIMING_KEY, sql);
+            w.submitMicroTiming(MICROTIMING_KEY, "UPDATE: " + sql);
         }
     }
 
@@ -205,7 +205,7 @@ public class SQLQuery extends BaseSQLQuery {
                 return dbs.fetchGeneratedKeys(stmt);
             }
         } finally {
-            w.submitMicroTiming(MICROTIMING_KEY, sql);
+            w.submitMicroTiming(MICROTIMING_KEY, "UPDATE: " + sql);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -153,7 +153,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                 return execCount(compiler, c);
             } finally {
                 if (Microtiming.isEnabled()) {
-                    w.submitMicroTiming("OMA", "COUNT: "+ compiler.getQuery());
+                    w.submitMicroTiming("OMA", "COUNT: " + compiler.getQuery());
                 }
             }
         } catch (Exception e) {
@@ -403,7 +403,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                 }
             } finally {
                 if (Microtiming.isEnabled()) {
-                    w.submitMicroTiming("OMA", "ITERATE: "+ compiler.getQuery());
+                    w.submitMicroTiming("OMA", "ITERATE: " + compiler.getQuery());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -153,7 +153,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                 return execCount(compiler, c);
             } finally {
                 if (Microtiming.isEnabled()) {
-                    w.submitMicroTiming("OMA", compiler.toString());
+                    w.submitMicroTiming("OMA", "COUNT: "+ compiler.getQuery());
                 }
             }
         } catch (Exception e) {
@@ -403,7 +403,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                 }
             } finally {
                 if (Microtiming.isEnabled()) {
-                    w.submitMicroTiming("OMA", compiler.toString());
+                    w.submitMicroTiming("OMA", "ITERATE: "+ compiler.getQuery());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/sirius/db/jdbc/UpdateStatement.java
+++ b/src/main/java/sirius/db/jdbc/UpdateStatement.java
@@ -33,7 +33,7 @@ import java.time.LocalDateTime;
  */
 public class UpdateStatement extends GeneratedStatement<UpdateStatement> {
 
-    private static final String MICROTIMING_KEY = "SQL-UPDATE";
+    private static final String MICROTIMING_KEY = "UPDATE";
     private final Monoflop setPartStarted = Monoflop.create();
 
     protected UpdateStatement(EntityDescriptor descriptor, Database db) {

--- a/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
@@ -57,7 +57,7 @@ class WrappedPreparedStatement implements PreparedStatement {
     }
 
     protected void updateStatistics(String sql, Watch w) {
-        w.submitMicroTiming("SQL", sql);
+        w.submitMicroTiming("SQL","PreparedStatement: "+ sql);
         Databases.numQueries.inc();
         if (!longRunning) {
             Databases.queryDuration.addValue(w.elapsedMillis());
@@ -412,7 +412,7 @@ class WrappedPreparedStatement implements PreparedStatement {
         Watch w = Watch.start();
         try (Operation op = new Operation(() -> "executeBatch: " + preparedSQL, determineOperationDuration())) {
             int[] result = delegate.executeBatch();
-            w.submitMicroTiming("BATCH-SQL", preparedSQL);
+            w.submitMicroTiming("SQL","Batch: " + preparedSQL);
             Databases.numQueries.inc();
             if (!longRunning) {
                 Databases.queryDuration.addValue(w.elapsedMillis());

--- a/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
@@ -57,7 +57,7 @@ class WrappedPreparedStatement implements PreparedStatement {
     }
 
     protected void updateStatistics(String sql, Watch w) {
-        w.submitMicroTiming("SQL","PreparedStatement: "+ sql);
+        w.submitMicroTiming("SQL","PreparedStatement: " + sql);
         Databases.numQueries.inc();
         if (!longRunning) {
             Databases.queryDuration.addValue(w.elapsedMillis());

--- a/src/main/java/sirius/db/jdbc/WrappedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedStatement.java
@@ -46,7 +46,7 @@ class WrappedStatement implements Statement {
     }
 
     protected void updateStatistics(String sql, Watch w) {
-        w.submitMicroTiming("SQL", sql);
+        w.submitMicroTiming("SQL", "Statement: " + sql);
         Databases.numQueries.inc();
         Databases.queryDuration.addValue(w.elapsedMillis());
         if (w.elapsedMillis() > Databases.getLogQueryThresholdMillis()) {

--- a/src/main/java/sirius/db/mongo/Deleter.java
+++ b/src/main/java/sirius/db/mongo/Deleter.java
@@ -51,7 +51,7 @@ public class Deleter extends QueryBuilder<Deleter> {
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                w.submitMicroTiming("mongo", "DELETE - " + collection + ": " + filterObject);
+                w.submitMicroTiming("mongo", "DELETE - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired(collection, w);
         }
@@ -86,7 +86,7 @@ public class Deleter extends QueryBuilder<Deleter> {
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                w.submitMicroTiming("mongo", "DELETE - " + collection + ": " + filterObject);
+                w.submitMicroTiming("mongo", "DELETE - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired(collection, w);
         }

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -226,7 +226,7 @@ public class Finder extends QueryBuilder<Finder> {
         } finally {
             mongo.callDuration.addValue(watch.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                watch.submitMicroTiming(KEY_MONGO, "FIND ONE - " + collection + ": " + filterObject);
+                watch.submitMicroTiming(KEY_MONGO, "FIND ONE - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired(collection, watch);
         }
@@ -327,7 +327,7 @@ public class Finder extends QueryBuilder<Finder> {
     private void handleTracingAndReporting(String collection, Watch w) {
         mongo.callDuration.addValue(w.elapsedMillis());
         if (Microtiming.isEnabled()) {
-            w.submitMicroTiming(KEY_MONGO, "FIND ALL - " + collection + ": " + filterObject);
+            w.submitMicroTiming(KEY_MONGO, "FIND ALL - " + collection + ": " + filterObject.keySet());
         }
         traceIfRequired(collection, w);
     }
@@ -384,7 +384,7 @@ public class Finder extends QueryBuilder<Finder> {
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                w.submitMicroTiming(KEY_MONGO, "COUNT - " + collection + ": " + filterObject);
+                w.submitMicroTiming(KEY_MONGO, "COUNT - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired(collection, w);
         }
@@ -437,7 +437,7 @@ public class Finder extends QueryBuilder<Finder> {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
                 w.submitMicroTiming(KEY_MONGO,
-                                    "AGGREGATE - " + collection + "." + field + " (" + operator + "): " + filterObject);
+                                    "AGGREGATE - " + collection + "." + field + " (" + operator + "): " + filterObject.keySet());
             }
             traceIfRequired("aggregate-" + collection, w);
         }
@@ -479,7 +479,7 @@ public class Finder extends QueryBuilder<Finder> {
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                w.submitMicroTiming(KEY_MONGO, "FACETS - " + collection + "): " + filterObject);
+                w.submitMicroTiming(KEY_MONGO, "FACETS - " + collection + "): " + filterObject.keySet());
             }
             traceIfRequired("facets-" + collection, w);
         }

--- a/src/main/java/sirius/db/mongo/Inserter.java
+++ b/src/main/java/sirius/db/mongo/Inserter.java
@@ -104,7 +104,7 @@ public class Inserter {
         mongo.db(database).getCollection(collection).insertOne(obj);
         mongo.callDuration.addValue(w.elapsedMillis());
         if (Microtiming.isEnabled()) {
-            w.submitMicroTiming("mongo", "INSERT - " + collection + ": " + obj);
+            w.submitMicroTiming("mongo", "INSERT - " + collection + ": " + obj.keySet());
         }
         return new Doc(obj);
     }

--- a/src/main/java/sirius/db/mongo/Updater.java
+++ b/src/main/java/sirius/db/mongo/Updater.java
@@ -340,7 +340,7 @@ public class Updater extends QueryBuilder<Updater> {
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
-                w.submitMicroTiming("mongo", "UPDATE - " + collection + ": " + filterObject);
+                w.submitMicroTiming("mongo", "UPDATE - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired(collection, w);
         }


### PR DESCRIPTION
As we currently output all filter values in Microtiming, each query is reported for itself.

For the microtiming we rather want an aggregation here and therefore only output the
fields being filtered on. Therefore common queries are aggregated and the reporting
improves. The raw querie can sill be retrieved by enabling fine logging for the DB logger.