### PR TITLE
BREAKING: Valid languages for MultiLanguageString are now customizable

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -83,11 +83,11 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             }
             if (!multiLanguageString.getValidLanguages().contains(language)) {
                 throw Exceptions.createHandled()
-                        .withNLSKey("MultiLanguageString.invalidLanguage")
-                        .set("language", language)
-                        .set("text", text)
-                        .set("field", getField().getName())
-                        .handle();
+                                .withNLSKey("MultiLanguageString.invalidLanguage")
+                                .set("language", language)
+                                .set("text", text)
+                                .set("field", getField().getName())
+                                .handle();
             }
         });
 
@@ -104,12 +104,12 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             return (MultiLanguageString) field.get(target);
         } catch (IllegalAccessException e) {
             throw Exceptions.handle()
-                    .to(Mixing.LOG)
-                    .error(e)
-                    .withSystemErrorMessage("Cannot read property '%s' (from '%s'): %s (%s)",
-                            getName(),
-                            getDefinition())
-                    .handle();
+                            .to(Mixing.LOG)
+                            .error(e)
+                            .withSystemErrorMessage("Cannot read property '%s' (from '%s'): %s (%s)",
+                                                    getName(),
+                                                    getDefinition())
+                            .handle();
         }
     }
 

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -103,7 +103,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
      */
     protected MultiLanguageString getMultiLanguageString(Object target) {
         try {
-            return (MultiLanguageString) field.get(target);
+            return (MultiLanguageString) field.get(accessPath.apply(target));
         } catch (IllegalAccessException e) {
             throw Exceptions.handle()
                             .to(Mixing.LOG)

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -81,7 +81,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             if (Strings.areEqual(language, MultiLanguageString.FALLBACK_KEY)) {
                 return;
             }
-            if (multiLanguageString.getValidLanguages() != null && !multiLanguageString.getValidLanguages().contains(language)) {
+            if (!multiLanguageString.getValidLanguages().contains(language)) {
                 throw Exceptions.createHandled()
                         .withNLSKey("MultiLanguageString.invalidLanguage")
                         .set("language", language)

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -81,7 +81,8 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             if (Strings.areEqual(language, MultiLanguageString.FALLBACK_KEY)) {
                 return;
             }
-            if (!multiLanguageString.getValidLanguages().contains(language)) {
+            if (!multiLanguageString.getValidLanguages().isEmpty() && !multiLanguageString.getValidLanguages()
+                                                                                          .contains(language)) {
                 throw Exceptions.createHandled()
                                 .withNLSKey("MultiLanguageString.invalidLanguage")
                                 .set("language", language)

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -21,7 +21,6 @@ import sirius.db.mixing.PropertyFactory;
 import sirius.db.mixing.types.MultiLanguageString;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
-import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 
@@ -32,7 +31,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -45,9 +43,6 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
 
     private static final String LANGUAGE_PROPERTY = "lang";
     private static final String TEXT_PROPERTY = "text";
-
-    @ConfigValue("mixing.multiLanguageStrings.supportedLanguages")
-    private static Set<String> supportedLanguages;
 
     /**
      * Factory for generating properties based on their field type
@@ -81,28 +76,41 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
 
     @Override
     protected void onBeforeSaveChecks(Object entity) {
-        getMultiLanguageString(entity).data().forEach((language, text) -> {
+        MultiLanguageString multiLanguageString = getMultiLanguageString(entity);
+        multiLanguageString.data().forEach((language, text) -> {
             if (Strings.areEqual(language, MultiLanguageString.FALLBACK_KEY)) {
                 return;
             }
-            if (supportedLanguages != null && !supportedLanguages.contains(language)) {
+            if (multiLanguageString.getValidLanguages() != null && !multiLanguageString.getValidLanguages().contains(language)) {
                 throw Exceptions.createHandled()
-                                .withNLSKey("MultiLanguageString.invalidLanguage")
-                                .set("language", language)
-                                .set("text", text)
-                                .set("field", getField().getName())
-                                .handle();
+                        .withNLSKey("MultiLanguageString.invalidLanguage")
+                        .set("language", language)
+                        .set("text", text)
+                        .set("field", getField().getName())
+                        .handle();
             }
         });
 
         super.onBeforeSaveChecks(entity);
     }
 
-    @SuppressWarnings("unchecked")
-    protected MultiLanguageString getMultiLanguageString(Object entity) {
-        MultiLanguageString multiLanguageString = new MultiLanguageString();
-        multiLanguageString.setData((Map<String, String>) super.getValueFromField(entity));
-        return multiLanguageString;
+    /**
+     * Bypasses {@link BaseMapProperty#getValueFromField(Object)} to access the actual MultiLanguageString entity.
+     *
+     * @see Property#getValueFromField(Object)
+     */
+    protected MultiLanguageString getMultiLanguageString(Object target) {
+        try {
+            return (MultiLanguageString) field.get(target);
+        } catch (IllegalAccessException e) {
+            throw Exceptions.handle()
+                    .to(Mixing.LOG)
+                    .error(e)
+                    .withSystemErrorMessage("Cannot read property '%s' (from '%s'): %s (%s)",
+                            getName(),
+                            getDefinition())
+                    .handle();
+        }
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -12,6 +12,7 @@ import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,7 +25,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
 
     public static final String FALLBACK_KEY = "fallback";
 
-    private Set<String> validLanguages;
+    private Set<String> validLanguages = Collections.emptySet();
 
     private boolean withFallback;
 
@@ -65,7 +66,6 @@ public class MultiLanguageString extends SafeMap<String, String> {
         this.validLanguages = validLanguages;
     }
 
-    @Nullable
     public Set<String> getValidLanguages() {
         return validLanguages;
     }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -13,6 +13,7 @@ import sirius.kernel.nls.NLS;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Provides a language-text map as property value.
@@ -22,6 +23,8 @@ import java.util.Optional;
 public class MultiLanguageString extends SafeMap<String, String> {
 
     public static final String FALLBACK_KEY = "fallback";
+
+    private Set<String> validLanguages;
 
     private boolean withFallback;
 
@@ -33,12 +36,38 @@ public class MultiLanguageString extends SafeMap<String, String> {
     }
 
     /**
+     * Creates a new object to hold a language-text map validating against the given set of language codes
+     * with no place for a fallback string.
+     *
+     * @param validLanguages set of language codes to validate against
+     */
+    public MultiLanguageString(Set<String> validLanguages) {
+        this.validLanguages = validLanguages;
+    }
+
+    /**
      * Creates a new object to hold a language-text map.
      *
      * @param withFallback if a fallback should also be stored in the map
      */
     public MultiLanguageString(boolean withFallback) {
         this.withFallback = withFallback;
+    }
+
+    /**
+     * Creates a new object to hold a language-text map validating against the given set of language codes.
+     *
+     * @param withFallback   if a fallback should also be stored in the map
+     * @param validLanguages set of language codes to validate against
+     */
+    public MultiLanguageString(boolean withFallback, Set<String> validLanguages) {
+        this.withFallback = withFallback;
+        this.validLanguages = validLanguages;
+    }
+
+    @Nullable
+    public Set<String> getValidLanguages() {
+        return validLanguages;
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -45,6 +45,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
      * @param validLanguages set of language codes to validate against
      */
     public MultiLanguageString(@Nonnull Set<String> validLanguages) {
+        this.withFallback = false;
         this.validLanguages = Collections.unmodifiableSet(validLanguages);
     }
 

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -42,8 +42,8 @@ public class MultiLanguageString extends SafeMap<String, String> {
      *
      * @param validLanguages set of language codes to validate against
      */
-    public MultiLanguageString(Set<String> validLanguages) {
-        this.validLanguages = validLanguages;
+    public MultiLanguageString(@Nonnull Set<String> validLanguages) {
+        this.validLanguages = Collections.unmodifiableSet(validLanguages);
     }
 
     /**
@@ -61,13 +61,13 @@ public class MultiLanguageString extends SafeMap<String, String> {
      * @param withFallback   if a fallback should also be stored in the map
      * @param validLanguages set of language codes to validate against
      */
-    public MultiLanguageString(boolean withFallback, Set<String> validLanguages) {
+    public MultiLanguageString(boolean withFallback, @Nonnull Set<String> validLanguages) {
         this.withFallback = withFallback;
-        this.validLanguages = validLanguages;
+        this.validLanguages = Collections.unmodifiableSet(validLanguages);
     }
 
     public Set<String> getValidLanguages() {
-        return validLanguages;
+        return Collections.unmodifiableSet(validLanguages);
     }
 
     @Override

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -300,11 +300,6 @@ mixing {
         }
     }
 
-    multiLanguageStrings {
-        # List of supported languages used by multi-language strings
-        supportedLanguages = ["da", "nl", "en", "fi", "fr", "de", "hu", "it", "nb", "pt", "ro", "ru", "es", "sv", "tr"]
-    }
-
     # Permits to adapt / use a legacy schema via mixing.
     # This way different table and column names can be used than the ones actually
     # determined by the property names. Note that this should only be used to migrate

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringComposite.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringComposite.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Composite;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.types.MultiLanguageString;
+
+/**
+ * Represents a composite to test properties of type {@link MultiLanguageString}
+ */
+public class MongoMultiLanguageStringComposite extends Composite {
+    public static final Mapping COMPOSITE_MULTILANGTEXT_WITH_VALID_LANGUAGES =
+            Mapping.named("compositeMultiLangTextWithValidLanguages");
+    private final MultiLanguageString compositeMultiLangTextWithValidLanguages =
+            new MultiLanguageString(MongoMultiLanguageStringEntity.validLanguages);
+
+    public MultiLanguageString getCompositeMultiLangTextWithValidLanguages() {
+        return compositeMultiLangTextWithValidLanguages;
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
@@ -12,6 +12,10 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.types.MultiLanguageString;
 import sirius.db.mongo.MongoEntity;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Represents an entity to test properties of type {@link MultiLanguageString}
  */
@@ -22,11 +26,19 @@ public class MongoMultiLanguageStringEntity extends MongoEntity {
     public static final Mapping MULTILANGTEXT_WITH_FALLBACK = Mapping.named("multiLangTextWithFallback");
     private final MultiLanguageString multiLangTextWithFallback = new MultiLanguageString(true);
 
+    private final Set<String> validLanguages = new HashSet<>(Arrays.asList("da", "nl", "en", "fi", "fr", "de", "hu", "it", "nb", "pt", "ro", "ru", "es", "sv", "tr"));
+    public static final Mapping MULTILANGTEXT_WITH_VALID_LANGUAGES = Mapping.named("multiLangTextWithValidLanguages");
+    private final MultiLanguageString multiLangTextWithValidLanguages = new MultiLanguageString(validLanguages);
+
     public MultiLanguageString getMultiLangText() {
         return multiLangText;
     }
 
     public MultiLanguageString getMultiLangTextWithFallback() {
         return multiLangTextWithFallback;
+    }
+
+    public MultiLanguageString getMultiLangTextWithValidLanguages() {
+        return multiLangTextWithValidLanguages;
     }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
@@ -26,9 +26,25 @@ public class MongoMultiLanguageStringEntity extends MongoEntity {
     public static final Mapping MULTILANGTEXT_WITH_FALLBACK = Mapping.named("multiLangTextWithFallback");
     private final MultiLanguageString multiLangTextWithFallback = new MultiLanguageString(true);
 
-    private final Set<String> validLanguages = new HashSet<>(Arrays.asList("da", "nl", "en", "fi", "fr", "de", "hu", "it", "nb", "pt", "ro", "ru", "es", "sv", "tr"));
+    public static final Set<String> validLanguages = new HashSet<>(Arrays.asList("da",
+                                                                                 "nl",
+                                                                                 "en",
+                                                                                 "fi",
+                                                                                 "fr",
+                                                                                 "de",
+                                                                                 "hu",
+                                                                                 "it",
+                                                                                 "nb",
+                                                                                 "pt",
+                                                                                 "ro",
+                                                                                 "ru",
+                                                                                 "es",
+                                                                                 "sv",
+                                                                                 "tr"));
     public static final Mapping MULTILANGTEXT_WITH_VALID_LANGUAGES = Mapping.named("multiLangTextWithValidLanguages");
     private final MultiLanguageString multiLangTextWithValidLanguages = new MultiLanguageString(validLanguages);
+
+    private final MongoMultiLanguageStringComposite multiLangComposite = new MongoMultiLanguageStringComposite();
 
     public MultiLanguageString getMultiLangText() {
         return multiLangText;
@@ -40,5 +56,9 @@ public class MongoMultiLanguageStringEntity extends MongoEntity {
 
     public MultiLanguageString getMultiLangTextWithValidLanguages() {
         return multiLangTextWithValidLanguages;
+    }
+
+    public MongoMultiLanguageStringComposite getMultiLangComposite() {
+        return multiLangComposite;
     }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntityWithMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntityWithMixin.java
@@ -1,0 +1,18 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.types.MultiLanguageString;
+import sirius.db.mongo.MongoEntity;
+
+/**
+ * Represents an entity with a mixin to test properties of type {@link MultiLanguageString}
+ */
+public class MongoMultiLanguageStringEntityWithMixin extends MongoEntity {
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
@@ -1,0 +1,29 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.Mixable;
+import sirius.db.mixing.annotations.Mixin;
+import sirius.db.mixing.types.MultiLanguageString;
+
+/**
+ * Represents an entity with a mixin to test properties of type {@link MultiLanguageString}
+ */
+@Mixin(MongoMultiLanguageStringEntityWithMixin.class)
+public class MongoMultiLanguageStringMixin extends Mixable {
+    public final Mapping MIXIN_MULTILANGTEXT_WITH_VALID_LANGUAGES =
+            Mapping.named("mixinMultiLangTextWithValidLanguages");
+    private final MultiLanguageString mixinMultiLangTextWithValidLanguages =
+            new MultiLanguageString(MongoMultiLanguageStringEntity.validLanguages);
+
+    public MultiLanguageString getMixinMultiLangTextWithValidLanguages() {
+        return mixinMultiLangTextWithValidLanguages;
+    }
+}

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
@@ -18,7 +18,7 @@ import sirius.db.mixing.types.MultiLanguageString;
  */
 @Mixin(MongoMultiLanguageStringEntityWithMixin.class)
 public class MongoMultiLanguageStringMixin extends Mixable {
-    public final Mapping MIXIN_MULTILANGTEXT_WITH_VALID_LANGUAGES =
+    public static final Mapping MIXIN_MULTILANGTEXT_WITH_VALID_LANGUAGES =
             Mapping.named("mixinMultiLangTextWithValidLanguages");
     private final MultiLanguageString mixinMultiLangTextWithValidLanguages =
             new MultiLanguageString(MongoMultiLanguageStringEntity.validLanguages);

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -36,6 +36,30 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
         thrown(HandledException)
     }
 
+    def "invalid language in composite"() {
+        given:
+        def entity = new MongoMultiLanguageStringEntity()
+        entity.getMultiLangComposite().getCompositeMultiLangTextWithValidLanguages().addText("00", "")
+
+        when:
+        mango.update(entity)
+
+        then:
+        thrown(HandledException)
+    }
+
+    def "invalid language in mixin"() {
+        given:
+        def entity = new MongoMultiLanguageStringEntityWithMixin()
+        entity.as(MongoMultiLanguageStringMixin.class).getMixinMultiLangTextWithValidLanguages().addText("00", "")
+
+        when:
+        mango.update(entity)
+
+        then:
+        thrown(HandledException)
+    }
+
     def "Comparing persisted data with null keys works as expected"() {
         given:
         def entity = new MongoMultiLanguageStringEntity()

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -26,7 +26,7 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
     def "invalid language"() {
         given:
         def entity = new MongoMultiLanguageStringEntity()
-        entity.getMultiLangText().addText("00", "")
+        entity.getMultiLangTextWithValidLanguages().addText("00", "")
 
         when:
         mango.update(entity)


### PR DESCRIPTION
Moves the set of supported languages to MultiLanguageString for better customizability.

**BREAKING:**
Entirely removes the previously used ConfigValue (mixing.multiLanguageStrings.supportedLanguages)! Be sure to use the new constructors with a corresponding list of language codes for MultiLanguageStrings that relied on this ConfigValue. Language code validation is only performed, if validLanguages are set.

Fixes: SIRI-240