### PR TITLE
Prevents NPE when trying to read a MultiLanguageString with a null value

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -111,7 +111,9 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
         Map<String, String> texts = new LinkedHashMap<>();
         for (Document document : (List<Document>) object.get()) {
             Object textValue = document.get(TEXT_PROPERTY);
-            texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue != null ? textValue.toString() : null);
+            if (textValue != null) {
+               texts.put(document.get(LANGUAGE_PROPERTY).toString(), ttextValue.toString());
+            }
         }
         return texts;
     }

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -110,7 +110,8 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
     protected Object transformFromMongo(Value object) {
         Map<String, String> texts = new LinkedHashMap<>();
         for (Document document : (List<Document>) object.get()) {
-            texts.put(document.get(LANGUAGE_PROPERTY).toString(), document.get(TEXT_PROPERTY).toString());
+            Object textValue = document.get(TEXT_PROPERTY);
+            texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue != null ? textValue.toString() : null);
         }
         return texts;
     }

--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -67,8 +67,8 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
                            Consumer<Property> propertyConsumer) {
             if (!Modifier.isFinal(field.getModifiers())) {
                 Mixing.LOG.WARN("Field %s in %s is not final! This will probably result in errors.",
-                        field.getName(),
-                        field.getDeclaringClass().getName());
+                                field.getName(),
+                                field.getDeclaringClass().getName());
             }
 
             propertyConsumer.accept(new MultiLanguageStringProperty(descriptor, accessPath, field));
@@ -87,11 +87,11 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
             }
             if (supportedLanguages != null && !supportedLanguages.contains(language)) {
                 throw Exceptions.createHandled()
-                        .withNLSKey("MultiLanguageString.invalidLanguage")
-                        .set("language", language)
-                        .set("text", text)
-                        .set("field", getField().getName())
-                        .handle();
+                                .withNLSKey("MultiLanguageString.invalidLanguage")
+                                .set("language", language)
+                                .set("text", text)
+                                .set("field", getField().getName())
+                                .handle();
             }
         });
 
@@ -105,6 +105,12 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
         return multiLanguageString;
     }
 
+    /**
+     * Loads a value from a MongoDB datasource into a {@link MultiLanguageStringProperty} and skips language entries with null values.
+     *
+     * @param object the database value
+     * @return the value which can be stored in the associated {@link MultiLanguageStringProperty} field
+     */
     @Override
     @SuppressWarnings("unchecked")
     protected Object transformFromMongo(Value object) {
@@ -112,7 +118,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
         for (Document document : (List<Document>) object.get()) {
             Object textValue = document.get(TEXT_PROPERTY);
             if (textValue != null) {
-               texts.put(document.get(LANGUAGE_PROPERTY).toString(), ttextValue.toString());
+                texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue.toString());
             }
         }
         return texts;

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -54,7 +54,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text using the language defined by {@link NLS#getCurrentLang()}.
      * <p>
-     * Null texts will be ignored.
+     * If a null text is given it will be ignored, if the list already contains an entry it will be removed.
      *
      * @param text the text associated with the language
      * @return the object itself for fluent method calls
@@ -67,7 +67,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text for the given language.
      * <p>
-     * Null texts will be ignored.
+     * If a null text is given it will be ignored, if the list already contains an entry it will be removed.
      *
      * @param language the language code
      * @param text     the text associated with the language
@@ -75,16 +75,14 @@ public class MultiLanguageString extends SafeMap<String, String> {
      * @throws sirius.kernel.health.HandledException if the provided language code is invalid
      */
     public MultiLanguageString addText(String language, String text) {
-        if (text != null) {
-            put(language, text);
-        }
+        put(language, text);
         return this;
     }
 
     /**
      * Adds the given text as a fallback to the map.
      * <p>
-     * Null texts will be ignored.
+     * If a null text is given it will be ignored, if the list already contains an entry it will be removed.
      *
      * @param text the text to be used as fallback
      * @return the object itself for fluent method calls
@@ -203,5 +201,24 @@ public class MultiLanguageString extends SafeMap<String, String> {
 
     private boolean hasFallback() {
         return withFallback && containsKey(FALLBACK_KEY);
+    }
+
+    /**
+     * Puts the given key and value into the map.
+     * <br>
+     * Keys with null values will be removed.
+     *
+     * @param key   the key used to store the value
+     * @param value the value to store
+     * @return the map itself for fluent method calls
+     */
+    @Override
+    public SafeMap<String, String> put(@Nonnull String key, String value) {
+        if (value != null) {
+            modify().put(key, value);
+        } else {
+            modify().remove(key);
+        }
+        return this;
     }
 }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -217,9 +217,9 @@ public class MultiLanguageString extends SafeMap<String, String> {
     @Override
     public SafeMap<String, String> put(@Nonnull String key, String value) {
         if (value != null) {
-            modify().put(key, value);
+            super.modify().put(key, value);
         } else {
-            modify().remove(key);
+            super.modify().remove(key);
         }
         return this;
     }
@@ -231,5 +231,29 @@ public class MultiLanguageString extends SafeMap<String, String> {
                              .stream()
                              .filter(entry -> entry.getValue() != null)
                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    @Override
+    public Map<String, String> modify() {
+        String className = getClass().getName();
+        throw new UnsupportedOperationException(className
+                                                + " does not support modify. Please use "
+                                                + className
+                                                + ".remove, "
+                                                + className
+                                                + ".put, "
+                                                + className
+                                                + ".addText or "
+                                                + className
+                                                + ".addFallback.");
+    }
+
+    /**
+     * Removes the given language key from the list of languages.
+     *
+     * @param languageKey the language key to be removed from the underlying list of languages.
+     */
+    public void remove(String languageKey) {
+        super.modify().remove(languageKey);
     }
 }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -222,4 +222,11 @@ public class MultiLanguageString extends SafeMap<String, String> {
         }
         return this;
     }
+
+    @Override
+    public void setData(Map<String, String> newData) {
+        // remove keys with null values first
+        newData.entrySet().removeIf(entry -> entry.getValue() == null);
+        super.setData(newData);
+    }
 }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Provides a language-text map as property value.
@@ -226,7 +227,9 @@ public class MultiLanguageString extends SafeMap<String, String> {
     @Override
     public void setData(Map<String, String> newData) {
         // remove keys with null values first
-        newData.entrySet().removeIf(entry -> entry.getValue() == null);
-        super.setData(newData);
+        super.setData(newData.entrySet()
+                             .stream()
+                             .filter(entry -> entry.getValue() != null)
+                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -67,7 +67,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text for the given language.
      * <p>
-     * Texts with null values will be removed.
+     * Null texts will be ignored.
      *
      * @param language the language code
      * @param text     the text associated with the language
@@ -77,8 +77,6 @@ public class MultiLanguageString extends SafeMap<String, String> {
     public MultiLanguageString addText(String language, String text) {
         if (text != null) {
             put(language, text);
-        } else {
-            modify().remove(language);
         }
         return this;
     }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -67,7 +67,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Adds a new text for the given language.
      * <p>
-     * Null texts will be ignored.
+     * Texts with null values will be removed.
      *
      * @param language the language code
      * @param text     the text associated with the language
@@ -77,6 +77,8 @@ public class MultiLanguageString extends SafeMap<String, String> {
     public MultiLanguageString addText(String language, String text) {
         if (text != null) {
             put(language, text);
+        } else {
+            modify().remove(language);
         }
         return this;
     }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -12,6 +12,7 @@ import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -233,6 +233,21 @@ public class MultiLanguageString extends SafeMap<String, String> {
                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
+    /**
+     * Direct modifications of the underlying map are not allowed. Therefore upon calling a {@link UnsupportedOperationException} will be thrown.
+     * <br>
+     * Please use one of the other methods to modify the underlying map:
+     * <ul>
+     *     <li>{@link MultiLanguageString#addText(String)}</li>
+     *     <li>{@link MultiLanguageString#addText(String, String)}</li>
+     *     <li>{@link MultiLanguageString#setData(Map)}</li>
+     *     <li>{@link MultiLanguageString#put(String, String)}</li>
+     *     <li>{@link MultiLanguageString#remove(String)}</li>
+     *     <li>{@link MultiLanguageString#clear()}
+     * </ul>
+     *
+     * @return throws an {@link UnsupportedOperationException}
+     */
     @Override
     public Map<String, String> modify() {
         String className = getClass().getName();

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -208,7 +208,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     /**
      * Puts the given key and value into the map.
      * <br>
-     * Keys with null values will be removed.
+     * If a null text is given it will be ignored, if the list already contains an entry it will be removed.
      *
      * @param key   the key used to store the value
      * @param value the value to store

--- a/src/main/java/sirius/db/mixing/types/SafeMap.java
+++ b/src/main/java/sirius/db/mixing/types/SafeMap.java
@@ -55,19 +55,13 @@ public abstract class SafeMap<K, V> implements Iterable<Map.Entry<K, V>> {
 
     /**
      * Puts the given key and value into the map.
-     * <br>
-     * Keys with null values will be removed.
      *
      * @param key   the key used to store the value
      * @param value the value to store
      * @return the map itself for fluent method calls
      */
     public SafeMap<K, V> put(@Nonnull K key, V value) {
-        if (value != null) {
-            modify().put(key, value);
-        } else {
-            modify().remove(key);
-        }
+        modify().put(key, value);
         return this;
     }
 

--- a/src/main/java/sirius/db/mixing/types/SafeMap.java
+++ b/src/main/java/sirius/db/mixing/types/SafeMap.java
@@ -55,13 +55,19 @@ public abstract class SafeMap<K, V> implements Iterable<Map.Entry<K, V>> {
 
     /**
      * Puts the given key and value into the map.
+     * <br>
+     * Keys with null values will be removed.
      *
      * @param key   the key used to store the value
      * @param value the value to store
      * @return the map itself for fluent method calls
      */
     public SafeMap<K, V> put(@Nonnull K key, V value) {
-        modify().put(key, value);
+        if (value != null) {
+            modify().put(key, value);
+        } else {
+            modify().remove(key);
+        }
         return this;
     }
 

--- a/src/test/java/sirius/db/es/properties/ESMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/es/properties/ESMultiLanguageStringPropertySpec.groovy
@@ -30,7 +30,7 @@ class ESMultiLanguageStringPropertySpec extends BaseSpecification {
         resolved.getMultiLang().getText("en").get() == "This is a test"
 
         when:
-        resolved.getMultiLang().modify().remove("de")
+        resolved.getMultiLang().remove("de")
         and:
         elastic.update(resolved)
         and:

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -214,4 +214,23 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
         then:
         output.getMultiLangTextWithFallback().fetchText() == null
     }
+
+    def "asserts setData removes null keys before persisting"() {
+        given:
+        CallContext.getCurrent().setLang("en")
+        def entity = new MongoMultiLanguageStringEntity()
+        Map<String, String> data = new LinkedHashMap<>()
+        data.put("en", "Great")
+        data.put("de", null)
+        entity.getMultiLangText().setData(data)
+        mango.update(entity)
+
+        when:
+        def output = mango.refreshOrFail(entity)
+
+        then:
+        output.getMultiLangText().fetchText("en") == "Great"
+        output.getMultiLangText().fetchText("de") == null
+        output.getMultiLangText().original().size() == 1
+    }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -206,7 +206,11 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
 
         when:
         entity = mango.refreshOrFail(entity)
+
+        then:
         entity.getMultiLangText().fetchText() == "Super"
+
+        when:
         entity.getMultiLangText().addText("en", null)
         mango.update(entity)
         def output = mango.refreshOrFail(entity)

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -237,4 +237,15 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
         output.getMultiLangText().fetchText("de") == null
         output.getMultiLangText().original().size() == 1
     }
+
+    def "trying to directly call modify should throw an unsupported operation exception"() {
+        given:
+        def entity = new MongoMultiLanguageStringEntity()
+
+        when:
+        entity.getMultiLangText().modify().put("de", null)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
 }


### PR DESCRIPTION
… now. This should not happen as null values should not be persisted and therefore not mapped when reading from database.

Fixes: SIRI-272
<img width="1168" alt="error" src="https://user-images.githubusercontent.com/8539026/97327810-a4335580-1875-11eb-95c4-d94a6f856cfd.png">
