### PR TITLE
Permits to read from secondary nodes in MongoDB

### DIFF
--- a/src/main/java/sirius/db/jdbc/OMA.java
+++ b/src/main/java/sirius/db/jdbc/OMA.java
@@ -352,9 +352,11 @@ public class OMA extends BaseMapper<SQLEntity, SQLConstraint, SmartQuery<? exten
     /**
      * Creates a query for the given type using the <tt>secondary</tt> datasource.
      * <p>
-     * Note that an entity fetched from a secondary database shoudln't be updated back into the
+     * Note that an entity fetched from a secondary database shouldn't be updated back into the
      * primary database. Call {@link #tryRefresh(E)} to obtain a up-to-date copy from
      * the primary or use <tt>optimistic locking</tt> to prevent re-inserting stale data into the primary db.
+     * <p>
+     * Also, this should NOT be used to fill any cache as this might poison the cache with already stale data.
      *
      * @param type the type of entities to query for.
      * @param <E>  the generic type of entities to be returned

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -234,7 +234,7 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
      * This provides an essential boost in performance, as all nodes of a MongoDB cluster are utilized. However, this
      * may return stale data if a secondary lags behind. Therefore this data must not be stored back in the primary
      * database using {@link Mango#update(MongoEntity)}. This should rather only be used to serve web requests or other
-     * queries where occasional stale date does no harm.
+     * queries where occasional stale data does no harm.
      * <p>
      * Also, this should NOT be used to fill any cache as this might poison the cache with already stale data.
      *

--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mongo;
 
+import com.mongodb.ReadPreference;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixing;
@@ -48,10 +49,11 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
      * Creates a new query for the given descriptor.
      *
      * @param descriptor the descriptor of the entities being queried
+     * @param readPreference the read preference to enforce
      */
-    protected MongoQuery(EntityDescriptor descriptor) {
+    protected MongoQuery(EntityDescriptor descriptor, ReadPreference readPreference) {
         super(descriptor);
-        this.finder = mongo.find(descriptor.getRealm());
+        this.finder = mongo.find(descriptor.getRealm(), readPreference);
     }
 
     /**

--- a/src/test/java/sirius/db/mongo/MongoSpec.groovy
+++ b/src/test/java/sirius/db/mongo/MongoSpec.groovy
@@ -34,6 +34,19 @@ class MongoSpec extends BaseSpecification {
                 orElse(null) == testString
     }
 
+    def "read from secondary works"() {
+        given:
+        def testString = String.valueOf(System.currentTimeMillis())
+        when:
+        def result = mongo.insert().set("test", testString).set("id", keyGen.generateId()).into("test")
+        then:
+        mongo.findInSecondary().
+                where("id", result.getString("id")).
+                singleIn("test").
+                map({ d -> d.getString("test") }).
+                orElse(null) == testString
+    }
+
     def "sort works for singleIn"() {
         when:
         def result1 = mongo.insert().set("sortBy", 1).set("id", keyGen.generateId()).into("test")


### PR DESCRIPTION
When using findInSecondary or selectFromSecondary we now issue a ReadPreference "NEAREST" instead of
"PRIMARY".