### PR TITLE
No Normalisation in Search Index

### DIFF
--- a/src/main/java/sirius/db/text/BasicIndexTokenizer.java
+++ b/src/main/java/sirius/db/text/BasicIndexTokenizer.java
@@ -18,10 +18,11 @@ public class BasicIndexTokenizer extends Tokenizer {
     @Override
     protected ChainableTokenProcessor createProcessor() {
         // ATTENTION: The pipeline used to contain a "new ReduceCharacterProcessor()" stage. This lead to the search
-        // index containing normalised strings, unlike earlier verions of sirius-db. Consequently, MEMOIO was no longer
-        // able to find search terms containing umlauts. Weighing the two possible options — keeping the normalised
-        // index and normalising the search term, or reverting the index – the decision was made to remove search index
-        // normalisation.
+        // index consisting of normalised strings, unlike earlier verions of sirius-db. Consequently, without migration,
+        // existing indices were incompatible. Furthermore, ElasticQueryCompiler did not follow along and continued to
+        // query for raw strings, hence not finding search terms containing special characters such as umlauts.
+        // Weighing the two possible options — keeping the normalised index and normalising the search term, or
+        // reverting the index generation – the decision was made to remove search index normalisation.
 
         return new PipelineProcessor(PatternReplaceProcessor.createRemoveControlCharacters(),
                                      PatternSplitProcessor.createHardBoundarySplitter(),

--- a/src/main/java/sirius/db/text/BasicIndexTokenizer.java
+++ b/src/main/java/sirius/db/text/BasicIndexTokenizer.java
@@ -17,8 +17,14 @@ public class BasicIndexTokenizer extends Tokenizer {
 
     @Override
     protected ChainableTokenProcessor createProcessor() {
+        // ATTENTION: The pipeline used to contain a "new ReduceCharacterProcessor()" stage. This lead to the search
+        // index containing normalised strings, unlike earlier verions of sirius-db. Consequently, MEMOIO was no longer
+        // able to find search terms containing umlauts. Weighing the two possible options — keeping the normalised
+        // index and normalising the search term, or reverting the index – the decision was made to remove search index
+        // normalisation.
+        // --- Stage removed by JVO on 2020/11/16 after discussion with AHA
+
         return new PipelineProcessor(PatternReplaceProcessor.createRemoveControlCharacters(),
-                                     new ReduceCharacterProcessor(),
                                      PatternSplitProcessor.createHardBoundarySplitter(),
                                      PatternSplitProcessor.createWhitespaceSplitter(),
                                      PatternExtractProcessor.createEmailExtractor(),

--- a/src/main/java/sirius/db/text/BasicIndexTokenizer.java
+++ b/src/main/java/sirius/db/text/BasicIndexTokenizer.java
@@ -22,7 +22,6 @@ public class BasicIndexTokenizer extends Tokenizer {
         // able to find search terms containing umlauts. Weighing the two possible options — keeping the normalised
         // index and normalising the search term, or reverting the index – the decision was made to remove search index
         // normalisation.
-        // --- Stage removed by JVO on 2020/11/16 after discussion with AHA
 
         return new PipelineProcessor(PatternReplaceProcessor.createRemoveControlCharacters(),
                                      PatternSplitProcessor.createHardBoundarySplitter(),


### PR DESCRIPTION
Removes character reduction stage from tokenizer, due to an incompatibility between search index and query normalisation. (See code.)