### PR TITLE
Makes a method public for reusage

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -626,7 +626,7 @@ public abstract class Property extends Composable {
      * @param value the illegal value itself
      * @return an exception filled with an appropriate message
      */
-    protected HandledException illegalFieldValue(Value value) {
+    public HandledException illegalFieldValue(Value value) {
         return Exceptions.createHandled()
                          .error(new InvalidFieldException(getName()))
                          .withNLSKey("Property.illegalValue")


### PR DESCRIPTION
For instance, the Importhandler from sirius-biz can throw this message when performing custom validation when parsing properties