### PR TITLE
Allows @NullAllowed to work on MultiLanguageStrings

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiLanguageStringProperty.java
@@ -188,4 +188,17 @@ public class MultiLanguageStringProperty extends BaseMapProperty implements ESPr
     public boolean doesEnableDynamicMappings() {
         return true;
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected boolean isConsideredNull(Object propertyValue) {
+        if (propertyValue == null) {
+            return true;
+        }
+        Map<String, String> values = ((Map<String, String>) propertyValue);
+        if (values.isEmpty()) {
+            return true;
+        }
+        return values.entrySet().stream().anyMatch(entry -> Strings.isEmpty(entry.getValue()));
+    }
 }

--- a/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
+++ b/src/main/java/sirius/db/mixing/types/MultiLanguageString.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mixing.types;
 
+import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
@@ -246,7 +247,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
      */
     @Override
     public SafeMap<String, String> put(@Nonnull String key, String value) {
-        if (value != null) {
+        if (Strings.isFilled(value)) {
             super.modify().put(key, value);
         } else {
             super.modify().remove(key);

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringComposite.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringComposite.java
@@ -10,6 +10,7 @@ package sirius.db.mongo.properties;
 
 import sirius.db.mixing.Composite;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.MultiLanguageString;
 
 /**
@@ -18,6 +19,7 @@ import sirius.db.mixing.types.MultiLanguageString;
 public class MongoMultiLanguageStringComposite extends Composite {
     public static final Mapping COMPOSITE_MULTILANGTEXT_WITH_VALID_LANGUAGES =
             Mapping.named("compositeMultiLangTextWithValidLanguages");
+    @NullAllowed
     private final MultiLanguageString compositeMultiLangTextWithValidLanguages =
             new MultiLanguageString(MongoMultiLanguageStringEntity.validLanguages);
 

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringEntity.java
@@ -9,6 +9,7 @@
 package sirius.db.mongo.properties;
 
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.MultiLanguageString;
 import sirius.db.mongo.MongoEntity;
 
@@ -21,9 +22,11 @@ import java.util.Set;
  */
 public class MongoMultiLanguageStringEntity extends MongoEntity {
     public static final Mapping MULTILANGTEXT = Mapping.named("multiLangText");
+    @NullAllowed
     private final MultiLanguageString multiLangText = new MultiLanguageString();
 
     public static final Mapping MULTILANGTEXT_WITH_FALLBACK = Mapping.named("multiLangTextWithFallback");
+    @NullAllowed
     private final MultiLanguageString multiLangTextWithFallback = new MultiLanguageString(true);
 
     public static final Set<String> validLanguages = new HashSet<>(Arrays.asList("da",
@@ -42,6 +45,7 @@ public class MongoMultiLanguageStringEntity extends MongoEntity {
                                                                                  "sv",
                                                                                  "tr"));
     public static final Mapping MULTILANGTEXT_WITH_VALID_LANGUAGES = Mapping.named("multiLangTextWithValidLanguages");
+    @NullAllowed
     private final MultiLanguageString multiLangTextWithValidLanguages = new MultiLanguageString(validLanguages);
 
     private final MongoMultiLanguageStringComposite multiLangComposite = new MongoMultiLanguageStringComposite();

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringMixin.java
@@ -11,6 +11,7 @@ package sirius.db.mongo.properties;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixable;
 import sirius.db.mixing.annotations.Mixin;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.MultiLanguageString;
 
 /**
@@ -20,6 +21,7 @@ import sirius.db.mixing.types.MultiLanguageString;
 public class MongoMultiLanguageStringMixin extends Mixable {
     public static final Mapping MIXIN_MULTILANGTEXT_WITH_VALID_LANGUAGES =
             Mapping.named("mixinMultiLangTextWithValidLanguages");
+    @NullAllowed
     private final MultiLanguageString mixinMultiLangTextWithValidLanguages =
             new MultiLanguageString(MongoMultiLanguageStringEntity.validLanguages);
 

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -24,6 +24,27 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
     @Part
     private static Mongo mongo
 
+    def "null check works"() {
+        given:
+        def entity = new MongoMultiLanguageStringRequiredEntity()
+
+        entity.getMultiLangText().addText("de", "")
+
+        when:
+        mango.update(entity)
+
+        then:
+        def e = thrown(HandledException)
+        e.getCause().getMessage() == "multiLangText"
+
+        when:
+        entity.getMultiLangText().addText("de", "erforderlich")
+        mango.update(entity)
+
+        then:
+        noExceptionThrown()
+    }
+
     def "invalid language"() {
         given:
         def entity = new MongoMultiLanguageStringEntity()

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringPropertySpec.groovy
@@ -48,7 +48,7 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
     def "invalid language"() {
         given:
         def entity = new MongoMultiLanguageStringEntity()
-        entity.getMultiLangTextWithValidLanguages().addText("00", "")
+        entity.getMultiLangTextWithValidLanguages().addText("00", "some text")
 
         when:
         mango.update(entity)
@@ -60,7 +60,7 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
     def "invalid language in composite"() {
         given:
         def entity = new MongoMultiLanguageStringEntity()
-        entity.getMultiLangComposite().getCompositeMultiLangTextWithValidLanguages().addText("00", "")
+        entity.getMultiLangComposite().getCompositeMultiLangTextWithValidLanguages().addText("00", "some text")
 
         when:
         mango.update(entity)
@@ -72,7 +72,7 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
     def "invalid language in mixin"() {
         given:
         def entity = new MongoMultiLanguageStringEntityWithMixin()
-        entity.as(MongoMultiLanguageStringMixin.class).getMixinMultiLangTextWithValidLanguages().addText("00", "")
+        entity.as(MongoMultiLanguageStringMixin.class).getMixinMultiLangTextWithValidLanguages().addText("00", "some text")
 
         when:
         mango.update(entity)
@@ -158,7 +158,7 @@ class MongoMultiLanguageStringPropertySpec extends BaseSpecification {
         mango.update(entity)
 
         when:
-        def expectedString = "[Document{{lang=pt, text=Borboleta}}, Document{{lang=es, text=Mariposa}}, Document{{lang=en, text=}}]"
+        def expectedString = "[Document{{lang=pt, text=Borboleta}}, Document{{lang=es, text=Mariposa}}]"
         def storedString = mongo.find()
                                 .where("id", entity.getId())
                                 .singleIn("mongomultilanguagestringentity")

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringRequiredEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiLanguageStringRequiredEntity.java
@@ -1,0 +1,25 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.types.MultiLanguageString;
+import sirius.db.mongo.MongoEntity;
+
+/**
+ * Represents an entity to test properties of type {@link MultiLanguageString}
+ */
+public class MongoMultiLanguageStringRequiredEntity extends MongoEntity {
+    public static final Mapping MULTILANGTEXT = Mapping.named("multiLangText");
+    private final MultiLanguageString multiLangText = new MultiLanguageString();
+
+    public MultiLanguageString getMultiLangText() {
+        return multiLangText;
+    }
+}

--- a/src/test/resources/test_de.properties
+++ b/src/test/resources/test_de.properties
@@ -3,3 +3,4 @@ Model.shortStringList=Model.shortStringList
 MongoIntEntity.testIntPositive=MongoIntEntity.testIntPositive
 MongoIntEntity.testIntMaxHundred=MongoIntEntity.testIntMaxHundred
 MongoIntEntity.testIntMinHundred=MongoIntEntity.testIntMinHundred
+MongoMultiLanguageStringRequiredEntity.multiLangText=MultiLanguageTextRequired


### PR DESCRIPTION
**BREAKING** `@NullAllowed` must be specified for all existing MultiLanguageStrings which expect empty values!

The annotation will work like on other Properties. MultiLanguageStrings not annotated with @NullAllowed will fail if empty or an empty string / null is defined for a language.

Fixes: OX-6462