### PR TITLE
Properly validates enum values provided from importers

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -78,23 +78,24 @@ public class EnumProperty extends Property implements SQLPropertyInfo, ESPropert
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     protected Object transformValueFromImport(Value value) {
-        if (value.isFilled()) {
-            // If a value is present, we check if any constant name or its translation matches...
-            String stringValue = value.asString().trim();
-            for (Enum enumValue : ((Class<Enum>) field.getType()).getEnumConstants()) {
-                // Check for a match of the constant...
-                if (Strings.equalIgnoreCase(enumValue.name(), stringValue)) {
-                    return enumValue;
-                }
+        if (value.isEmptyString()) {
+            return null;
+        }
+        // If a value is present, we check if any constant name or its translation matches...
+        String stringValue = value.asString().trim();
+        for (Enum enumValue : ((Class<Enum>) field.getType()).getEnumConstants()) {
+            // Check for a match of the constant...
+            if (Strings.equalIgnoreCase(enumValue.name(), stringValue)) {
+                return enumValue;
+            }
 
-                // Check of a match of the translation...
-                if (Strings.equalIgnoreCase(enumValue.toString(), stringValue)) {
-                    return enumValue;
-                }
+            // Check of a match of the translation...
+            if (Strings.equalIgnoreCase(enumValue.toString(), stringValue)) {
+                return enumValue;
             }
         }
 
-        return super.transformValueFromImport(value);
+        throw illegalFieldValue(value);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/sirius/db/mixing/properties/EnumPropertySpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/EnumPropertySpec.groovy
@@ -13,6 +13,7 @@ import sirius.db.mixing.Mixing
 import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
 
 class EnumPropertySpec extends BaseSpecification {
 
@@ -34,10 +35,10 @@ class EnumPropertySpec extends BaseSpecification {
         then:
         entity.getTestEnum() == ESDataTypesEntity.TestEnum.Test1
 
-        when: // Invalid values become nulll
+        when: // Invalid values throws an exception
         property.parseValueFromImport(entity, Value.of("test0"))
         then:
-        entity.getTestEnum() == null
+        thrown(HandledException)
         when: // Enum constants can be resolved by their "toString" representation...
         property.parseValueFromImport(entity, Value.of("test25"))
         then:

--- a/src/test/resources/test_de.properties
+++ b/src/test/resources/test_de.properties
@@ -1,3 +1,4 @@
+ESDataTypesEntity.enumValue=Enum Value
 Model.firstname=Vorname
 Model.shortStringList=Model.shortStringList
 MongoIntEntity.testIntPositive=MongoIntEntity.testIntPositive


### PR DESCRIPTION
When an enum couldn't be validated against its constant or its translation, a null value was being returned (via #transformValue -> Value.asEnum).

This caused invalid enum values to empty non required target fields.

Sample of this fix when an enum value cannot be validated:
![image](https://user-images.githubusercontent.com/54799255/105208179-ae997e80-5b48-11eb-8a65-f213ae63cbda.png)


Fixes: OX-6357