### PR TITLE
Specifies a proper read timeout for redis.

### DIFF
--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -44,6 +44,7 @@ public class RedisDB {
     private String host;
     private int port;
     private int connectTimeout;
+    private int readTimeout;
     private String password;
     private int db;
     private int maxActive;
@@ -61,6 +62,7 @@ public class RedisDB {
         this.host = config.getString("host");
         this.port = config.getInt("port");
         this.connectTimeout = config.getInt("connectTimeout");
+        this.readTimeout = config.getInt("readTimeout");
         this.password = config.getString("password");
         this.db = config.getInt("db");
         this.maxActive = config.getInt("maxActive");
@@ -124,7 +126,11 @@ public class RedisDB {
                                                  Arrays.stream(sentinels.split(","))
                                                        .map(String::trim)
                                                        .collect(Collectors.toSet()),
-                                                 poolConfig);
+                                                 poolConfig,
+                                                 connectTimeout,
+                                                 readTimeout,
+                                                 null,
+                                                 db);
             return sentinelPool.getResource();
         }
         if (sentinelPool != null) {
@@ -147,6 +153,7 @@ public class RedisDB {
                                   effectiveHostAndPort.getFirst(),
                                   effectiveHostAndPort.getSecond(),
                                   connectTimeout,
+                                  readTimeout,
                                   Strings.isFilled(password) ? password : null,
                                   db,
                                   CallContext.getNodeName());

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -345,7 +345,10 @@ redis {
             port = 6379
 
             # Contains the connection timeout in ms
-            timeout = 2000
+            connectTimeout = 2000
+
+            # Contains the read timeout in ms - use 0 to disable
+            readTimeout = 10000
 
             # Contains the password used to connect to redis
             password = ""


### PR DESCRIPTION
By default "no timeout" is used, which is quite dangerous.
Still, by default we use quite a high value of 10s in case a
tasks is long running.

Also the config name for the default value of the connection
timeout was fixed.