### PR TITLE
Extends SkipDefaultValue to empty maps and lists

### DIFF
--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -33,6 +33,8 @@ import sirius.kernel.health.Exceptions;
 
 import java.util.HashSet;
 import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -160,7 +162,19 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
      * @return <tt>true</tt> if the given value is a default value, <tt>false</tt> otherwise
      */
     private boolean isDefaultValue(Object valueForDatasource) {
-        return valueForDatasource == null || Boolean.FALSE.equals(valueForDatasource);
+        if (valueForDatasource == null) {
+            return true;
+        }
+
+        if (valueForDatasource instanceof List && ((List<?>) valueForDatasource).isEmpty()) {
+            return true;
+        }
+
+        if (valueForDatasource instanceof Map && ((Map<?, ?>) valueForDatasource).isEmpty()) {
+            return true;
+        }
+
+        return Boolean.FALSE.equals(valueForDatasource);
     }
 
     private <E extends MongoEntity> void enforceUpdate(E entity, boolean force, long updatedRows, boolean versioned)

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -146,7 +146,7 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
 
     private void writeField(MongoEntity entity, Updater updater, Property property) {
         Object valueForDatasource = property.getValueForDatasource(Mango.class, entity);
-        if (isDefaultValue(valueForDatasource) && property.isAnnotationPresent(SkipDefaultValue.class)) {
+        if (property.isAnnotationPresent(SkipDefaultValue.class) && isDefaultValue(valueForDatasource)) {
             updater.unset(property.getPropertyName());
         } else {
             updater.set(property.getPropertyName(), valueForDatasource);

--- a/src/test/java/sirius/db/mongo/MangoSpec.groovy
+++ b/src/test/java/sirius/db/mongo/MangoSpec.groovy
@@ -271,6 +271,8 @@ class MangoSpec extends BaseSpecification {
         then:
         test.getStringTest() == null
         test.isBoolTest() == false
+        test.getListTest().size() == 0
+        test.getMapTest().size() == 0
         and:
         // Only the id (and _id) is stored...
         mongo.
@@ -286,12 +288,16 @@ class MangoSpec extends BaseSpecification {
         test = new SkipDefaultTestEntity()
         test.setStringTest("Hello")
         test.setBoolTest(true)
+        test.getListTest().add("Item")
+        test.getMapTest().put("Key", "Value")
         mango.update(test)
         and:
         test = mango.find(SkipDefaultTestEntity.class, test.getId()).get()
         then:
         test.getStringTest() == "Hello"
         test.isBoolTest() == true
+        test.getListTest().contains("Item")
+        test.getMapTest().get("Key").orElse("") == "Value"
         and:
         // All fields are stored...
         mongo.
@@ -301,17 +307,21 @@ class MangoSpec extends BaseSpecification {
                 get().
                 getUnderlyingObject().
                 keySet().
-                size() == 4
+                size() == 6
 
         when:
         test.setStringTest(null)
         test.setBoolTest(false)
+        test.getListTest().clear()
+        test.getMapTest().clear()
         mango.update(test)
         and:
         test = mango.find(SkipDefaultTestEntity.class, test.getId()).get()
         then:
         test.getStringTest() == null
         test.isBoolTest() == false
+        test.getListTest().size() == 0
+        test.getMapTest().size() == 0
         and:
         // Only the id (and again _id) is stored...
         mongo.

--- a/src/test/java/sirius/db/mongo/SkipDefaultTestEntity.java
+++ b/src/test/java/sirius/db/mongo/SkipDefaultTestEntity.java
@@ -10,6 +10,8 @@ package sirius.db.mongo;
 
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.SkipDefaultValue;
+import sirius.db.mixing.types.StringList;
+import sirius.db.mixing.types.StringMap;
 
 public class SkipDefaultTestEntity extends MongoEntity {
 
@@ -19,6 +21,12 @@ public class SkipDefaultTestEntity extends MongoEntity {
 
     @SkipDefaultValue
     private boolean boolTest;
+
+    @SkipDefaultValue
+    private final StringList listTest = new StringList();
+
+    @SkipDefaultValue
+    private final StringMap mapTest = new StringMap();
 
     public String getStringTest() {
         return stringTest;
@@ -34,5 +42,13 @@ public class SkipDefaultTestEntity extends MongoEntity {
 
     public void setBoolTest(boolean boolTest) {
         this.boolTest = boolTest;
+    }
+
+    public StringList getListTest() {
+        return listTest;
+    }
+
+    public StringMap getMapTest() {
+        return mapTest;
     }
 }


### PR DESCRIPTION
So we can annotate map and list based fields to not be physically persisted when their contents are empty.

Direct use case are MultiLanguageStrings.