### PR TITLE
Fixes microtiming for Mongo queries and adds additional timings for save and delete handlers.

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -242,19 +242,19 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     @Override
-    protected void createEntity(ElasticEntity entity, EntityDescriptor ed) throws Exception {
+    protected void createEntity(ElasticEntity entity, EntityDescriptor entityDescriptor) throws Exception {
         JSONObject data = new JSONObject();
-        toJSON(ed, entity, data);
+        toJSON(entityDescriptor, entity, data);
 
         String id = determineId(entity);
-        JSONObject response = getLowLevelClient().index(determineWriteAlias(ed),
+        JSONObject response = getLowLevelClient().index(determineWriteAlias(entityDescriptor),
                                                         id,
-                                                        determineRouting(ed, entity, RoutingAccessMode.WRITE),
+                                                        determineRouting(entityDescriptor, entity, RoutingAccessMode.WRITE),
                                                         null,
                                                         null,
                                                         data);
         entity.setId(id);
-        if (ed.isVersioned()) {
+        if (entityDescriptor.isVersioned()) {
             entity.setPrimaryTerm(response.getLong(RESPONSE_PRIMARY_TERM));
             entity.setSeqNo(response.getLong(RESPONSE_SEQ_NO));
         }
@@ -283,22 +283,22 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     @Override
-    protected void updateEntity(ElasticEntity entity, boolean force, EntityDescriptor ed) throws Exception {
+    protected void updateEntity(ElasticEntity entity, boolean force, EntityDescriptor entityDescriptor) throws Exception {
         JSONObject data = new JSONObject();
-        boolean changed = toJSON(ed, entity, data);
+        boolean changed = toJSON(entityDescriptor, entity, data);
 
         if (!changed) {
             return;
         }
 
-        JSONObject response = getLowLevelClient().index(determineWriteAlias(ed),
+        JSONObject response = getLowLevelClient().index(determineWriteAlias(entityDescriptor),
                                                         determineId(entity),
-                                                        determineRouting(ed, entity, RoutingAccessMode.WRITE),
-                                                        determinePrimaryTerm(force, ed, entity),
-                                                        determineSeqNo(force, ed, entity),
+                                                        determineRouting(entityDescriptor, entity, RoutingAccessMode.WRITE),
+                                                        determinePrimaryTerm(force, entityDescriptor, entity),
+                                                        determineSeqNo(force, entityDescriptor, entity),
                                                         data);
 
-        if (ed.isVersioned()) {
+        if (entityDescriptor.isVersioned()) {
             entity.setPrimaryTerm(response.getLong(RESPONSE_PRIMARY_TERM));
             entity.setSeqNo(response.getLong(RESPONSE_SEQ_NO));
         }
@@ -501,12 +501,12 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     @Override
-    protected void deleteEntity(ElasticEntity entity, boolean force, EntityDescriptor ed) throws Exception {
-        getLowLevelClient().delete(determineWriteAlias(ed),
+    protected void deleteEntity(ElasticEntity entity, boolean force, EntityDescriptor entityDescriptor) throws Exception {
+        getLowLevelClient().delete(determineWriteAlias(entityDescriptor),
                                    entity.getId(),
-                                   determineRouting(ed, entity, RoutingAccessMode.WRITE),
-                                   determinePrimaryTerm(force, ed, entity),
-                                   determineSeqNo(force, ed, entity));
+                                   determineRouting(entityDescriptor, entity, RoutingAccessMode.WRITE),
+                                   determinePrimaryTerm(force, entityDescriptor, entity),
+                                   determineSeqNo(force, entityDescriptor, entity));
     }
 
     /**
@@ -547,17 +547,17 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     @SuppressWarnings("unchecked")
     @Override
     protected <E extends ElasticEntity> Optional<E> findEntity(Object id,
-                                                               EntityDescriptor ed,
+                                                               EntityDescriptor entityDescriptor,
                                                                Function<String, Value> context) throws Exception {
-        JSONObject obj = getLowLevelClient().get(determineReadAlias(ed),
+        JSONObject obj = getLowLevelClient().get(determineReadAlias(entityDescriptor),
                                                  id.toString(),
-                                                 determineRoutingForFind(id, ed, context),
+                                                 determineRoutingForFind(id, entityDescriptor, context),
                                                  true);
         if (obj == null || !Boolean.TRUE.equals(obj.getBoolean(RESPONSE_FOUND))) {
             return Optional.empty();
         }
 
-        E result = (E) make(ed, obj);
+        E result = (E) make(entityDescriptor, obj);
         return Optional.of(result);
     }
 

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -231,7 +231,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     /**
      * Calls the given function on all items in the result, as long as it returns <tt>true</tt>.
      * <p>
-     * In contrast to {@link #iterate(Predicate)}, this method is suitable for large result sets or log processing
+     * In contrast to {@link #iterate(Predicate)}, this method is suitable for large result sets or long processing
      * times. As <tt>iterate</tt> keeps the JDBC <tt>ResultSet</tt> open, the underlying server might discard the
      * result at some point in time (e.g. MySQL does this after 30-45min). Therefore, we execute the query and start
      * processing. If a timeout ({@link #QUERY_ITERATE_TIMEOUT} is reached, we stop iterating, discard the result set

--- a/src/main/java/sirius/db/mixing/BaseMapper.java
+++ b/src/main/java/sirius/db/mixing/BaseMapper.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, Q extends Query<?, ? extends B, C>> {
 
     private static final Function<String, Value> EMPTY_CONTEXT = key -> Value.EMPTY;
+    private static final String TIMING_CATEGORY_MIXING = "MIXING";
 
     /**
      * Contains the name of the version column used for optimistic locking.
@@ -223,7 +224,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         try {
             entityDescriptor.beforeSave(entity);
         } finally {
-            watch.submitMicroTiming("MIXING", "BeforeSave - " + ed.getName());
+            watch.submitMicroTiming(TIMING_CATEGORY_MIXING, "BeforeSave - " + entityDescriptor.getName());
         }
     }
 
@@ -232,7 +233,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         try {
             entityDescriptor.afterSave(entity);
         } finally {
-            watch.submitMicroTiming("MIXING", "AferSave - " + ed.getName());
+            watch.submitMicroTiming(TIMING_CATEGORY_MIXING, "AferSave - " + entityDescriptor.getName());
         }
     }
 
@@ -332,7 +333,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         try {
             entityDescriptor.beforeDelete(entity);
         } finally {
-            watch.submitMicroTiming("MIXING", "BeforeDelete - " + ed.getName());
+            watch.submitMicroTiming(TIMING_CATEGORY_MIXING, "BeforeDelete - " + entityDescriptor.getName());
         }
     }
 
@@ -341,7 +342,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         try {
             entityDescriptor.afterDelete(entity);
         } finally {
-            watch.submitMicroTiming("MIXING", "AfterDelete - " + ed.getName());
+            watch.submitMicroTiming(TIMING_CATEGORY_MIXING, "AfterDelete - " + entityDescriptor.getName());
         }
     }
 

--- a/src/main/java/sirius/db/mixing/BaseMapper.java
+++ b/src/main/java/sirius/db/mixing/BaseMapper.java
@@ -195,16 +195,16 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         }
 
         try {
-            EntityDescriptor ed = entity.getDescriptor();
-            invokeBeforeSaveHandlers(entity, ed);
+            EntityDescriptor entityDescriptor = entity.getDescriptor();
+            invokeBeforeSaveHandlers(entity, entityDescriptor);
 
             if (entity.isNew()) {
-                createEntity(entity, ed);
+                createEntity(entity, entityDescriptor);
             } else {
-                updateEntity(entity, force, ed);
+                updateEntity(entity, force, entityDescriptor);
             }
 
-            invokeAfterSaveHandlers(entity, ed);
+            invokeAfterSaveHandlers(entity, entityDescriptor);
         } catch (IntegrityConstraintFailedException | OptimisticLockException e) {
             throw e;
         } catch (Exception e) {
@@ -218,19 +218,19 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         }
     }
 
-    private <E extends B> void invokeBeforeSaveHandlers(E entity, EntityDescriptor ed) {
+    private <E extends B> void invokeBeforeSaveHandlers(E entity, EntityDescriptor entityDescriptor) {
         Watch watch = Watch.start();
         try {
-            ed.beforeSave(entity);
+            entityDescriptor.beforeSave(entity);
         } finally {
             watch.submitMicroTiming("MIXING", "BeforeSave - " + ed.getName());
         }
     }
 
-    private <E extends B> void invokeAfterSaveHandlers(E entity, EntityDescriptor ed) {
+    private <E extends B> void invokeAfterSaveHandlers(E entity, EntityDescriptor entityDescriptor) {
         Watch watch = Watch.start();
         try {
-            ed.afterSave(entity);
+            entityDescriptor.afterSave(entity);
         } finally {
             watch.submitMicroTiming("MIXING", "AferSave - " + ed.getName());
         }
@@ -240,20 +240,20 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
      * Creates a new entity in the underlying database.
      *
      * @param entity the entity to create
-     * @param ed     the descriptor of the entity
+     * @param entityDescriptor     the descriptor of the entity
      * @throws Exception in case of an database error
      */
-    protected abstract void createEntity(B entity, EntityDescriptor ed) throws Exception;
+    protected abstract void createEntity(B entity, EntityDescriptor entityDescriptor) throws Exception;
 
     /**
      * Updates an existing entity in the underlying database.
      *
      * @param entity the entity to update
      * @param force  <tt>ture</tt> if the update is forced and optimistic locking must be disabled
-     * @param ed     the descriptor of the entity
+     * @param entityDescriptor     the descriptor of the entity
      * @throws Exception in case of an database error
      */
-    protected abstract void updateEntity(B entity, boolean force, EntityDescriptor ed) throws Exception;
+    protected abstract void updateEntity(B entity, boolean force, EntityDescriptor entityDescriptor) throws Exception;
 
     /**
      * Deletes the given entity from the database.
@@ -308,11 +308,11 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         }
 
         try {
-            EntityDescriptor ed = entity.getDescriptor();
-            invokeBeforeDeleteHandlers(entity, ed);
+            EntityDescriptor entityDescriptor = entity.getDescriptor();
+            invokeBeforeDeleteHandlers(entity, entityDescriptor);
             if (TaskContext.get().isActive()) {
-                deleteEntity(entity, force, ed);
-                invokeAfterDeleteHandlers(entity, ed);
+                deleteEntity(entity, force, entityDescriptor);
+                invokeAfterDeleteHandlers(entity, entityDescriptor);
             }
         } catch (OptimisticLockException e) {
             throw e;
@@ -327,19 +327,19 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
         }
     }
 
-    private <E extends B> void invokeBeforeDeleteHandlers(E entity, EntityDescriptor ed) {
+    private <E extends B> void invokeBeforeDeleteHandlers(E entity, EntityDescriptor entityDescriptor) {
         Watch watch = Watch.start();
         try {
-            ed.beforeDelete(entity);
+            entityDescriptor.beforeDelete(entity);
         } finally {
             watch.submitMicroTiming("MIXING", "BeforeDelete - " + ed.getName());
         }
     }
 
-    private <E extends B> void invokeAfterDeleteHandlers(E entity, EntityDescriptor ed) {
+    private <E extends B> void invokeAfterDeleteHandlers(E entity, EntityDescriptor entityDescriptor) {
         Watch watch = Watch.start();
         try {
-            ed.afterDelete(entity);
+            entityDescriptor.afterDelete(entity);
         } finally {
             watch.submitMicroTiming("MIXING", "AfterDelete - " + ed.getName());
         }
@@ -350,10 +350,10 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
      *
      * @param entity the entity to delete
      * @param force  <tt>true</tt> if the delete is forced and optimistic locking must be disabled
-     * @param ed     the descriptor of the entity
+     * @param entityDescriptor     the descriptor of the entity
      * @throws Exception in case of an database error
      */
-    protected abstract void deleteEntity(B entity, boolean force, EntityDescriptor ed) throws Exception;
+    protected abstract void deleteEntity(B entity, boolean force, EntityDescriptor entityDescriptor) throws Exception;
 
     /**
      * Determines if the given entity has validation warnings.
@@ -366,8 +366,8 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
             return false;
         }
 
-        EntityDescriptor ed = entity.getDescriptor();
-        return ed.hasValidationWarnings(entity);
+        EntityDescriptor entityDescriptor = entity.getDescriptor();
+        return entityDescriptor.hasValidationWarnings(entity);
     }
 
     /**
@@ -381,8 +381,8 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
             return Collections.emptyList();
         }
 
-        EntityDescriptor ed = entity.getDescriptor();
-        return ed.validate(entity);
+        EntityDescriptor entityDescriptor = entity.getDescriptor();
+        return entityDescriptor.validate(entity);
     }
 
     /**
@@ -410,8 +410,8 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
                                 .handle();
             }
 
-            EntityDescriptor ed = mixing.getDescriptor(type);
-            return findEntity(id, ed, makeContext(info));
+            EntityDescriptor entityDescriptor = mixing.getDescriptor(type);
+            return findEntity(id, entityDescriptor, makeContext(info));
         } catch (HandledException e) {
             throw e;
         } catch (Exception e) {
@@ -453,7 +453,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
      * Tries to find the entity with the given id.
      *
      * @param id      the id of the entity to find
-     * @param ed      the descriptor of the entity to find
+     * @param entityDescriptor      the descriptor of the entity to find
      * @param context the advanced search context which can be populated using {@link ContextInfo} in
      *                {@link #find(Class, Object, ContextInfo...)}
      * @param <E>     the effective type of the entity
@@ -461,7 +461,7 @@ public abstract class BaseMapper<B extends BaseEntity<?>, C extends Constraint, 
      * @throws Exception in case of a database error
      */
     protected abstract <E extends B> Optional<E> findEntity(Object id,
-                                                            EntityDescriptor ed,
+                                                            EntityDescriptor entityDescriptor,
                                                             Function<String, Value> context) throws Exception;
 
     /**

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -549,7 +549,7 @@ public class Finder extends QueryBuilder<Finder> {
                 mongo.secondaryCallDuration.addValue(callDuration);
             }
             if (Microtiming.isEnabled()) {
-                watch.submitMicroTiming(KEY_MONGO, "FACETS - " + collection + "): " + filterObject.keySet());
+                watch.submitMicroTiming(KEY_MONGO, "FACETS - " + collection + ": " + filterObject.keySet());
             }
             traceIfRequired("facets-" + collection, watch);
         }

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -312,6 +312,7 @@ public class Finder extends QueryBuilder<Finder> {
         Watch watch = Watch.start();
         TaskContext taskContext = TaskContext.get();
         Monoflop shouldHandleTracing = Monoflop.create();
+
         for (Document doc : cursor) {
             if (shouldHandleTracing.firstCall()) {
                 handleTracingAndReporting(collection, watch);
@@ -321,6 +322,13 @@ public class Finder extends QueryBuilder<Finder> {
             if (!keepGoing || !taskContext.isActive()) {
                 return;
             }
+        }
+
+        // If we didn't log any tracing data up until now, the result was completely empty and
+        // we can (and should) safely log now - otherwise some entries might be missing in
+        // the Microtiming...
+        if (shouldHandleTracing.firstCall()) {
+            handleTracingAndReporting(collection, watch);
         }
     }
 


### PR DESCRIPTION
* Unsuccessful mongo queries didn't log a microtiming, this has been fixed.
* BeforeSave/AfterSave/BeforeDelete/AfterDelete handlers now submit microtimings as these might massively contribute to the save duration of an entity.