### PR TITLE
Avoids idempotent Schema Change when @Length annotation is missing on a string field

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
@@ -287,6 +287,9 @@ public abstract class BasicDatabaseDialect implements DatabaseDialect {
         if (!areTypesEqual(Types.CHAR, target.getType())) {
             return true;
         }
+        if (target.getLength() == 0) {
+            return true;
+        }
 
         return Strings.areEqual(target.getLength(), current.getLength());
     }

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -610,7 +610,7 @@ public abstract class Property extends Composable {
      * Converts the given value, which is read from an import (e.g. an Excel import) into the target type of this
      * property.
      * <p>
-     * By default, this will use the logic provided by {@link #transformValue(Value)} but cen be overwritten by
+     * By default, this will use the logic provided by {@link #transformValue(Value)} but can be overwritten by
      * properties.
      *
      * @param value the value to convert


### PR DESCRIPTION
Avoid a schema change when the @Length annotation is missing

Before, the schema tool tried to adjust the column width to 0 (which is the default value when no @Length is present), but defaulted to length = 255 when creating the change query.
This made the schema change execute successful, but re-appear (because it actually did nothing)

