### PR TITLE
Allow row values in OMA-SQL Queries and improve the iterate blockwise with them

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -305,22 +305,22 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         }
 
         // create and install the filter
-        Object[] lhs = new Object[query.orderBys.size()];
-        Object[] rhs = new Object[query.orderBys.size()];
+        Object[] leftHandSide = new Object[query.orderBys.size()];
+        Object[] rightHandSide = new Object[query.orderBys.size()];
         for (int i = 0; i < query.orderBys.size(); i++) {
             Mapping mapping = query.orderBys.get(i).getFirst();
             Object value = lastValue.getDescriptor().getProperty(mapping).getValue(lastValue);
             if (query.orderBys.get(i).getSecond().booleanValue()) {
                 // the order by is ascending -> COLUMN > lastvalue.column
-                lhs[i] = mapping;
-                rhs[i] = value;
+                leftHandSide[i] = mapping;
+                rightHandSide[i] = value;
             } else {
                 // lastvalue.column > COLUMN
-                rhs[i] = mapping;
-                lhs[i] = value;
+                rightHandSide[i] = mapping;
+                leftHandSide[i] = value;
             }
         }
-        return query.where(OMA.FILTERS.gt(new RowValue(lhs), new RowValue(rhs)));
+        return query.where(OMA.FILTERS.gt(new RowValue(leftHandSide), new RowValue(rightHandSide)));
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -8,7 +8,9 @@
 
 package sirius.db.jdbc;
 
+import sirius.db.jdbc.constraints.RowValue;
 import sirius.db.jdbc.constraints.SQLConstraint;
+import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
@@ -22,6 +24,7 @@ import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Timeout;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
+import sirius.kernel.commons.ValueHolder;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
@@ -44,7 +47,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -239,9 +241,13 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * processing. If a timeout ({@link #queryIterateTimeout} is reached, we stop iterating, discard the result set
      * and emit another query which starts just where the previous query stopped.
      * <p>
-     * Note however, as we either do this by ID or by setting an appropriate LIMIT range, there is a possibility,
-     * that we either miss an entity or even process an entity twice if a concurrent modification happens, which
-     * then changes the result set of this query.
+     * While we try hard to keep the result consistent, there is no way to guarantee this. There is a possibility,
+     * that we either miss an entity or even process an entity twice if a concurrent modification happens. Basically,
+     * you might get <a href="https://en.wikipedia.org/wiki/Isolation_(database_systems)#Non-repeatable_reads">
+     * non-repeatable reads</a> or <a href="https://en.wikipedia.org/wiki/Isolation_(database_systems)#Phantom_reads">
+     * phantom reads</a>.
+     * <p>
+     * Performance wise, it helps a lot if there are indices on any fields used for {@link #orderAsc(Mapping) ordering}.
      *
      * @param handler the handler to be invoked for each item in the result. Should return <tt>true</tt>
      *                to continue processing or <tt>false</tt> to abort processing of the result set.
@@ -250,10 +256,32 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         if (forceFail) {
             return;
         }
-        if (orderBys.isEmpty()) {
-            iterateBlockwiseById(handler);
-        } else {
-            iterateBlockwiseByPaging(handler);
+
+        // make sure we got a total order
+        orderAsc(BaseEntity.ID);
+
+        ValueHolder<E> lastValue = ValueHolder.of(null);
+
+        AtomicBoolean keepGoing = new AtomicBoolean(true);
+        TaskContext context = TaskContext.get();
+        while (keepGoing.get() && context.isActive()) {
+            keepGoing.set(false);
+            Timeout timeout = new Timeout(queryIterateTimeout);
+            pagingGreaterThanLastValue(lastValue.get(), copy()).iterate(entity -> {
+                if (!handler.test(entity)) {
+                    // As soon as the handler returns false, we're done and can abort entirely...
+                    return false;
+                }
+
+                if (timeout.isReached()) {
+                    // We abort this result set to avoid a hard timeout, but we keep going with another query
+                    lastValue.set(entity);
+                    keepGoing.set(true);
+                    return false;
+                }
+
+                return true;
+            });
         }
     }
 
@@ -270,82 +298,29 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         });
     }
 
-    /**
-     * Provides a blockwise strategy based on the {@link SQLEntity#ID} of the entities.
-     * <p>
-     * If there are no ORDER BY clauses present, we can sort by ID and remember the last processed ID before
-     * attempting another query.
-     *
-     * @param handler the handler to be invoked for each item in the result. Should return <tt>true</tt>
-     *                to continue processing or <tt>false</tt> to abort processing of the result set.
-     */
-    private void iterateBlockwiseById(Predicate<E> handler) {
-        AtomicLong lastId = new AtomicLong(-1);
-        AtomicBoolean keepGoing = new AtomicBoolean(true);
-        TaskContext context = TaskContext.get();
-        while (keepGoing.get() && context.isActive()) {
-            keepGoing.set(false);
-            Timeout timeout = new Timeout(queryIterateTimeout);
-
-            // Creates a copy and start processing results just after the results we have processed with the
-            // previous query...
-            copy().orderAsc(SQLEntity.ID).where(OMA.FILTERS.gt(SQLEntity.ID, lastId.get())).iterate(entity -> {
-                if (!handler.test(entity)) {
-                    // As soon as the handler returns false, we're done and can abort entirely...
-                    return false;
-                }
-
-                if (timeout.isReached()) {
-                    // If the timeout is reached, we set a flag so that another query will be attempted....
-                    keepGoing.set(true);
-                    // We remember the ID of the last processed entity, so that the query starts right after
-                    // this one...
-                    lastId.set(entity.getId());
-                    // Abort local processing so that another result set is opened.
-                    return false;
-                }
-
-                // Timeout not reached yet, continue processing results...
-                return true;
-            });
+    private SmartQuery<E> pagingGreaterThanLastValue(E lastValue, SmartQuery<E> query) {
+        // no last value => we query everything
+        if (lastValue == null) {
+            return query;
         }
-    }
 
-    /**
-     * Provides a blockwise strategy based on the LIMIT range.
-     * <p>
-     * If ORDER BY clauses are present, we have to employ a sliding window technique.
-     *
-     * @param handler the handler to be invoked for each item in the result. Should return <tt>true</tt>
-     *                to continue processing or <tt>false</tt> to abort processing of the result set.
-     */
-    private void iterateBlockwiseByPaging(Predicate<E> handler) {
-        // Contains the counter of already processed entities. These have to be skipped when emitting the
-        // next query...
-        AtomicInteger skipCounter = new AtomicInteger(0);
-        AtomicBoolean keepGoing = new AtomicBoolean(true);
-        TaskContext context = TaskContext.get();
-        while (keepGoing.get() && context.isActive()) {
-            keepGoing.set(false);
-            Timeout timeout = new Timeout(queryIterateTimeout);
-            // Create a copy of the query an install an appropriate skip value...
-            copy().skip(skipCounter.get()).iterate(entity -> {
-                if (!handler.test(entity)) {
-                    // As soon as the handler returns false, we're done and can abort entirely...
-                    return false;
-                }
-
-                // Remember the processed entity...
-                skipCounter.incrementAndGet();
-
-                if (timeout.isReached()) {
-                    keepGoing.set(true);
-                    return false;
-                }
-
-                return true;
-            });
+        // create and install the filter
+        Object[] lhs = new Object[query.orderBys.size()];
+        Object[] rhs = new Object[query.orderBys.size()];
+        for (int i = 0; i < query.orderBys.size(); i++) {
+            Mapping mapping = query.orderBys.get(i).getFirst();
+            Object value = lastValue.getDescriptor().getProperty(mapping).getValue(lastValue);
+            if (query.orderBys.get(i).getSecond().booleanValue()) {
+                // the order by is ascending -> COLUMN > lastvalue.column
+                lhs[i] = mapping;
+                rhs[i] = value;
+            } else {
+                // lastvalue.column > COLUMN
+                rhs[i] = mapping;
+                lhs[i] = value;
+            }
         }
+        return query.where(OMA.FILTERS.gt(new RowValue(lhs), new RowValue(rhs)));
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/constraints/FieldOperator.java
+++ b/src/main/java/sirius/db/jdbc/constraints/FieldOperator.java
@@ -19,27 +19,27 @@ import java.util.List;
  */
 class FieldOperator extends SQLConstraint {
 
-    private final RowValue lhs;
-    private final RowValue rhs;
-    private final String op;
+    private final RowValue leftHandSide;
+    private final RowValue rightHandSide;
+    private final String operator;
 
-    protected FieldOperator(RowValue lhs, String op, RowValue rhs) {
-        this.lhs = lhs;
-        this.op = op;
-        this.rhs = rhs;
+    protected FieldOperator(RowValue leftHandSide, String operator, RowValue rightHandSide) {
+        this.leftHandSide = leftHandSide;
+        this.operator = operator;
+        this.rightHandSide = rightHandSide;
     }
 
     @Override
     public void appendSQL(SmartQuery.Compiler compiler) {
-        Tuple<String, List<Object>> compiledLhs = lhs.compileExpression(compiler);
-        Tuple<String, List<Object>> compiledRhs = rhs.compileExpression(compiler);
-        compiler.getWHEREBuilder().append(Strings.join(" ", compiledLhs.getFirst(), op, compiledRhs.getFirst()));
+        Tuple<String, List<Object>> compiledLhs = leftHandSide.compileExpression(compiler);
+        Tuple<String, List<Object>> compiledRhs = rightHandSide.compileExpression(compiler);
+        compiler.getWHEREBuilder().append(Strings.join(" ", compiledLhs.getFirst(), operator, compiledRhs.getFirst()));
         compiledLhs.getSecond().forEach(compiler::addParameter);
         compiledRhs.getSecond().forEach(compiler::addParameter);
     }
 
     @Override
     public void asString(StringBuilder builder) {
-        builder.append(Strings.join(" ", lhs.toString(), op, rhs.toString()));
+        builder.append(Strings.join(" ", leftHandSide.toString(), operator, rightHandSide.toString()));
     }
 }

--- a/src/main/java/sirius/db/jdbc/constraints/RowValue.java
+++ b/src/main/java/sirius/db/jdbc/constraints/RowValue.java
@@ -1,0 +1,80 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc.constraints;
+
+import sirius.db.jdbc.SmartQuery;
+import sirius.db.mixing.Mapping;
+import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An n-tuple of normal values that can be used in the OMA {@link sirius.db.jdbc.OMA#FILTERS filters}.
+ * <p>
+ * Use {@link Mapping} objects to indicate a column; every other object will be treated as an actual value.
+ * Usage example:<br>
+ * {@code
+ * oma.select(Entity.class).where(OMA.FILTERS.gte(new RowValue(Entity.COLUMN1, Entity.COLUMN2), new RowValue(4, "Test")))
+ * }
+ * <br>will compile to<br>
+ * {@code
+ * SELECT * FROM Entity e1 WHERE (e1.column1, e2.column2) >= (4, "Test")
+ * }
+ */
+public class RowValue {
+    private final Object[] objects;
+
+    /**
+     * Construct a row value from its contents.
+     *
+     * @param objects an array of {@link Mapping mappings} and values.
+     */
+    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
+    @Explain("It is not much of a deal to use a varargs array")
+    public RowValue(Object... objects) {
+        this.objects = objects;
+    }
+
+    /**
+     * Compiles the expression to the string representation.
+     *
+     * @param compiler the compiler to use.
+     * @return a tuple containing the SQL string and the required parameters for the prepared statement.
+     */
+    public Tuple<String, List<Object>> compileExpression(SmartQuery.Compiler compiler) {
+        List<String> sqlRepresentation = new ArrayList<>();
+        List<Object> parameter = new ArrayList<>();
+        for (Object object : objects) {
+            if (object instanceof Mapping) {
+                sqlRepresentation.add(compiler.translateColumnName((Mapping) object));
+            } else {
+                sqlRepresentation.add("?");
+                parameter.add(object);
+            }
+        }
+        if (objects.length == 1) {
+            return Tuple.create(sqlRepresentation.get(0), parameter);
+        }
+        return Tuple.create("(" + Strings.join(sqlRepresentation, ", ") + ")", parameter);
+    }
+
+    @Override
+    public String toString() {
+        if (objects.length == 1) {
+            return Objects.toString(objects[0]);
+        }
+        return "(" + Arrays.stream(objects).map(Objects::toString).collect(Collectors.joining(", ")) + ")";
+    }
+}

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -36,14 +36,14 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     }
 
     /**
-     * Represents {@code lhs = rhs} as constraint
+     * Represents {@code leftHandSide = rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint eq(RowValue lhs, RowValue rhs) {
-        return new FieldOperator(lhs, "=", rhs);
+    public SQLConstraint eq(RowValue leftHandSide, RowValue rightHandSide) {
+        return new FieldOperator(leftHandSide, "=", rightHandSide);
     }
 
     @Override
@@ -52,14 +52,14 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     }
 
     /**
-     * Represents {@code lhs <> rhs} as constraint
+     * Represents {@code leftHandSide <> rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint ne(RowValue lhs, RowValue rhs) {
-        return new FieldOperator(lhs, "<>", rhs);
+    public SQLConstraint ne(RowValue leftHandSide, RowValue rightHandSide) {
+        return new FieldOperator(leftHandSide, "<>", rightHandSide);
     }
 
     @Override
@@ -68,29 +68,29 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     }
 
     /**
-     * Represents {@code lhs > rhs} as constraint
+     * Represents {@code leftHandSide > rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint gt(RowValue lhs, RowValue rhs) {
-        return gt(lhs, rhs, false);
+    public SQLConstraint gt(RowValue leftHandSide, RowValue rightHandSide) {
+        return gt(leftHandSide, rightHandSide, false);
     }
 
     /**
-     * Represents {@code lhs >= rhs} as constraint
+     * Represents {@code leftHandSide >= rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint gte(RowValue lhs, RowValue rhs) {
-        return gt(lhs, rhs, true);
+    public SQLConstraint gte(RowValue leftHandSide, RowValue rightHandSide) {
+        return gt(leftHandSide, rightHandSide, true);
     }
 
-    protected SQLConstraint gt(RowValue lhs, RowValue rhs, boolean orEqual) {
-        return new FieldOperator(lhs, orEqual ? ">=" : ">", rhs);
+    protected SQLConstraint gt(RowValue leftHandSide, RowValue rightHandSide, boolean orEqual) {
+        return new FieldOperator(leftHandSide, orEqual ? ">=" : ">", rightHandSide);
     }
 
     @Override
@@ -99,29 +99,29 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
     }
 
     /**
-     * Represents {@code lhs < rhs} as constraint
+     * Represents {@code leftHandSide < rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint lt(RowValue lhs, RowValue rhs) {
-        return lt(lhs, rhs, false);
+    public SQLConstraint lt(RowValue leftHandSide, RowValue rightHandSide) {
+        return lt(leftHandSide, rightHandSide, false);
     }
 
     /**
-     * Represents {@code lhs <= rhs} as constraint
+     * Represents {@code leftHandSide <= rightHandSide} as constraint
      *
-     * @param lhs the first row value
-     * @param rhs the second row value
+     * @param leftHandSide  the first row value
+     * @param rightHandSide the second row value
      * @return the generated constraint
      */
-    public SQLConstraint lte(RowValue lhs, RowValue rhs) {
-        return lt(lhs, rhs, true);
+    public SQLConstraint lte(RowValue leftHandSide, RowValue rightHandSide) {
+        return lt(leftHandSide, rightHandSide, true);
     }
 
-    protected SQLConstraint lt(RowValue lhs, RowValue rhs, boolean orEqual) {
-        return new FieldOperator(lhs, orEqual ? "<=" : "<", rhs);
+    protected SQLConstraint lt(RowValue leftHandSide, RowValue rightHandSide, boolean orEqual) {
+        return new FieldOperator(leftHandSide, orEqual ? "<=" : "<", rightHandSide);
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -32,22 +32,96 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
 
     @Override
     protected SQLConstraint eqValue(Mapping field, Object value) {
-        return new FieldOperator(field, "=", value);
+        return eq(new RowValue(field), new RowValue(value));
+    }
+
+    /**
+     * Represents {@code lhs = rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint eq(RowValue lhs, RowValue rhs) {
+        return new FieldOperator(lhs, "=", rhs);
     }
 
     @Override
     protected SQLConstraint neValue(Mapping field, Object value) {
-        return new FieldOperator(field, "<>", value);
+        return ne(new RowValue(field), new RowValue(value));
+    }
+
+    /**
+     * Represents {@code lhs <> rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint ne(RowValue lhs, RowValue rhs) {
+        return new FieldOperator(lhs, "<>", rhs);
     }
 
     @Override
     protected SQLConstraint gtValue(Mapping field, Object value, boolean orEqual) {
-        return new FieldOperator(field, orEqual ? ">=" : ">", value);
+        return gt(new RowValue(field), new RowValue(value), orEqual);
+    }
+
+    /**
+     * Represents {@code lhs > rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint gt(RowValue lhs, RowValue rhs) {
+        return gt(lhs, rhs, false);
+    }
+
+    /**
+     * Represents {@code lhs >= rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint gte(RowValue lhs, RowValue rhs) {
+        return gt(lhs, rhs, true);
+    }
+
+    protected SQLConstraint gt(RowValue lhs, RowValue rhs, boolean orEqual) {
+        return new FieldOperator(lhs, orEqual ? ">=" : ">", rhs);
     }
 
     @Override
     protected SQLConstraint ltValue(Mapping field, Object value, boolean orEqual) {
-        return new FieldOperator(field, orEqual ? "<=" : "<", value);
+        return lt(new RowValue(field), new RowValue(value), orEqual);
+    }
+
+    /**
+     * Represents {@code lhs < rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint lt(RowValue lhs, RowValue rhs) {
+        return lt(lhs, rhs, false);
+    }
+
+    /**
+     * Represents {@code lhs <= rhs} as constraint
+     *
+     * @param lhs the first row value
+     * @param rhs the second row value
+     * @return the generated constraint
+     */
+    public SQLConstraint lte(RowValue lhs, RowValue rhs) {
+        return lt(lhs, rhs, true);
+    }
+
+    protected SQLConstraint lt(RowValue lhs, RowValue rhs, boolean orEqual) {
+        return new FieldOperator(lhs, orEqual ? "<=" : "<", rhs);
     }
 
     @Override


### PR DESCRIPTION
SIRI-357

# Improve the iterate blockwise using row values

The skip/limit construct is implemented rather slow in the database.
Because we know the value sorted right above the one we want to continue with, we can instead use this value, in conjunction with a total ordering to remove the entities already read from the result set.
This can result in a significant speedup, especially if you have the right indices, and even more so when there are expensive joins involved.

To implement this without too much hassle, we need the ability to use row values:

# Allow the usage of row values in sql constraints

A row value is what you'd call a tuple, and you can use it in SQL constraints like so:
```
... WHERE (column1, column2) > (5, "foo") ...
```
which is equivalent to
```
... WHERE column1 > 5 OR (column1 = 5 AND column2 > "foo") ...
```

A RowValue entity can contain both values and mappings, and you can also mix them.
As a drive-by, you can now also use them to compare columns with each other:
```
oma.select(Foo.class).where(OMA.FILTERS.eq(new RowValue(Foo.COLUMN1), new RowValue(Foo.COLUMN2)))
```
compiling to
```
... WHERE column1 = column2 ...
```
which might help with some more involved queries
