### PR TITLE
Allows to use a script source as a query score

### DIFF
--- a/src/main/java/sirius/db/es/FunctionScoreBuilder.java
+++ b/src/main/java/sirius/db/es/FunctionScoreBuilder.java
@@ -77,10 +77,7 @@ public class FunctionScoreBuilder {
      * @return the builder itself for fluent method calls
      */
     public FunctionScoreBuilder script(String script) {
-        return function(new JSONObject().fluentPut("script_score",
-                                                   new JSONObject().fluentPut("script",
-                                                                              new JSONObject().fluentPut("source",
-                                                                                                         script))));
+        return function(new ScriptScoreBuilder().source(script).build());
     }
 
     /**

--- a/src/main/java/sirius/db/es/ScriptScoreBuilder.java
+++ b/src/main/java/sirius/db/es/ScriptScoreBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.es;
+
+import com.alibaba.fastjson.JSONObject;
+import sirius.kernel.commons.Strings;
+
+/**
+ * Helper class which generates a script score query for elasticsearch which can be used via
+ * {@link ElasticQuery#scriptScore(ScriptScoreBuilder)}.
+ */
+public class ScriptScoreBuilder {
+
+    private static final String SCRIPT_SCORE = "script_score";
+    private static final String FIELD_QUERY = "query";
+    private static final String FIELD_SCRIPT = "script";
+    private static final String FIELD_SOURCE = "source";
+
+    private String source;
+
+    /**
+     * Adds a script function which uses the given script to return the score to use.
+     *
+     * @param source the script source as string
+     * @return the builder itself for fluent method calls
+     */
+    public ScriptScoreBuilder source(String source) {
+        this.source = source;
+        return this;
+    }
+
+    /**
+     * Adds a random score source with the given start seed.
+     *
+     * @param startSeed the field to read
+     * @return the builder itself for fluent method calls
+     */
+    public ScriptScoreBuilder randomScore(int startSeed) {
+        return source(Strings.apply("randomScore(%s)", startSeed));
+    }
+
+    /**
+     * Applies the given query to the function score query and returns the newly created query.
+     *
+     * @param query the query to apply
+     * @return the function score query as {@link JSONObject}
+     */
+    public JSONObject apply(JSONObject query) {
+        return new JSONObject().fluentPut(SCRIPT_SCORE,
+                                          new JSONObject().fluentPut(FIELD_QUERY, query)
+                                                          .fluentPut(FIELD_SCRIPT,
+                                                                     new JSONObject().fluentPut(FIELD_SOURCE, source)));
+    }
+
+    /**
+     * Builds the function score query.
+     *
+     * @return the function score query as {@link JSONObject}
+     */
+    public JSONObject build() {
+        return new JSONObject().fluentPut(SCRIPT_SCORE,
+                                          new JSONObject().fluentPut(FIELD_SCRIPT,
+                                                                     new JSONObject().fluentPut(FIELD_SOURCE, source)));
+    }
+
+    /**
+     * Generates a copy of this function score builder to support {@link ElasticQuery#copy()}.
+     *
+     * @return a copy of this builder
+     */
+    public ScriptScoreBuilder copy() {
+        ScriptScoreBuilder copy = new ScriptScoreBuilder();
+        copy.source = source;
+        return copy;
+    }
+}

--- a/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
@@ -380,6 +380,35 @@ class ElasticQuerySpec extends BaseSpecification {
         Doubles.areEqual(entities.get(29).getScore(), 0d)
     }
 
+    def "script score works"() {
+        when:
+        for (int i = 1; i <= 30; i++) {
+            QueryTestEntity entity = new QueryTestEntity()
+            entity.setValue("SCRIPTSCORE")
+            entity.setCounter(i)
+            elastic.update(entity)
+        }
+        elastic.refresh(QueryTestEntity.class)
+        def scriptScore = new ScriptScoreBuilder().source("doc['counter'].value * 10")
+        and:
+        def query = elastic.select(QueryTestEntity.class)
+                           .eq(QueryTestEntity.VALUE, "SCRIPTSCORE")
+                           .scriptScore(scriptScore)
+                           .orderByScoreDesc()
+        and:
+        def entities = query.queryList()
+        then:
+        entities.size() == 30
+        and:
+        Doubles.areEqual(entities.get(0).getScore(), 300d)
+        and:
+        Doubles.areEqual(entities.get(9).getScore(), 210d)
+        and:
+        Doubles.areEqual(entities.get(19).getScore(), 110d)
+        and:
+        Doubles.areEqual(entities.get(29).getScore(), 10d)
+    }
+
     @Scope(Scope.SCOPE_NIGHTLY)
     def "selecting over 1000 entities in queryList throws an exception"() {
         given:


### PR DESCRIPTION
Previously only a complex function score was possible (which most of the time means all query fields need to be scored as well to get a score other than 0). This basically implements https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html which is a simple way of scoring the results of a query by a Plainless script. A common use case is "sorting" a query by random so we also provide a small helper function for that.

Generated sample query:
```
{
  "query": {
    "script_score": {
      "script": {
        "source": "randomScore(1)"
      },
      "query": { <filter_constraints> }
  }
}
```