### PR TITLE
Prevents SQLSyntaxErrorException thrown as a result of `SmartQuery#count` and `SmartQuery#fields` combination

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -808,11 +808,18 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         Compiler c = new Compiler(descriptor);
         c.getSELECTBuilder().append("SELECT COUNT(");
 
-        if (!fields.isEmpty() && distinct) {
-            c.getSELECTBuilder().append("DISTINCT ");
-            appendFieldList(c, false);
-        } else if (fields.stream().count() == 1) {
-            appendFieldList(c, false);
+        if (fields.size() > 1) {
+            if (distinct) {
+                c.getSELECTBuilder().append("DISTINCT ");
+                appendFieldList(c, false);
+            } else {
+                throw Exceptions.createHandled()
+                                .to(OMA.LOG)
+                                .withSystemErrorMessage(
+                                        "Only use multiple arguments in 'fields' and 'count' in "
+                                        + "combination with the 'distinct' statement")
+                                .handle();
+            }
         } else {
             c.getSELECTBuilder().append("*");
         }

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -806,16 +806,18 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
 
     private Compiler selectCount() {
         Compiler c = new Compiler(descriptor);
-        if (!fields.isEmpty()) {
-            c.getSELECTBuilder().append("SELECT COUNT(");
-            if (distinct) {
-                c.getSELECTBuilder().append("DISTINCT");
-            }
+        c.getSELECTBuilder().append("SELECT COUNT(");
+
+        if (!fields.isEmpty() && distinct) {
+            c.getSELECTBuilder().append("DISTINCT ");
             appendFieldList(c, false);
-            c.getSELECTBuilder().append(")");
+        } else if (fields.stream().count() == 1) {
+            appendFieldList(c, false);
         } else {
-            c.getSELECTBuilder().append("SELECT COUNT(*)");
+            c.getSELECTBuilder().append("*");
         }
+
+        c.getSELECTBuilder().append(")");
         return c;
     }
 


### PR DESCRIPTION
`COUNT` won't take multiple arguments unless it's a `COUNT(DISTINCT ...)` expression. Multiple fields in combination with `SmartQuery#count` will now result in `COUNT(*)` to prevent a SQLSyntaxErrorException.