### PR TITLE
BREAKING: Gives all primitive number properties a default value of 0

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -97,7 +97,7 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
     protected void determineDefaultValue() {
         super.determineDefaultValue();
         if (defaultValue == null && field.getType().isPrimitive()) {
-            this.defaultValue = "false";
+            this.defaultValue = "0";
         }
     }
 

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -78,7 +78,7 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
             return object;
         }
 
-        if (data.is(String.class) ) {
+        if (data.is(String.class)) {
             return data.asBoolean();
         }
 
@@ -95,10 +95,9 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
 
     @Override
     protected void determineDefaultValue() {
-        if (field.getType().isPrimitive()) {
-            this.defaultValue = "0";
-        } else {
-            super.determineDefaultValue();
+        super.determineDefaultValue();
+        if (defaultValue == null && field.getType().isPrimitive()) {
+            this.defaultValue = "false";
         }
     }
 

--- a/src/main/java/sirius/db/mixing/properties/NumberProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/NumberProperty.java
@@ -114,4 +114,12 @@ public abstract class NumberProperty extends Property {
         super.onBeforeSaveChecks(entity);
         assertValueIsInRange(Value.of(getValue(entity)).getAmount());
     }
+
+    @Override
+    protected void determineDefaultValue() {
+        super.determineDefaultValue();
+        if (defaultValue == null && field.getType().isPrimitive()) {
+            this.defaultValue = "0";
+        }
+    }
 }

--- a/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
@@ -20,6 +20,10 @@ public class MongoDefaultValuesEntity extends MongoEntity {
     public static final Mapping PRIMITIVE_INT = Mapping.named("primitiveint");
     private int primitiveInt;
 
+    public static final Mapping PRIMITIVE_INT_WITH_DEFAULT = Mapping.named("primitiveintWithDefault");
+    @DefaultValue("50")
+    private int primitiveIntWithDefault = 50;
+
     public boolean isPrimitiveBoolean() {
         return primitiveBoolean;
     }
@@ -34,5 +38,13 @@ public class MongoDefaultValuesEntity extends MongoEntity {
 
     public void setPrimitiveInt(int primitiveInt) {
         this.primitiveInt = primitiveInt;
+    }
+
+    public int getPrimitiveIntWithDefault() {
+        return primitiveIntWithDefault;
+    }
+
+    public void setPrimitiveIntWithDefault(int primitiveIntWithDefault) {
+        this.primitiveIntWithDefault = primitiveIntWithDefault;
     }
 }

--- a/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.mixing.annotations.DefaultValue;
+import sirius.db.mongo.MongoEntity;
+
+public class MongoDefaultValuesEntity extends MongoEntity {
+
+    public static final Mapping PRIMITIVE_BOOLEAN = Mapping.named("primitiveBoolean");
+    @DefaultValue("true")
+    private boolean primitiveBoolean = true;
+
+    public boolean isPrimitiveBoolean() {
+        return primitiveBoolean;
+    }
+
+    public void setPrimitiveBoolean(boolean primitiveBoolean) {
+        this.primitiveBoolean = primitiveBoolean;
+    }
+}

--- a/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
@@ -17,11 +17,22 @@ public class MongoDefaultValuesEntity extends MongoEntity {
     @DefaultValue("true")
     private boolean primitiveBoolean = true;
 
+    public static final Mapping PRIMITIVE_INT = Mapping.named("primitiveint");
+    private int primitiveInt;
+
     public boolean isPrimitiveBoolean() {
         return primitiveBoolean;
     }
 
     public void setPrimitiveBoolean(boolean primitiveBoolean) {
         this.primitiveBoolean = primitiveBoolean;
+    }
+
+    public int getPrimitiveInt() {
+        return primitiveInt;
+    }
+
+    public void setPrimitiveInt(int primitiveInt) {
+        this.primitiveInt = primitiveInt;
     }
 }

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -25,8 +25,20 @@ class DefaultValuesSpec extends BaseSpecification {
         and:
         MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
         when: // an empty value is given, its default (true) should be applied
-        property.parseValueFromImport(entity, Value.of(""))
+        property.parseValueFromImport(entity, Value.EMPTY)
         then:
         entity.isPrimitiveBoolean()
+    }
+
+    def "primitive number fields get an automatic default value"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveInt")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setPrimitiveInt(12)
+        when: // an empty value is given, its default (0) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getPrimitiveInt() == 0
     }
 }

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -41,4 +41,16 @@ class DefaultValuesSpec extends BaseSpecification {
         then:
         entity.getPrimitiveInt() == 0
     }
+
+    def "primitive number fields default value annotation works"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveIntWithDefault")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setPrimitiveIntWithDefault(12)
+        when: // an empty value is given, its default (50) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getPrimitiveIntWithDefault() == 50
+    }
 }

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing.properties
+
+import sirius.db.mixing.Mixing
+import sirius.db.mixing.MongoDefaultValuesEntity
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Value
+import sirius.kernel.di.std.Part
+
+class DefaultValuesSpec extends BaseSpecification {
+
+    @Part
+    private static Mixing mixing
+
+    def "default value works on primitive boolean"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveBoolean")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        when: // an empty value is given, its default (true) should be applied
+        property.parseValueFromImport(entity, Value.of(""))
+        then:
+        entity.isPrimitiveBoolean()
+    }
+}


### PR DESCRIPTION
As we can't mark a primitive field as empty until the beforeSave handler checks for nullability, we can't produce proper error messages - so we always give them a default value of 0 so they behave just like in the java language.
Although this could also be considered a bugfix, this is marked as BREAKING as some functionality might rely on the IllegalArgumentException being thrown.
Developers should look at all primitive number fields and change them to non-primitive non-nullable if they want an error to be thrown/shown when empty values are given.


Also includes a bugfix where default values on primitive boolean fields never worked.
