### PR TITLE
BREAKING: Gives all properties a default value determined by their initial value

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/TableColumn.java
+++ b/src/main/java/sirius/db/jdbc/schema/TableColumn.java
@@ -46,7 +46,7 @@ public class TableColumn {
         this.name = property.getPropertyName();
         this.nullable = property.isNullable();
         this.length = property.getLength();
-        this.defaultValue = property.getDefaultValue();
+        this.defaultValue = property.getColumnDefaultValue();
         this.type = sqlType;
 
         property.getAnnotation(Numeric.class).ifPresent(numeric -> {

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -158,16 +158,16 @@ public abstract class Property extends Composable {
     }
 
     /**
-     * Determines the default value of the property by checking for a {@link DefaultValue} annotation on the field, or its inital value.
+     * Determines the default value of the property by checking for a {@link DefaultValue} annotation on the field, or its initial value.
      */
     protected void determineDefaultValue() {
         DefaultValue dv = field.getAnnotation(DefaultValue.class);
         if (dv != null) {
             this.defaultValue = Value.of(transformValueFromImport(Value.of(dv.value())));
         } else {
-            Object initalValue = getValue(getDescriptor().getReferenceInstance());
-            if (!isConsideredNull(initalValue)) {
-                this.defaultValue = Value.of(initalValue);
+            Object initialValue = getValue(getDescriptor().getReferenceInstance());
+            if (!isConsideredNull(initialValue)) {
+                this.defaultValue = Value.of(initialValue);
             }
         }
     }

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -162,6 +162,11 @@ public abstract class Property extends Composable {
         DefaultValue dv = field.getAnnotation(DefaultValue.class);
         if (dv != null) {
             this.defaultValue = dv.value();
+        } else {
+            Object initalValue = getValue(getDescriptor().getReferenceInstance());
+            if (!isConsideredNull(initalValue)) {
+                this.defaultValue = Value.of(initalValue).asString();
+            }
         }
     }
 

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -90,10 +90,10 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
         if (value.isFilled()) {
             return NLS.parseUserString(Amount.class, value.asString());
         }
-        if (this.isNullable() || Strings.isEmpty(defaultValue)) {
+        if (this.isNullable() || defaultValue.isEmptyString()) {
             return Amount.NOTHING;
         }
-        return Value.of(defaultValue).getAmount();
+        return defaultValue.getAmount();
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -78,7 +78,7 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
             return object;
         }
 
-        if (data.is(String.class) ) {
+        if (data.is(String.class)) {
             return data.asBoolean();
         }
 
@@ -91,15 +91,6 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
         }
 
         return ((Integer) object) != 0;
-    }
-
-    @Override
-    protected void determineDefaultValue() {
-        if (field.getType().isPrimitive()) {
-            this.defaultValue = "0";
-        } else {
-            super.determineDefaultValue();
-        }
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -60,7 +60,7 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
 
     @Override
     public Object transformValue(Value value) {
-        if (defaultValue == null) {
+        if (defaultValue.isEmptyString()) {
             if (value.isNull() || value.isEmptyString()) {
                 return null;
             } else {
@@ -68,7 +68,7 @@ public class BooleanProperty extends Property implements ESPropertyInfo, SQLProp
             }
         }
 
-        return value.asBoolean(NLS.parseMachineString(Boolean.class, defaultValue));
+        return value.asBoolean(defaultValue.asBoolean());
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -69,10 +69,10 @@ public class EnumProperty extends Property implements SQLPropertyInfo, ESPropert
         if (value.isFilled()) {
             return value.asEnum((Class<Enum>) field.getType());
         }
-        if (this.isNullable() || Strings.isEmpty(defaultValue)) {
+        if (this.isNullable() || defaultValue.isEmptyString()) {
             return null;
         }
-        return Value.of(defaultValue).asEnum((Class<Enum>) field.getType());
+        return defaultValue.asEnum((Class<Enum>) field.getType());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
@@ -21,7 +21,6 @@ import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixable;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 
@@ -67,10 +66,10 @@ public class IntegerProperty extends NumberProperty implements SQLPropertyInfo, 
             }
             return result;
         }
-        if (this.isNullable() || Strings.isEmpty(defaultValue)) {
+        if (this.isNullable() || defaultValue.isEmptyString()) {
             return null;
         }
-        return Value.of(defaultValue).getInteger();
+        return defaultValue.getInteger();
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
@@ -57,6 +57,17 @@ public class LocalTimeProperty extends Property implements SQLPropertyInfo {
     }
 
     @Override
+    protected Object transformValueFromImport(Value value) {
+        if (value.is(LocalTime.class)) {
+            return value.get();
+        }
+        if (value.is(LocalDateTime.class)) {
+            return value.get(LocalDateTime.class, null).toLocalTime();
+        }
+        return NLS.parseMachineString(LocalTime.class, value.asString());
+    }
+
+    @Override
     public Object transformValue(Value value) {
         if (value.is(LocalTime.class)) {
             return value.get();

--- a/src/main/java/sirius/db/mixing/properties/LongProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LongProperty.java
@@ -67,10 +67,10 @@ public class LongProperty extends NumberProperty implements SQLPropertyInfo, ESP
             }
             return result;
         }
-        if (this.isNullable() || Strings.isEmpty(defaultValue)) {
+        if (this.isNullable() || defaultValue.isEmptyString()) {
             return null;
         }
-        return Value.of(defaultValue).getLong();
+        return defaultValue.getLong();
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/StringListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringListProperty.java
@@ -253,4 +253,10 @@ public class StringListProperty extends Property implements ESPropertyInfo, SQLP
             table.getColumns().add(new TableColumn(this, Types.CHAR));
         }
     }
+
+    @Override
+    public String getColumnDefaultValue() {
+        // not yet supported
+        return null;
+    }
 }

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -122,10 +122,10 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
         if (value.isFilled()) {
             return value.asString();
         }
-        if (this.isNullable() || Strings.isEmpty(defaultValue)) {
+        if (this.isNullable() || defaultValue.isEmptyString()) {
             return null;
         }
-        return defaultValue;
+        return defaultValue.asString();
     }
 
     @Override

--- a/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/MongoDefaultValuesEntity.java
@@ -1,0 +1,148 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.db.jdbc.DataTypesEntity;
+import sirius.db.mongo.MongoEntity;
+import sirius.kernel.commons.Amount;
+
+public class MongoDefaultValuesEntity extends MongoEntity {
+
+    public static final Mapping PRIMITIVE_BOOLEAN = Mapping.named("primitiveBoolean");
+    private boolean primitiveBoolean;
+
+    public static final Mapping PRIMITIVE_BOOLEAN_TRUE = Mapping.named("primitiveBooleanTrue");
+    private boolean primitiveBooleanTrue = true;
+
+    public static final Mapping BOOLEAN_OBJECT = Mapping.named("booleanObject");
+    private Boolean booleanObject;
+
+    public static final Mapping PRIMITIVE_INT = Mapping.named("primitiveInt");
+    private int primitiveInt;
+
+    public static final Mapping PRIMITIVE_INT_WITH_VALUE = Mapping.named("primitiveIntWithValue");
+    private int primitiveIntWithValue = 50;
+
+    public static final Mapping AMOUNT = Mapping.named("amount");
+    private Amount amount;
+
+    public static final Mapping AMOUNT_WITH_VALUE = Mapping.named("amountWithValue");
+    private Amount amountWithValue = Amount.ONE_HUNDRED;
+
+    public static final Mapping AMOUNT_ZERO = Mapping.named("amountZero");
+    private Amount amountZero = Amount.ZERO;
+
+    public static final Mapping AMOUNT_NOTHING = Mapping.named("amountNothing");
+    private Amount amountNothing = Amount.NOTHING;
+
+    public static final Mapping STRING = Mapping.named("string");
+    private String string;
+
+    public static final Mapping EMPTY_STRING = Mapping.named("emptyString");
+    private String emptyString = "";
+
+    public static final Mapping ENUM_WITH_VALUE = Mapping.named("enumWithValue");
+    private DataTypesEntity.TestEnum enumWithValue = DataTypesEntity.TestEnum.Test2;
+
+    public boolean isPrimitiveBoolean() {
+        return primitiveBoolean;
+    }
+
+    public void setPrimitiveBoolean(boolean primitiveBoolean) {
+        this.primitiveBoolean = primitiveBoolean;
+    }
+
+    public boolean isPrimitiveBooleanTrue() {
+        return primitiveBooleanTrue;
+    }
+
+    public void setPrimitiveBooleanTrue(boolean primitiveBooleanTrue) {
+        this.primitiveBooleanTrue = primitiveBooleanTrue;
+    }
+
+    public Boolean getBooleanObject() {
+        return booleanObject;
+    }
+
+    public void setBooleanObject(Boolean booleanObject) {
+        this.booleanObject = booleanObject;
+    }
+
+    public int getPrimitiveInt() {
+        return primitiveInt;
+    }
+
+    public void setPrimitiveInt(int primitiveInt) {
+        this.primitiveInt = primitiveInt;
+    }
+
+    public int getPrimitiveIntWithValue() {
+        return primitiveIntWithValue;
+    }
+
+    public void setPrimitiveIntWithValue(int primitiveIntWithValue) {
+        this.primitiveIntWithValue = primitiveIntWithValue;
+    }
+
+    public Amount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Amount amount) {
+        this.amount = amount;
+    }
+
+    public Amount getAmountWithValue() {
+        return amountWithValue;
+    }
+
+    public void setAmountWithValue(Amount amountWithValue) {
+        this.amountWithValue = amountWithValue;
+    }
+
+    public Amount getAmountZero() {
+        return amountZero;
+    }
+
+    public void setAmountZero(Amount amountZero) {
+        this.amountZero = amountZero;
+    }
+
+    public Amount getAmountNothing() {
+        return amountNothing;
+    }
+
+    public void setAmountNothing(Amount amountNothing) {
+        this.amountNothing = amountNothing;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    public String getEmptyString() {
+        return emptyString;
+    }
+
+    public void setEmptyString(String emptyString) {
+        this.emptyString = emptyString;
+    }
+
+    public DataTypesEntity.TestEnum getEnumWithValue() {
+        return enumWithValue;
+    }
+
+    public void setEnumWithValue(DataTypesEntity.TestEnum enumWithValue) {
+        this.enumWithValue = enumWithValue;
+    }
+}

--- a/src/test/java/sirius/db/mixing/SQLDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/SQLDefaultValuesEntity.java
@@ -9,10 +9,10 @@
 package sirius.db.mixing;
 
 import sirius.db.jdbc.DataTypesEntity;
-import sirius.db.mongo.MongoEntity;
+import sirius.db.jdbc.SQLEntity;
 import sirius.kernel.commons.Amount;
 
-public class MongoDefaultValuesEntity extends MongoEntity {
+public class SQLDefaultValuesEntity extends SQLEntity {
 
     public static final Mapping PRIMITIVE_BOOLEAN = Mapping.named("primitiveBoolean");
     private boolean primitiveBoolean;

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -1,0 +1,126 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing.properties
+
+import sirius.db.mixing.Mixing
+import sirius.db.mixing.MongoDefaultValuesEntity
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Amount
+import sirius.kernel.commons.Value
+import sirius.kernel.di.std.Part
+
+class DefaultValuesSpec extends BaseSpecification {
+
+    @Part
+    private static Mixing mixing
+
+    def "the default values are properly initialized"() {
+        expect:
+        mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty(propertyName).getDefaultValue() ==
+                excpectedDefault
+
+        where:
+        propertyName            | excpectedDefault
+        "primitiveBoolean"      | "false"
+        "primitiveBooleanTrue"  | "true"
+        "booleanObject"         | null
+        "primitiveInt"          | "0"
+        "primitiveIntWithValue" | "50"
+        "amount"                | null
+        "amountWithValue"       | "100.00"
+        "amountZero"            | "0.00"
+        "amountNothing"         | null
+        "string"                | null
+        "emptyString"           | ""
+        "enumWithValue"         | "Test2"
+    }
+
+    def "a primitive boolean with no default value annotation does not throw an error"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveBoolean")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setPrimitiveBoolean(true)
+        when: // an empty value is given, its default (false) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        !entity.isPrimitiveBoolean()
+    }
+
+    def "a primitive boolean gets its default value from its initial assigned value"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveBooleanTrue")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        when: // an empty value is given, its default (true) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.isPrimitiveBooleanTrue()
+    }
+
+    def "a boolean object field can have no default value"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("booleanObject")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setBooleanObject(Boolean.TRUE)
+        when: // an empty value is given, the field should reset to 'null'
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getBooleanObject() == null
+    }
+
+    def "primitive number fields get automatic default value from their initial default value"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveInt")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setPrimitiveInt(12)
+        when: // an empty value is given, its default (0) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getPrimitiveInt() == 0
+    }
+
+    def "primitive number fields get automatic default value from their initial assigned value"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveIntWithValue")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setPrimitiveIntWithValue(12)
+        when: // an empty value is given, its default (50) should be applied
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getPrimitiveIntWithValue() == 50
+    }
+
+    def "amount fields which are not initialized should reset to Amount.NOTHING"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("amount")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setAmount(Amount.of(12))
+        when:
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getAmount()== Amount.NOTHING
+    }
+
+    def "amount fields which are initialized with Amount.NOTHING should reset to Amount.NOTHING"() {
+        given:
+        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("amountNothing")
+        and:
+        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        entity.setAmountNothing(Amount.of(12))
+        when:
+        property.parseValueFromImport(entity, Value.EMPTY)
+        then:
+        entity.getAmountNothing()== Amount.NOTHING
+    }
+}

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -24,10 +24,10 @@ class DefaultValuesSpec extends BaseSpecification {
     def "the default values are properly initialized"() {
         expect:
         mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty(propertyName).getDefaultValue() ==
-                excpectedDefault
+                expectedDefault
 
         where:
-        propertyName            | excpectedDefault
+        propertyName            | expectedDefault
         "primitiveBoolean"      | Value.of(false)
         "primitiveBooleanTrue"  | Value.of(true)
         "booleanObject"         | Value.EMPTY
@@ -45,10 +45,10 @@ class DefaultValuesSpec extends BaseSpecification {
     def "column default values are properly transformed"() {
         expect:
         mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty(propertyName).getColumnDefaultValue() ==
-                excpectedDefault
+                expectedDefault
 
         where:
-        propertyName            | excpectedDefault
+        propertyName            | expectedDefault
         "primitiveBoolean"      | "0"
         "primitiveBooleanTrue"  | "1"
         "booleanObject"         | null

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -8,8 +8,9 @@
 
 package sirius.db.mixing.properties
 
+import sirius.db.jdbc.DataTypesEntity
 import sirius.db.mixing.Mixing
-import sirius.db.mixing.MongoDefaultValuesEntity
+import sirius.db.mixing.SQLDefaultValuesEntity
 import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Amount
 import sirius.kernel.commons.Value
@@ -22,30 +23,48 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "the default values are properly initialized"() {
         expect:
-        mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty(propertyName).getDefaultValue() ==
+        mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty(propertyName).getDefaultValue() ==
                 excpectedDefault
 
         where:
         propertyName            | excpectedDefault
-        "primitiveBoolean"      | "false"
-        "primitiveBooleanTrue"  | "true"
+        "primitiveBoolean"      | Value.of(false)
+        "primitiveBooleanTrue"  | Value.of(true)
+        "booleanObject"         | Value.EMPTY
+        "primitiveInt"          | Value.of(0)
+        "primitiveIntWithValue" | Value.of(50)
+        "amount"                | Value.EMPTY
+        "amountWithValue"       | Value.of(Amount.ONE_HUNDRED)
+        "amountZero"            | Value.of(Amount.ZERO)
+        "amountNothing"         | Value.EMPTY //Amount.NOTHING should be considered null and therefore have no default
+        "string"                | Value.EMPTY
+        "emptyString"           | Value.of("")
+        "enumWithValue"         | Value.of(DataTypesEntity.TestEnum.Test2)
+    }
+
+    def "column default values are properly transformed"() {
+        expect:
+        mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty(propertyName).getColumnDefaultValue() ==
+                excpectedDefault
+
+        where:
+        propertyName            | excpectedDefault
+        "primitiveBoolean"      | "0"
+        "primitiveBooleanTrue"  | "1"
         "booleanObject"         | null
         "primitiveInt"          | "0"
         "primitiveIntWithValue" | "50"
         "amount"                | null
-        "amountWithValue"       | "100.00"
-        "amountZero"            | "0.00"
+        "amountWithValue"       | "100.00000"
+        "amountZero"            | "0.00000"
         "amountNothing"         | null
-        "string"                | null
-        "emptyString"           | ""
-        "enumWithValue"         | "Test2"
     }
 
     def "a primitive boolean with no default value annotation does not throw an error"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveBoolean")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("primitiveBoolean")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setPrimitiveBoolean(true)
         when: // an empty value is given, its default (false) should be applied
         property.parseValueFromImport(entity, Value.EMPTY)
@@ -55,9 +74,9 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "a primitive boolean gets its default value from its initial assigned value"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveBooleanTrue")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("primitiveBooleanTrue")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         when: // an empty value is given, its default (true) should be applied
         property.parseValueFromImport(entity, Value.EMPTY)
         then:
@@ -66,9 +85,9 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "a boolean object field can have no default value"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("booleanObject")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("booleanObject")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setBooleanObject(Boolean.TRUE)
         when: // an empty value is given, the field should reset to 'null'
         property.parseValueFromImport(entity, Value.EMPTY)
@@ -78,9 +97,9 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "primitive number fields get automatic default value from their initial default value"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveInt")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("primitiveInt")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setPrimitiveInt(12)
         when: // an empty value is given, its default (0) should be applied
         property.parseValueFromImport(entity, Value.EMPTY)
@@ -90,9 +109,9 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "primitive number fields get automatic default value from their initial assigned value"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("primitiveIntWithValue")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("primitiveIntWithValue")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setPrimitiveIntWithValue(12)
         when: // an empty value is given, its default (50) should be applied
         property.parseValueFromImport(entity, Value.EMPTY)
@@ -102,25 +121,25 @@ class DefaultValuesSpec extends BaseSpecification {
 
     def "amount fields which are not initialized should reset to Amount.NOTHING"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("amount")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("amount")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setAmount(Amount.of(12))
         when:
         property.parseValueFromImport(entity, Value.EMPTY)
         then:
-        entity.getAmount()== Amount.NOTHING
+        entity.getAmount() == Amount.NOTHING
     }
 
     def "amount fields which are initialized with Amount.NOTHING should reset to Amount.NOTHING"() {
         given:
-        def property = mixing.getDescriptor(MongoDefaultValuesEntity.class).findProperty("amountNothing")
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("amountNothing")
         and:
-        MongoDefaultValuesEntity entity = new MongoDefaultValuesEntity()
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
         entity.setAmountNothing(Amount.of(12))
         when:
         property.parseValueFromImport(entity, Value.EMPTY)
         then:
-        entity.getAmountNothing()== Amount.NOTHING
+        entity.getAmountNothing() == Amount.NOTHING
     }
 }


### PR DESCRIPTION
### BREAKING: Gives all properties a default value determined by their initial value

The biggest change from this is that all primitive number fields have a default value of '0' if not initialized with another number.
Previously they produced an IllegalArgumentException when they had no default value.
This means, for non-nullable fields that should not have a default value but should produce an error when left empty, a non-primitve datatype should be used. Then they will be properly transformed from import/webcontext to null and produce an error on save.

Please note that for primitive booleans this was already implemented, but if you used the default value directly, the actual default value has changed from '0' to 'false'.

### BREAKING:Changes Property#defaultValue type from String to Value

Instead of a string that doubles as a value used for the column default value, the defaultValue will now hold an Object that represents the property wrapped in a Value, or Value.EMPTY if no default Value is present. JDBC Column default value can be retrieved via a new method.

To make it more universal, DefaultValue Annotations are now transformed like machine input (Property#transformValueFromImport), so existing DefaultValue annotations might need to be adjusted, especially times,dates and booleans.