### PR TITLE
Fixes the behaviour of ElasticQuery.count() and .exists()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-23.4.1</sirius.kernel>
+        <sirius.kernel>dev-23.6.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -894,9 +894,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
         if (forceFail) {
             return 0;
         }
-        if (skip > 0 || limit > 0) {
-            Elastic.LOG.WARN("COUNT queries support neither skip nor limit: %s\n%s", this, ExecutionPoint.snapshot());
-        }
 
         String filteredRouting = checkRouting(Elastic.RoutingAccessMode.READ);
 
@@ -958,9 +955,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
     public boolean exists() {
         if (forceFail) {
             return false;
-        }
-        if (skip > 0 || limit > 0) {
-            Elastic.LOG.WARN("EXISTS queries support neither skip nor limit: %s\n%s", this, ExecutionPoint.snapshot());
         }
 
         String filteredRouting = checkRouting(Elastic.RoutingAccessMode.READ);

--- a/src/main/java/sirius/db/mixing/query/Query.java
+++ b/src/main/java/sirius/db/mixing/query/Query.java
@@ -111,6 +111,8 @@ public abstract class Query<Q, E extends BaseEntity<?>, C extends Constraint> ex
 
     /**
      * Executes the query and counts the number of results.
+     * <p>
+     * Note that this will ignore any {@link #skip(int) skip} or {@link #limit(int) limit} settings on the query.
      *
      * @return the number of matched result entries
      */
@@ -118,6 +120,8 @@ public abstract class Query<Q, E extends BaseEntity<?>, C extends Constraint> ex
 
     /**
      * Determines if the query would have at least one matching entity.
+     * <p>
+     * Note that this will ignore any {@link #skip(int) skip} or {@link #limit(int) limit} settings on the query.
      *
      * @return <tt>true</tt> if at least one entity matches the query, <tt>false</tt> otherwise.
      */

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -422,7 +422,9 @@ public class Finder extends QueryBuilder<Finder> {
      * If there are no filters in this query and forceAccurate is false, a pre-counted estimate is returned instead.
      *
      * @param collection    the collection to search in
-     * @param forceAccurate if set to <tt>true</tt> we'll never use <b>estimatedDocumentCount</b> which is way more efficient but might return wrong values in case a cluster is active which had experienced an unclean shutdown.
+     * @param forceAccurate if set to <tt>true</tt> we'll never use <b>estimatedDocumentCount</b> which is way more
+     *                      efficient but might return wrong values in case a cluster is active which had experienced
+     *                      an unclean shutdown.
      * @param maxTimeMS     the maximum process time for this cursor in milliseconds, 0 for unlimited
      * @return the number of documents found, wrapped in an Optional, or an empty Optional if the query timed out
      */


### PR DESCRIPTION
OMA/SMartQuery and Mango/MongoQuery both also perform a proper count
(while ignoring the limit). This is useful as we often have queries
which are "paged" and thus have a limit. Still when performing a count,
we want the total, e.g. to properly fill Page.withTotal()