### PR TITLE
Reverts to a previous logic

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -323,7 +323,7 @@ public class EntityDescriptor {
      * @return the effective property key used to get the plural name of this entity
      */
     public String getPluralLabelKey() {
-        return getLabelKey() + ".plural";
+        return translationSource.getSimpleName() + ".plural";
     }
 
     /**


### PR DESCRIPTION
The entity plural version was obtained from ClassName.plural instead of Model.ClassName.plural