### PR TITLE
Drops milliseconds when persisting LocalDateTime in MongoDB

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -151,7 +151,7 @@ public class EntityDescriptor {
     protected PriorityCollector<Consumer<Object>> beforeSaveHandlerCollector = PriorityCollector.create();
 
     /**
-     * A list of all additional handlers to be executed once an entity is was saved
+     * A list of all additional handlers to be executed once an entity is saved
      */
     protected final List<Consumer<Object>> afterSaveHandlers = new ArrayList<>();
 
@@ -292,10 +292,10 @@ public class EntityDescriptor {
     }
 
     /**
-     * Returns the "end user friendly" name of the entity.
+     * Returns the "end-user friendly" name of the entity.
      * <p>
      * This is determined by calling <tt>NLS.get()</tt>
-     * with the full class name or as fallback the simple class name as lower case, prepended with "Model.". Therefore
+     * with the full class name or as fallback the simple class name as lower case, prepended with "Model.". Therefore,
      * the property keys for "org.acme.model.Customer" would be the class name and "Model.customer". The fallback
      * key will be the same which is tried for a property named "customer" and can therefore be reused.
      *
@@ -438,7 +438,7 @@ public class EntityDescriptor {
     }
 
     /**
-     * Executes all <tt>beforedSaveHandlers</tt> known to the descriptor.
+     * Executes all <tt>beforeSaveHandlers</tt> known to the descriptor.
      *
      * @param entity the entity to perform the handlers on
      */
@@ -1136,7 +1136,7 @@ public class EntityDescriptor {
      * with a {@link ComplexDelete} annotation. This way even a <b>Mixin</b> can mark an entity
      * as complex.
      * <p>
-     * If an entity has cascade delete actions but should not be considered complex, an annotation with
+     * If an entity has cascaded delete actions but should not be considered complex, an annotation with
      * <tt>value</tt> set to <tt>false</tt> can be placed on the entity class.
      *
      * @return <tt>true</tt> if entities of this descriptor are complex to delete, <tt>false</tt>

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -151,7 +151,7 @@ public class LocalDateTimeProperty extends Property implements ESPropertyInfo, S
      * Overrides the default behavior, as the initial value of a temporal property is not suited for a default.
      * <p>
      * The initial value will commonly be a temporal value and thus not a constant.
-     * Therefore we ignore the initial value here, and only check for a {@link DefaultValue} annotation on the field.
+     * Therefore, we ignore the initial value here, and only check for a {@link DefaultValue} annotation on the field.
      */
     @Override
     protected void determineDefaultValue() {

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -102,7 +102,8 @@ public class LocalDateTimeProperty extends Property implements ESPropertyInfo, S
 
     @Override
     protected Object transformFromMongo(Value object) {
-        return object.asLocalDateTime(null);
+        LocalDateTime localDateTime = object.asLocalDateTime(null);
+        return localDateTime == null ? null : localDateTime.withNano(0);
     }
 
     @Override
@@ -124,11 +125,10 @@ public class LocalDateTimeProperty extends Property implements ESPropertyInfo, S
 
     @Override
     protected Object transformToMongo(Object object) {
-        if (!(object instanceof LocalDateTime)) {
-            return null;
+        if (object instanceof LocalDateTime localDateTime) {
+            return QueryBuilder.FILTERS.transform(localDateTime == null ? null : localDateTime.withNano(0));
         }
-
-        return QueryBuilder.FILTERS.transform(object);
+        return null;
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -125,10 +125,11 @@ public class LocalDateTimeProperty extends Property implements ESPropertyInfo, S
 
     @Override
     protected Object transformToMongo(Object object) {
-        if (object instanceof LocalDateTime localDateTime) {
-            return QueryBuilder.FILTERS.transform(localDateTime == null ? null : localDateTime.withNano(0));
+        if (!(object instanceof LocalDateTime)) {
+            return null;
         }
-        return null;
+
+        return QueryBuilder.FILTERS.transform(object);
     }
 
     @Override

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -46,19 +46,20 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
 
     @Override
     protected Object customTransform(Object value) {
-        if (value instanceof LocalDate) {
-            return Date.from(((LocalDate) value).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+        if (value instanceof LocalDate localDate) {
+            return Date.from(localDate.atStartOfDay().withNano(0).atZone(ZoneId.systemDefault()).toInstant());
         }
-        if (value instanceof LocalDateTime) {
-            return Date.from(((LocalDateTime) value).atZone(ZoneId.systemDefault()).toInstant());
+        if (value instanceof LocalDateTime localDateTime) {
+            return Date.from(localDateTime.withNano(0).atZone(ZoneId.systemDefault()).toInstant());
         }
-        if (value instanceof LocalTime) {
-            return Date.from(((LocalTime) value).atDate(LocalDate.now(ZoneId.systemDefault()))
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant());
+        if (value instanceof LocalTime localTime) {
+            return Date.from(localTime.atDate(LocalDate.now(ZoneId.systemDefault()))
+                                      .withNano(0)
+                                      .atZone(ZoneId.systemDefault())
+                                      .toInstant());
         }
-        if (value instanceof Instant) {
-            return Date.from((Instant) value);
+        if (value instanceof Instant instant) {
+            return Date.from(Instant.ofEpochSecond(instant.getEpochSecond()));
         }
 
         return value;

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -160,7 +160,7 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
     }
 
     /**
-     * Creates a constraint which ensures that the given field contains all of the given values.
+     * Creates a constraint which ensures that the given field contains all the given values.
      *
      * @param field  the field to filter on
      * @param values the values to check
@@ -188,7 +188,7 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
      *
      * @param key        the name of the field to check
      * @param expression the regular expression to apply
-     * @param options    the options to apply like "i" to match case insensitive
+     * @param options    the options to apply like "i" to match case-insensitive
      * @return a filter representing the given operation
      */
     public MongoConstraint regex(Mapping key, Object expression, String options) {
@@ -253,7 +253,7 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
      * <p>
      * If the given value is empty, no constraint will be generated.
      * <p>
-     * Due to the nature of the MongoDB implementation on full token matches are successfull. To provide a
+     * Due to the nature of the MongoDB implementation on full token matches are successful. To provide a
      * prefix search use {@link #prefix(Mapping, String)} and ensure that a proper index is present.
      *
      * @param value the token to search for


### PR DESCRIPTION
When storing `LocalDateTime` in MongoDB, it only stores up to 1 ms as precision, but in recent Java we have nanoseconds.
Therefore, fields of LocalDateTimeProperty were being identified as changed (especially TraceData.changedAt), when 2 updates were issued within 1 ms but nothing changed, resulting in the `Tried to update the changed entity ... but actually nothing was changed in the database!`
By using seconds we also keep it on-pair with how LocalDateTimeProperty are handled in OMA and ES.

We also adjust the isChanged method to only compare dates up to 1 second when comparing dates.

Fixes: OX-7281