### PR TITLE
Enables to remove an entity from a cache by only specifying its id.

### DIFF
--- a/src/main/java/sirius/db/util/BaseEntityCache.java
+++ b/src/main/java/sirius/db/util/BaseEntityCache.java
@@ -16,6 +16,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Optional;
 
@@ -126,9 +127,20 @@ public abstract class BaseEntityCache<I extends Serializable, E extends BaseEnti
      *
      * @param entity the entity to purge
      */
-    public void remove(E entity) {
+    public void remove(@Nullable E entity) {
         if (entity != null && !entity.isNew()) {
             entityByIdCache.remove(entity.getIdAsString());
+        }
+    }
+
+    /**
+     * Purges the entity specified by its id from the cache.
+     *
+     * @param entityId the id of the entity to purge
+     */
+    public void remove(@Nullable String entityId) {
+        if (Strings.isFilled(entityId)) {
+            entityByIdCache.remove(entityId);
         }
     }
 }


### PR DESCRIPTION
This is useful in cases where two entities are related but changing one does not directly affect a persisted field of the other, but rather a transient field. Instead of modifying the transient field, we may want to load a clean instance of the other entity if it is needed again.

- Fixes: OX-7421