### PR TITLE
Kills collation handling for MongoDB.

### DIFF
--- a/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
+++ b/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
@@ -14,6 +14,7 @@ import sirius.db.es.ElasticQuery;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -171,8 +172,9 @@ public class BoolQueryBuilder {
      *
      * @return the query as constraint
      */
-    @SuppressWarnings({"squid:MethodCyclomaticComplexity","java:S1168"})
-    @Explain("Splitting this method would most probably increase the complexity. Also, we return null to indicate that no filter has been generated.")
+    @SuppressWarnings("squid:MethodCyclomaticComplexity")
+    @Explain("Splitting this method would most probably increase the complexity.")
+    @Nullable
     public JSONObject build() {
         int filters = filter == null ? 0 : filter.size();
         int musts = must == null ? 0 : must.size();

--- a/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
+++ b/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
@@ -171,8 +171,8 @@ public class BoolQueryBuilder {
      *
      * @return the query as constraint
      */
-    @SuppressWarnings("squid:MethodCyclomaticComplexity")
-    @Explain("Splitting this method would most probably increase the complexity")
+    @SuppressWarnings({"squid:MethodCyclomaticComplexity","java:S1168"})
+    @Explain("Splitting this method would most probably increase the complexity. Also, we return null to indicate that no filter has been generated.")
     public JSONObject build() {
         int filters = filter == null ? 0 : filter.size();
         int musts = must == null ? 0 : must.size();

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -23,7 +23,6 @@ import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
-import sirius.kernel.nls.NLS;
 
 import java.lang.reflect.Field;
 import java.sql.Types;

--- a/src/main/java/sirius/db/mixing/properties/LongProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LongProperty.java
@@ -21,7 +21,6 @@ import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixable;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 

--- a/src/main/java/sirius/db/mixing/properties/MultiPointLocationProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiPointLocationProperty.java
@@ -17,7 +17,6 @@ import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.types.MultiPointLocation;
-import sirius.kernel.commons.Lambdas;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -101,18 +100,16 @@ public class MultiPointLocationProperty extends Property {
                     "MultiPointLocationProperty currently only supports Mango as mapper!");
         }
 
-        List<Tuple<Double, Double>> locations = new ArrayList<>();
-
         if (!object.isNull()) {
             Object coordinates = ((Document) object.get()).get("coordinates");
             if (coordinates instanceof List<?>) {
-                ((List<List<Double>>) coordinates).stream()
-                                                  .map(entry -> Tuple.create(entry.get(0), entry.get(1)))
-                                                  .collect(Lambdas.into(locations));
+                return ((List<List<Double>>) coordinates).stream()
+                                                         .map(entry -> Tuple.create(entry.get(0), entry.get(1)))
+                                                         .collect(Collectors.toList());
             }
         }
 
-        return locations;
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
@@ -26,8 +26,6 @@ import sirius.kernel.di.std.Register;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
@@ -340,19 +340,6 @@ public abstract class FilterFactory<C extends Constraint> {
     public abstract C notFilled(Mapping field);
 
     /**
-     * Generates a constraint which ensures that the given list field is not filled (empty)
-     *
-     * @param field the field to check
-     * @return the generated constraint
-     * @deprecated use {@link #isEmptyList(Mapping)} - in MongoDB and Elastisearch we commonly
-     * refer to lists as "list" rather than array.
-     */
-    @Deprecated(forRemoval = true)
-    public C isEmptyArray(Mapping field) {
-        return isEmptyList(field);
-    }
-
-    /**
      * Generates a constraint which ensures that the given list field is not filled (empty).
      * <p>
      * This can be overwritten if a database specific handling is required.

--- a/src/main/java/sirius/db/mongo/Deleter.java
+++ b/src/main/java/sirius/db/mongo/Deleter.java
@@ -8,7 +8,6 @@
 
 package sirius.db.mongo;
 
-import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.result.DeleteResult;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.health.Microtiming;
@@ -45,9 +44,7 @@ public class Deleter extends QueryBuilder<Deleter> {
                 Mongo.LOG.FINE("DELETE: %s\nFilter: %s", collection, filterObject);
             }
 
-            return mongo.db(database)
-                        .getCollection(collection)
-                        .deleteOne(filterObject, new DeleteOptions().collation(mongo.determineCollation()));
+            return mongo.db(database).getCollection(collection).deleteOne(filterObject);
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {
@@ -80,9 +77,7 @@ public class Deleter extends QueryBuilder<Deleter> {
                 Mongo.LOG.FINE("DELETE: %s\nFilter: %s", collection, filterObject);
             }
 
-            return mongo.db(database)
-                        .getCollection(collection)
-                        .deleteMany(filterObject, new DeleteOptions().collation(mongo.determineCollation()));
+            return mongo.db(database).getCollection(collection).deleteMany(filterObject);
         } finally {
             mongo.callDuration.addValue(w.elapsedMillis());
             if (Microtiming.isEnabled()) {

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -249,8 +249,7 @@ public class Finder extends QueryBuilder<Finder> {
     }
 
     private FindIterable<Document> buildCursor(String collection) {
-        FindIterable<Document> cursor =
-                getMongoCollection(collection).find(filterObject).collation(mongo.determineCollation());
+        FindIterable<Document> cursor = getMongoCollection(collection).find(filterObject);
         if (fields != null) {
             cursor.projection(fields);
         }
@@ -431,13 +430,12 @@ public class Finder extends QueryBuilder<Finder> {
         Watch watch = Watch.start();
         try {
             if (filterObject.isEmpty() && !forceAccurate) {
-                return Optional.of(getMongoCollection(collection).estimatedDocumentCount(new EstimatedDocumentCountOptions()
-                                                                                                 .maxTime(maxTimeMS,
-                                                                                                          TimeUnit.MILLISECONDS)));
+                return Optional.of(getMongoCollection(collection).estimatedDocumentCount(new EstimatedDocumentCountOptions().maxTime(
+                        maxTimeMS,
+                        TimeUnit.MILLISECONDS)));
             }
             return Optional.of(getMongoCollection(collection).countDocuments(filterObject,
-                                                                             new CountOptions().collation(mongo.determineCollation())
-                                                                                               .maxTime(maxTimeMS,
+                                                                             new CountOptions().maxTime(maxTimeMS,
                                                                                                         TimeUnit.MILLISECONDS)));
         } catch (MongoExecutionTimeoutException e) {
             Exceptions.ignore(e);
@@ -490,7 +488,6 @@ public class Finder extends QueryBuilder<Finder> {
                     getMongoCollection(collection).aggregate(Arrays.asList(new BasicDBObject(OPERATOR_MATCH,
                                                                                              filterObject),
                                                                            new BasicDBObject("$group", groupStage)))
-                                                  .collation(mongo.determineCollation())
                                                   .iterator();
             if (queryResult.hasNext()) {
                 return Value.of(queryResult.next().get("result"));
@@ -541,7 +538,6 @@ public class Finder extends QueryBuilder<Finder> {
                     getMongoCollection(collection).aggregate(Arrays.asList(new BasicDBObject(OPERATOR_MATCH,
                                                                                              filterObject),
                                                                            new BasicDBObject("$facet", facetStage)))
-                                                  .collation(mongo.determineCollation())
                                                   .iterator();
 
             if (queryResult.hasNext()) {

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -407,12 +407,10 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
 
     private void createIndex(EntityDescriptor descriptor, MongoDatabase client, Index index) {
         try {
-            boolean textColumnSeen = false;
             Document document = new Document();
             for (int i = 0; i < index.columns().length; i++) {
                 Value setting = Value.of(index.columnSettings()[i]);
                 document.append(index.columns()[i], setting.isNumeric() ? setting.asInt(1) : setting.asString());
-                textColumnSeen |= Mango.INDEX_AS_FULLTEXT.equals(setting.getString());
             }
 
             Mongo.LOG.FINE("Creating MongoDB index %s for: %s...", index.name(), descriptor.getRelationName());

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -415,13 +415,9 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
                 textColumnSeen |= Mango.INDEX_AS_FULLTEXT.equals(setting.getString());
             }
 
-            IndexOptions indexOptions = new IndexOptions().name(index.name()).unique(index.unique());
-            if (!textColumnSeen) {
-                indexOptions.collation(mongo.determineCollation());
-            }
-
             Mongo.LOG.FINE("Creating MongoDB index %s for: %s...", index.name(), descriptor.getRelationName());
-            client.getCollection(descriptor.getRelationName()).createIndex(document, indexOptions);
+            client.getCollection(descriptor.getRelationName())
+                  .createIndex(document, new IndexOptions().name(index.name()).unique(index.unique()));
         } catch (Exception e) {
             Exceptions.handle()
                       .error(e)

--- a/src/main/java/sirius/db/mongo/Mongo.java
+++ b/src/main/java/sirius/db/mongo/Mongo.java
@@ -15,16 +15,13 @@ import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Collation;
 import sirius.db.mixing.Mixing;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
 import sirius.kernel.Stoppable;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Explain;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
-import sirius.kernel.commons.ValueHolder;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.ConfigValue;
@@ -64,10 +61,6 @@ public class Mongo implements Startable, Stoppable {
     @ConfigValue("mongo.logQueryThreshold")
     private Duration logQueryThreshold;
     private long logQueryThresholdMillis = -1;
-
-    @ConfigValue("mongo.collationLocale")
-    private static String collationLocale;
-    private ValueHolder<Collation> collationHolder = null;
 
     @Parts(IndexDescription.class)
     private PartCollection<IndexDescription> indexDescriptions;
@@ -319,28 +312,6 @@ public class Mongo implements Startable, Stoppable {
      */
     public Deleter delete() {
         return delete(Mixing.DEFAULT_REALM);
-    }
-
-    /**
-     * Tries to determine which collation should be used for queries.
-     *
-     * @return the collation to be used or <tt>null</tt> to indicate that no collation should be used.
-     */
-    @Nullable
-    public Collation determineCollation() {
-        if (collationHolder == null) {
-            initializeCollation();
-        }
-
-        return collationHolder.get();
-    }
-
-    private void initializeCollation() {
-        if (Strings.isFilled(collationLocale)) {
-            collationHolder = new ValueHolder<>(Collation.builder().locale(collationLocale).build());
-        } else {
-            collationHolder = new ValueHolder<>(null);
-        }
     }
 
     /**

--- a/src/main/java/sirius/db/mongo/SortField.java
+++ b/src/main/java/sirius/db/mongo/SortField.java
@@ -34,7 +34,7 @@ public class SortField extends Composite {
     public static final Mapping SORT_FIELD = Mapping.named("sortField");
     @NullAllowed
     @SuppressWarnings("java:S1700")
-    @Explain("We actually to want the same name here.")
+    @Explain("We actually do want the same name here.")
     private String sortField;
 
     @Transient

--- a/src/main/java/sirius/db/mongo/SortField.java
+++ b/src/main/java/sirius/db/mongo/SortField.java
@@ -1,0 +1,67 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo;
+
+import sirius.db.mixing.Composite;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.BeforeSave;
+import sirius.db.mixing.annotations.NullAllowed;
+import sirius.db.mixing.annotations.Transient;
+import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.nls.NLS;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+/**
+ * Provides a container composite to be used in MongoDB entities which can be used for sorting.
+ * <p>
+ * As MongoDB doesn't sort values properly (as we use it without collations), we use a normalized sort field here.
+ * This field is populated with all values which are marked with {@link SortValue}.
+ */
+public class SortField extends Composite {
+
+    /**
+     * Contains the effective field to sort by.
+     */
+    public static final Mapping SORT_FIELD = Mapping.named("sortField");
+    @NullAllowed
+    @SuppressWarnings("java:S1700")
+    @Explain("We actually to want the same name here.")
+    private String sortField;
+
+    @Transient
+    private MongoEntity owner;
+
+    /**
+     * Creates a sort field for the given entity.
+     *
+     * @param owner the owning entity which contains the sort field
+     */
+    public SortField(MongoEntity owner) {
+        this.owner = owner;
+    }
+
+    @BeforeSave
+    protected void fillSortField() {
+        String sortFieldContents = owner.getDescriptor()
+                                        .getProperties()
+                                        .stream()
+                                        .filter(property -> property.isAnnotationPresent(SortValue.class))
+                                        .sorted(Comparator.comparing(property -> property.getAnnotation(SortValue.class)
+                                                                                         .map(SortValue::order)
+                                                                                         .orElse(99)))
+                                        .map(property -> property.getValue(owner))
+                                        .map(NLS::toUserString)
+                                        .collect(Collectors.joining(""));
+
+        this.sortField = Strings.reduceCharacters(sortFieldContents).toLowerCase();
+    }
+}

--- a/src/main/java/sirius/db/mongo/SortValue.java
+++ b/src/main/java/sirius/db/mongo/SortValue.java
@@ -1,0 +1,29 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks all properties to be included in {@link SortField#SORT_FIELD} to build a normalized sort field for MongoDB.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SortValue {
+
+    /**
+     * Determines to order of this field within all fields wearing a {@link SortValue}.
+     *
+     * @return the sort order / priority
+     */
+    int order();
+}

--- a/src/main/java/sirius/db/mongo/Updater.java
+++ b/src/main/java/sirius/db/mongo/Updater.java
@@ -380,7 +380,7 @@ public class Updater extends QueryBuilder<Updater> {
             if (Mongo.LOG.isFINE()) {
                 Mongo.LOG.FINE("UPDATE: %s\nFilter: %s\n Update:%s", collection, filterObject, updateObject);
             }
-            UpdateOptions updateOptions = new UpdateOptions().upsert(this.upsert).collation(mongo.determineCollation());
+            UpdateOptions updateOptions = new UpdateOptions().upsert(this.upsert);
             if (forMany) {
                 return mongo.db(database)
                             .getCollection(collection)

--- a/src/main/java/sirius/db/mongo/Updater.java
+++ b/src/main/java/sirius/db/mongo/Updater.java
@@ -34,27 +34,9 @@ public class Updater extends QueryBuilder<Updater> {
     private BasicDBObject pullAllObject;
     private BasicDBObject pullObject;
     private boolean upsert = false;
-    private boolean many = false;
 
     protected Updater(Mongo mongo, String database) {
         super(mongo, database);
-    }
-
-    /**
-     * Specifies that multiple documents should be updated.
-     * <p>
-     * By default only one document is updated.
-     * <p>
-     * Note that this is a legacy flag and will not be honored by neither {@link #executeForOne(String)} nor
-     * {@link #executeForMany(String)}.
-     *
-     * @return the builder itself for fluent method calls
-     * @deprecated use {@link #executeForOne(String)} or {@link #executeForMany(String)}
-     */
-    @Deprecated(forRemoval = true)
-    public Updater many() {
-        this.many = true;
-        return this;
     }
 
     /**
@@ -298,18 +280,6 @@ public class Updater extends QueryBuilder<Updater> {
     }
 
     /**
-     * Executes the update on the given collection.
-     *
-     * @param type the type of entities to update
-     * @return the result of the update
-     * @deprecated use either {@link #executeForOne(Class)} or {@link #executeForMany(Class)}
-     */
-    @Deprecated(forRemoval = true)
-    public UpdateResult executeFor(Class<?> type) {
-        return executeFor(getRelationName(type));
-    }
-
-    /**
      * Executes the update on the given collection for a single document.
      *
      * @param type the type of entities to update
@@ -338,18 +308,6 @@ public class Updater extends QueryBuilder<Updater> {
     public UpdateResult executeFor(MongoEntity entity) {
         where(MongoEntity.ID, entity.getId());
         return executeForOne(entity.getDescriptor().getRelationName());
-    }
-
-    /**
-     * Executes the update on the given collection.
-     *
-     * @param collection the collection to update
-     * @return the result of the update
-     * @deprecated use either {@link #executeForOne(String)} or {@link #executeForMany(String)}
-     */
-    @Deprecated(forRemoval = true)
-    public UpdateResult executeFor(String collection) {
-        return execute(collection, many);
     }
 
     /**

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -407,9 +407,6 @@ mongo {
 
     # Every query which takes longer will be logged to "db-slow" on level INFO
     logQueryThreshold = 10 seconds
-
-    # The language / collation to be used for string comparison, if not set, strings will be compared binary.
-    collationLocale = "de"
 }
 
 # Contains the default config used to connect to an Elasticsearch cluster

--- a/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
+++ b/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
@@ -246,7 +246,7 @@ class MongoFilterFactorySpec extends BaseSpecification {
              .countIn(MangoTestEntity.class) == 1
     }
 
-    def "isEmptyArray works on List fields"() {
+    def "isEmptyList works on List fields"() {
         setup:
         mango.select(MangoTestEntity.class).delete()
         when:
@@ -261,7 +261,7 @@ class MongoFilterFactorySpec extends BaseSpecification {
         mango.update(e2)
         then:
         mango.select(MangoTestEntity.class)
-             .where(QueryBuilder.FILTERS.isEmptyArray(MangoTestEntity.SUPER_POWERS)).count() == 1
+             .where(QueryBuilder.FILTERS.isEmptyList(MangoTestEntity.SUPER_POWERS)).count() == 1
     }
 
     def "forceEmpty works on List fields"() {


### PR DESCRIPTION
Collations are very tricky to use properly and ruin almost any ad-hoc
query as indices need to be aware of them. Also, we ran into strange
bugs / shortcomings with index misses for prefix/$regex queries.

We therefore resort to a normalized sort column:
Strings.reduceCharacters(...).toLowerCase() for sorting and ignore
collations for everything else.

Fixes: SIRI-440

Note that all indices need to be re-created after this has been merged!