### PR TITLE
Tries to prevent possible misuse of containsOne and containsNone

### DIFF
--- a/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Defines a factory to create common filters or constraints to be used in a {@link sirius.db.mixing.query.Query}.
@@ -463,7 +464,14 @@ public abstract class FilterFactory<C extends Constraint> {
      * @return a filter builder used to generate a constraint
      */
     public OneInField<C> containsOne(Mapping field, Object... values) {
-        return new OneInField<>(this, field, Arrays.asList(values));
+        if (values.length > 0 && (values[0] instanceof Collection
+                                  || values[0] instanceof Iterable
+                                  || values[0] instanceof Stream)) {
+            throw new IllegalArgumentException(
+                    "FilterFactory#containsOne will produce wrong/unexpected behaviour when passing a Collection, Iterable or Stream!"
+                    + " This is most probably a mistake, use FilterFactory#oneInField instead.");
+        }
+        return oneInField(field, Arrays.asList(values));
     }
 
     /**
@@ -485,6 +493,13 @@ public abstract class FilterFactory<C extends Constraint> {
      * @return the generated constraint
      */
     public C containsNone(Mapping field, Object... values) {
+        if (values.length > 0 && (values[0] instanceof Collection
+                                  || values[0] instanceof Iterable
+                                  || values[0] instanceof Stream)) {
+            throw new IllegalArgumentException(
+                    "FilterFactory#containsNone will produce wrong/unexpected behaviour when passing a Collection, Iterable or Stream!"
+                    + " This is most probably a mistake, use FilterFactory#noneInField instead.");
+        }
         return noneInField(field, Arrays.asList(values));
     }
 


### PR DESCRIPTION
As the syntax of both containsOne and containsNone accept a varargs of Objects it is quite easy to mistake them for oneInField and noneInField, as nothing previously did warn about passing a Collection directly into those methods which would result in a constraint being generated that does not match the expected behaviour described in the JavaDoc.

Fixes: SIRI-442