### PR TITLE
Introduces onValidate in properties

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -531,6 +531,10 @@ public class EntityDescriptor {
             }
         }
 
+        for (Property property : properties.values()) {
+            property.onValidate(entity, warnings::add);
+        }
+
         return warnings;
     }
 

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -293,7 +293,7 @@ public abstract class Property extends Composable {
     }
 
     /**
-     * Returns the full label or nme of the property which is shown in error messages etc.
+     * Returns the full label or name of the property which is shown in error messages etc.
      * <p>
      * This will only differ from {@link #getLabel()} for field in composites or mixins. In this case,
      * we try to look up the "parent" name (<tt>[entityClass].[compositeName]</tt>), that is the access path leading

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -680,6 +680,7 @@ public abstract class Property extends Composable {
      * @param validationConsumer the consumer collecting the validation messages
      */
     protected void onValidate(Object entity, Consumer<String> validationConsumer) {
+        // this method does nothing by default
     }
 
     /**
@@ -690,6 +691,7 @@ public abstract class Property extends Composable {
      * @param entity the entity to check
      */
     protected void onBeforeSaveChecks(Object entity) {
+        // this method does nothing by default
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Maps a field, which is either defined in an entity, a composite or a mixin to a mapped property.
@@ -668,6 +669,17 @@ public abstract class Property extends Composable {
             // Only enforce uniqueness if the value actually changed...
             checkUniqueness(entity, propertyValue);
         }
+    }
+
+    /**
+     * Invoked during validation of an entity.
+     * <p>
+     * This method is intended to be overwritten with custom logic.
+     *
+     * @param entity             the entity to check
+     * @param validationConsumer the consumer collecting the validation messages
+     */
+    protected void onValidate(Object entity, Consumer<String> validationConsumer) {
     }
 
     /**


### PR DESCRIPTION
A Property now defines an onValidate method (empty by default), which can be overwritten if validation code can be written at property level

Fixes: SIRI-446