### PR TITLE
Persists emptied Amounts with its default if not nullable

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -102,6 +102,9 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
     @Override
     protected Object transformValueFromImport(Value value) {
         if (value.is(Amount.class)) {
+            if (value.getAmount().isEmpty() && !this.isNullable()) {
+                return defaultValue.getAmount();
+            }
             return value.get();
         }
 

--- a/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
+++ b/src/test/java/sirius/db/mixing/properties/DefaultValuesSpec.groovy
@@ -133,4 +133,22 @@ class DefaultValuesSpec extends BaseSpecification {
         then:
         entity.getAmountNothing() == Amount.NOTHING
     }
+
+    def "amount fields initialized with a non-empty Amount should persist the default when emptied"() {
+        given:
+        def property = mixing.getDescriptor(SQLDefaultValuesEntity.class).findProperty("amountZero")
+
+        expect:
+        SQLDefaultValuesEntity entity = new SQLDefaultValuesEntity()
+        entity.setAmountZero(Amount.of(77))
+        property.parseValueFromImport(entity, input)
+        entity.getAmountZero() == output
+
+        where:
+        input                     | output
+        Value.EMPTY               | Amount.ZERO
+        Value.of(5)               | Amount.of(5)
+        Value.of(Amount.NOTHING)  | Amount.ZERO
+        Value.of(Amount.of(44.1)) | Amount.of(44.1)
+    }
 }


### PR DESCRIPTION
The default value declared in an Amount Property got lost when setting it with Amount.NOTHING.
We only do this for non-nullable properties, as otherwise one might really want to empty the contents persisted in the DB.

Fixes: SIRI-451