### PR TITLE
Ignores ID field when checking for changed mappings in ES entities

### DIFF
--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -95,6 +95,14 @@ public abstract class ElasticEntity extends BaseEntity<String> {
         this.id = id;
     }
 
+    @Override
+    public boolean isAnyMappingChanged() {
+        return getDescriptor().getProperties()
+                              .stream()
+                              .filter(property -> !ElasticEntity.ID.getName().equals(property.getName()))
+                              .anyMatch(property -> getDescriptor().isChanged(this, property));
+    }
+
     @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
     @Explain("We only pass the result JSON along internally and want to avoid an extra copy.")
     protected void setSearchHit(JSONObject searchHit) {


### PR DESCRIPTION
In the Elastic update method this is already correctly done, it is only missing in the any mapping changed method. This needs to be done as the persisted data / source returned by ES doesn't include the ID field.