### PR TITLE
Makes CONTAINS_ANY CSVFilter work correctly without orEmpty

### DIFF
--- a/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
@@ -122,7 +122,9 @@ public class CSVFilter<C extends Constraint> {
         C orEmptyConstraint = orEmpty ? factory.isEmptyList(field) : null;
 
         if (mode == Mode.CONTAINS_ANY) {
-            constraints.add(factory.isEmptyList(field));
+            if (orEmpty) {
+                constraints.add(factory.isEmptyList(field));
+            }
             return factory.or(constraints);
         }
 

--- a/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
@@ -122,9 +122,7 @@ public class CSVFilter<C extends Constraint> {
         C orEmptyConstraint = orEmpty ? factory.isEmptyList(field) : null;
 
         if (mode == Mode.CONTAINS_ANY) {
-            if (orEmpty) {
-                constraints.add(factory.isEmptyList(field));
-            }
+            constraints.add(orEmptyConstraint);
             return factory.or(constraints);
         }
 


### PR DESCRIPTION
Previously, empty lists where always added to the constraint, but it should only be added if orEmpty is set

Fixes: SIRI-510