### PR TITLE
Uses the proper filter name as defined by Elastic.

### DIFF
--- a/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
+++ b/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
@@ -194,7 +194,7 @@ public class BoolQueryBuilder {
             query.put("must", must);
         }
         if (mustNots > 0) {
-            query.put("mustNot", mustNot);
+            query.put("must_not", mustNot);
         }
         if (shoulds > 0) {
             query.put("should", should);


### PR DESCRIPTION
ES still accepts both names, but now started to log a deprecation
warning for each query starting with 7.16.0