### PR TITLE
Improve oma exists capabilities

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -22,7 +22,6 @@ import sirius.db.mixing.ContextInfo;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Property;
-import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.async.Future;
 import sirius.kernel.commons.Strings;
@@ -721,7 +720,7 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     @Override
-    public FilterFactory<ElasticConstraint> filters() {
+    public ElasticFilterFactory filters() {
         return FILTERS;
     }
 
@@ -746,6 +745,6 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
             return null;
         }
 
-        return (JSONObject) json.clone();
+        return json.clone();
     }
 }

--- a/src/main/java/sirius/db/jdbc/OMA.java
+++ b/src/main/java/sirius/db/jdbc/OMA.java
@@ -17,7 +17,6 @@ import sirius.db.mixing.IntegrityConstraintFailedException;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.OptimisticLockException;
 import sirius.db.mixing.Property;
-import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.kernel.async.Future;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Strings;
@@ -370,7 +369,7 @@ public class OMA extends BaseMapper<SQLEntity, SQLConstraint, SmartQuery<? exten
     }
 
     @Override
-    public FilterFactory<SQLConstraint> filters() {
+    public SQLFilterFactory filters() {
         return FILTERS;
     }
 

--- a/src/main/java/sirius/db/jdbc/constraints/Exists.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Exists.java
@@ -12,8 +12,8 @@ import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SmartQuery;
 import sirius.db.jdbc.TranslationState;
 import sirius.db.mixing.EntityDescriptor;
-import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixing;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Part;
 
 import java.util.ArrayList;
@@ -24,15 +24,15 @@ import java.util.List;
  */
 public class Exists extends SQLConstraint {
 
-    private Mapping outerColumn;
-    private Mapping innerColumn;
-    private List<SQLConstraint> constraints = new ArrayList<>();
-    private Class<? extends SQLEntity> other;
+    private final CompoundValue outerColumn;
+    private final CompoundValue innerColumn;
+    private final List<SQLConstraint> constraints = new ArrayList<>();
+    private final Class<? extends SQLEntity> other;
 
     @Part
     private static Mixing mixing;
 
-    protected Exists(Mapping outerColumn, Class<? extends SQLEntity> other, Mapping innerColumn) {
+    protected Exists(CompoundValue outerColumn, Class<? extends SQLEntity> other, CompoundValue innerColumn) {
         this.outerColumn = outerColumn;
         this.other = other;
         this.innerColumn = innerColumn;
@@ -63,9 +63,13 @@ public class Exists extends SQLConstraint {
         compiler.setWHEREBuilder(new StringBuilder());
 
         // Applies the main constraint and switches the underlying JOIN state just in time.
-        compiler.getWHEREBuilder().append(" WHERE ").append(compiler.translateColumnName(outerColumn)).append(" = ");
+        Tuple<String, List<Object>> compiledOuterColumn = outerColumn.compileExpression(compiler);
+        compiler.getWHEREBuilder().append(" WHERE ").append(compiledOuterColumn.getFirst()).append(" = ");
+        compiledOuterColumn.getSecond().forEach(compiler::addParameter);
         TranslationState state = compiler.captureAndReplaceTranslationState(newAlias, ed);
-        compiler.getWHEREBuilder().append(compiler.translateColumnName(innerColumn));
+        Tuple<String, List<Object>> compiledInnerColumn = innerColumn.compileExpression(compiler);
+        compiler.getWHEREBuilder().append(compiledInnerColumn.getFirst());
+        compiledInnerColumn.getSecond().forEach(compiler::addParameter);
 
         // Applies additional constraints...
         for (SQLConstraint c : constraints) {

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -176,6 +176,18 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
      * @return an exists constraint which can be filtered with additional constraints
      */
     public Exists existsIn(Mapping outerColumn, Class<? extends SQLEntity> other, Mapping innerColumn) {
+        return existsIn(new CompoundValue(outerColumn), other, new CompoundValue(innerColumn));
+    }
+
+    /**
+     * Generates an EXISTS clause: <tt>EXISTS(SELECT * FROM other WHERE e.outerColumn = other.innerColumn</tt>.
+     *
+     * @param outerColumn the column of the entities being queried to match
+     * @param other       the entity type to search in (which must exist)
+     * @param innerColumn the column within that inner entity type which must match the outer column
+     * @return an exists constraint which can be filtered with additional constraints
+     */
+    public Exists existsIn(CompoundValue outerColumn, Class<? extends SQLEntity> other, CompoundValue innerColumn) {
         return new Exists(outerColumn, other, innerColumn);
     }
 

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -181,14 +181,16 @@ public class SQLFilterFactory extends FilterFactory<SQLConstraint> {
 
     /**
      * Generates an EXISTS clause: <tt>EXISTS(SELECT * FROM other WHERE e.outerColumn = other.innerColumn</tt>.
+     * <p>
+     * In contrast to {@link #existsIn(Mapping, Class, Mapping)} you can specify multiple join-columns
      *
-     * @param outerColumn the column of the entities being queried to match
-     * @param other       the entity type to search in (which must exist)
-     * @param innerColumn the column within that inner entity type which must match the outer column
+     * @param outerColumns the columns of the entities being queried to match
+     * @param other        the entity type to search in (which must exist)
+     * @param innerColumns the columns within that inner entity type which must match the outer columns
      * @return an exists constraint which can be filtered with additional constraints
      */
-    public Exists existsIn(CompoundValue outerColumn, Class<? extends SQLEntity> other, CompoundValue innerColumn) {
-        return new Exists(outerColumn, other, innerColumn);
+    public Exists existsIn(CompoundValue outerColumns, Class<? extends SQLEntity> other, CompoundValue innerColumns) {
+        return new Exists(outerColumns, other, innerColumns);
     }
 
     /**

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -22,8 +22,8 @@ import sirius.db.mixing.OptimisticLockException;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.SkipDefaultValue;
-import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.db.mongo.constraints.MongoConstraint;
+import sirius.db.mongo.constraints.MongoFilterFactory;
 import sirius.kernel.Startable;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -298,7 +298,7 @@ public class Mango extends BaseMapper<MongoEntity, MongoConstraint, MongoQuery<?
     }
 
     @Override
-    public FilterFactory<MongoConstraint> filters() {
+    public MongoFilterFactory filters() {
         return QueryBuilder.FILTERS;
     }
 

--- a/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
@@ -272,12 +272,9 @@ class SmartQuerySpec extends BaseSpecification {
         when:
         def result = qry.queryList()
         then:
-        result
-                .stream()
-                .
-                        map({ x -> x.getParent().fetchValue().getName() + x.getOtherParent().fetchValue().getName() } as Function)
-                .
-                        collect(Collectors.toList()) == ["Parent 1Parent 2", "Parent 2Parent 1"]
+        result.stream().
+                map({ x -> x.getParent().fetchValue().getName() + x.getOtherParent().fetchValue().getName() } as Function).
+                collect(Collectors.toList()) == ["Parent 1Parent 2", "Parent 2Parent 1"]
     }
 
     def "automatic joins work across several tables"() {
@@ -454,8 +451,7 @@ class SmartQuerySpec extends BaseSpecification {
     def "eq with row values works"() {
         when:
         def items = oma.select(SmartQueryTestEntity.class).
-                where(OMA.FILTERS.eq(new CompoundValue(SmartQueryTestEntity.VALUE).addComponent(SmartQueryTestEntity
-                                                                                                        .TEST_NUMBER),
+                where(OMA.FILTERS.eq(new CompoundValue(SmartQueryTestEntity.VALUE).addComponent(SmartQueryTestEntity.TEST_NUMBER),
                                      new CompoundValue("Test").addComponent(1))).queryList()
         then:
         items.size() == 1

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestChildEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestChildEntity.java
@@ -11,6 +11,7 @@ package sirius.db.jdbc;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.ComplexDelete;
 import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.NullAllowed;
 
 /**
  * Testentity for SmartQuerySpec
@@ -30,6 +31,11 @@ public class SmartQueryTestChildEntity extends SQLEntity {
             SQLEntityRef.on(SmartQueryTestParentEntity.class, SQLEntityRef.OnDelete.CASCADE);
     public static final Mapping OTHER_PARENT = Mapping.named("otherParent");
 
+    @Length(50)
+    @NullAllowed
+    private String parentName;
+    public static final Mapping PARENT_NAME = Mapping.named("parentName");
+
     public String getName() {
         return name;
     }
@@ -44,5 +50,13 @@ public class SmartQueryTestChildEntity extends SQLEntity {
 
     public SQLEntityRef<SmartQueryTestParentEntity> getOtherParent() {
         return otherParent;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(String parentName) {
+        this.parentName = parentName;
     }
 }


### PR DESCRIPTION
Allows queries like
```
SELECT * FROM x WHERE EXISTS (SELECT * FROM y WHERE x.a = y.b AND x.c = y.d)
```
via the `oma.select(...)` interface

Also: QoL improvement: `oma.filters()` is now of the same type as `OMA.FILTERS` (and elastic / mongo likewise)