### PR TITLE
Upgrades clickhouse to version 0.2.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.1.40</version>
+            <version>0.2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -13,7 +13,7 @@ jdbc {
         }
         clickhouse {
             profile = "clickhouse"
-            user = ""
+            user = "default"
             password = ""
             database = "test"
         }


### PR DESCRIPTION
Note: The default clickhouse user is now called "default" instead of being empty.

Fixes: SIRI-539