### PR TITLE
MongoFilterFactory now allows negation of $or constraints.

### DIFF
--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -126,6 +126,9 @@ public class MongoFilterFactory extends FilterFactory<MongoConstraint> {
 
     @Override
     protected MongoConstraint invert(MongoConstraint constraint) {
+        if ("$or".equals(constraint.getKey())) {
+            return new MongoConstraint("$nor", constraint.getObject());
+        }
         if (constraint.getKey().startsWith("$")) {
             throw new IllegalArgumentException(Strings.apply("The %s constraint can't be easily inverted!",
                                                              constraint.getKey()));

--- a/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
+++ b/src/test/java/sirius/db/mongo/MongoFilterFactorySpec.groovy
@@ -127,7 +127,29 @@ class MongoFilterFactorySpec extends BaseSpecification {
              .queryOne().getId() == entityEmpty.getId()
     }
 
-    def "complex constraint cant be inverted"() {
+    def "complex OR-constraint can be inverted"() {
+        setup:
+        MongoStringListEntity entity = new MongoStringListEntity()
+        entity.getList().modify().addAll(["1", "2", "3", "4"])
+        MongoStringListEntity entityEmpty = new MongoStringListEntity()
+        when:
+        mango.update(entity)
+        mango.update(entityEmpty)
+        then:
+        mango.select(MongoStringListEntity.class)
+             .eq(MongoEntity.ID, entity.getId())
+             .where(QueryBuilder.FILTERS.not(QueryBuilder.FILTERS.containsAny(MongoStringListEntity.LIST,
+                                                                              Value.of("4,5,6")).build()))
+             .count() == 0
+        then:
+        mango.select(MongoStringListEntity.class)
+             .eq(MongoEntity.ID, entityEmpty.getId())
+             .where(QueryBuilder.FILTERS.not(QueryBuilder.FILTERS.containsAny(MongoStringListEntity.LIST,
+                                                                              Value.of("4,5,6")).build()))
+             .queryOne().getId() == entityEmpty.getId()
+    }
+
+    def "complex AND-constraint cannot be inverted"() {
         setup:
         MongoStringListEntity entity = new MongoStringListEntity()
         entity.getList().modify().addAll(["1", "2", "3"])
@@ -137,8 +159,8 @@ class MongoFilterFactorySpec extends BaseSpecification {
         when:
         mango.select(MongoStringListEntity.class)
              .eq(MongoEntity.ID, entityEmpty.getId())
-             .where(QueryBuilder.FILTERS.not(QueryBuilder.FILTERS.containsAny(MongoStringListEntity.LIST,
-                                                                              Value.of("4,5,6")).build()))
+             .where(QueryBuilder.FILTERS.not(QueryBuilder.FILTERS.containsAll(MongoStringListEntity.LIST,
+                                                                              Value.of("1,2,3,4")).build()))
              .queryOne()
         then:
         thrown IllegalArgumentException
@@ -279,7 +301,8 @@ class MongoFilterFactorySpec extends BaseSpecification {
         mango.update(e2)
         then:
         mango.select(MangoTestEntity.class)
-             .where(QueryBuilder.FILTERS.oneInField(MangoTestEntity.SUPER_POWERS, Collections.emptyList()).forceEmpty().build()).count() == 1
+             .where(QueryBuilder.FILTERS.oneInField(MangoTestEntity.SUPER_POWERS, Collections.emptyList())
+                                .forceEmpty().build()).count() == 1
     }
 
     def "hasListSize works on List fields"() {


### PR DESCRIPTION
This is done by replacing the `$or` with the `$nor` operator, which effectively returns all documents that fail all parts of the initial or expression.
see https://www.mongodb.com/docs/manual/reference/operator/query/nor/.

Fixes: SIRI-571

NOTE:
The constraint `{ $or: [ { price: 1.99 }, { sale: true } ]  } ` would return all documents that have a price of 1.99 or where the sale field value is true.
The inverted constraint `{ $nor: [ { price: 1.99 }, { sale: true } ]  } ` returns all documents that
- contain the price field whose value is not equal to 1.99 **and** contain the sale field whose value is not equal to true or
- contain the price field whose value is not equal to 1.99 **and** do not contain the sale field or
- do not contain the price field **and** contain the sale field whose value is not equal to true or
- do not contain the price field **and** do not contain the sale field

Make sure to add proper `$exists` constraints where only documents containing the fields in question should be returned.
