### PR TITLE
Fixes a sneaky injection of an Integer object into a Long field.

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -20,6 +20,7 @@ import sirius.db.jdbc.schema.SQLPropertyInfo;
 import sirius.db.jdbc.schema.Table;
 import sirius.db.jdbc.schema.TableColumn;
 import sirius.db.mixing.AccessPath;
+import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixable;
 import sirius.db.mixing.Mixing;
@@ -155,6 +156,19 @@ public class SQLEntityRefProperty extends BaseEntityRefProperty<Long, SQLEntity,
         if (!targetRef.is(referencedId) && referencedId != -1) {
             child.setId(referencedId);
             targetRef.setId(referencedId);
+        }
+    }
+
+    @Override
+    public Object transformFromDatasource(Class<? extends BaseMapper<?, ?, ?>> mapperType, Value object) {
+        Object value = object.get();
+        if (value instanceof Integer intValue) {
+            // We need to convert integers to longs here, as otherwise the autoboxing magic of the JVM will
+            // happily write the Integer object into the Long field of the SQLEntityRef#id, which might cause
+            // ClassCastExceptions downstream...
+            return intValue.longValue();
+        } else {
+            return value;
         }
     }
 }

--- a/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
@@ -9,10 +9,14 @@
 package sirius.db.es.properties;
 
 import sirius.db.es.ElasticEntity;
+import sirius.db.jdbc.SQLEntity;
+import sirius.db.jdbc.SQLEntityRef;
+import sirius.db.jdbc.TestEntity;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Ordinal;
+import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.commons.Amount;
 
 import java.time.LocalDate;
@@ -65,6 +69,9 @@ public class ESDataTypesEntity extends ElasticEntity {
     @NullAllowed
     @Ordinal
     private TestEnum enumValue2;
+
+    @NullAllowed
+    private final SQLEntityRef<TestEntity> sqlEntityRef = SQLEntityRef.on(TestEntity.class, BaseEntityRef.OnDelete.IGNORE);
 
     private int intValue2 = 5;
 
@@ -156,5 +163,9 @@ public class ESDataTypesEntity extends ElasticEntity {
 
     public void setIntValue2(int intValue2) {
         this.intValue2 = intValue2;
+    }
+
+    public SQLEntityRef<TestEntity> getSqlEntityRef() {
+        return sqlEntityRef;
     }
 }

--- a/src/test/java/sirius/db/es/properties/ESDataTypesSpec.groovy
+++ b/src/test/java/sirius/db/es/properties/ESDataTypesSpec.groovy
@@ -257,4 +257,19 @@ class ESDataTypesSpec extends BaseSpecification {
         then:
         test.getTestEnum2() == ESDataTypesEntity.TestEnum.Test2
     }
+
+    def "reading and writing SQLEntityRefs work"() {
+        given:
+        ESDataTypesEntity test = new ESDataTypesEntity()
+        when:
+        test.getSqlEntityRef().setId(1)
+        and:
+        elastic.update(test)
+        and:
+        test = elastic.refreshOrFail(test)
+        then:
+        test.getSqlEntityRef().getId() == 1L
+        and:
+        test.getSqlEntityRef().getId().getClass() == Long.class
+    }
 }


### PR DESCRIPTION
As Elasticsearch stores numbers as Integer, we might end up with
an SQLEntityRef which contains an Integer instead of a Long within
its id field. Under normal use, this will be autoboxed back and
forth by the JVM, but when calling some methods, strange class cast
or event invalid class exceptions start to occur.

We therefore convert the integer into a long.