### PR TITLE
Properly converts entity instances with an empty toString method.

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -102,18 +102,19 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
 
     @Override
     public Object transformValue(Value value) {
-        if (value.isEmptyString()) {
-            return null;
-        }
-
         if (entityRef.getType().isInstance(value.get())) {
             return value.get();
+        }
+
+        if (value.isEmptyString()) {
+            return null;
         }
 
         Optional<E> e = find(entityRef.getType(), value);
         if (e.isEmpty()) {
             throw illegalFieldValue(value);
         }
+
         return e.get();
     }
 


### PR DESCRIPTION
This filter was only targeting empty IDs, therefore we switched the order
to always pass-through values of the expected entity type - even is their
toString representation is empty.