### PR TITLE
Permits to use alternative ports for mongo

### DIFF
--- a/src/main/java/sirius/db/mongo/Mongo.java
+++ b/src/main/java/sirius/db/mongo/Mongo.java
@@ -117,9 +117,10 @@ public class Mongo implements Startable, Stoppable {
     @Explain("We cannot close the client here as it is part of the return value.")
     protected synchronized Tuple<MongoClient, String> setupClient(String database) {
         Extension config = Sirius.getSettings().getExtension("mongo.databases", database);
+        int port = config.get("port").asInt(MONGO_PORT);
         String connectionString = Arrays.stream(config.get("hosts").asString().split(","))
                                         .map(String::trim)
-                                        .map(hostname -> PortMapper.mapPort(SERVICE_NAME, hostname, MONGO_PORT))
+                                        .map(hostname -> PortMapper.mapPort(SERVICE_NAME, hostname, port))
                                         .map(hostAndPort -> hostAndPort.getFirst() + ":" + hostAndPort.getSecond())
                                         .collect(Collectors.joining(","));
         MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder()

--- a/src/main/resources/component-db.conf
+++ b/src/main/resources/component-db.conf
@@ -391,6 +391,9 @@ mongo {
             # Contains the name of the database to connect to.
             db = ""
 
+            # Contains an alternative port to use. When not defined, 27017 will be used by default.
+            port = 27017
+
             # Specifies the username used for authentication. Leave blank if the
             # Mongo instance doesn't require authentication.
             user = ""


### PR DESCRIPTION
and not only the default 27017

Note that all hosts of the cluster will use the defined port

Example:

``` yaml
mongo {
    databases {
        backups {
            hosts = "host1, host2, ..."
            db = "db-name"
            port = 27018
        }
    }
}
```