### PR TITLE
Saves the generated id in elastic entities upon insert

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -252,9 +252,10 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     @Override
     protected void createEntity(ElasticEntity entity, EntityDescriptor entityDescriptor) throws Exception {
         JSONObject data = new JSONObject();
+        String id = determineId(entity);
+        entity.setId(id);
         toJSON(entityDescriptor, entity, data);
 
-        String id = determineId(entity);
         JSONObject response = getLowLevelClient().index(determineWriteAlias(entityDescriptor),
                                                         id,
                                                         determineRouting(entityDescriptor,
@@ -263,7 +264,6 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
                                                         null,
                                                         null,
                                                         data);
-        entity.setId(id);
         if (entityDescriptor.isVersioned()) {
             entity.setPrimaryTerm(response.getLong(RESPONSE_PRIMARY_TERM));
             entity.setSeqNo(response.getLong(RESPONSE_SEQ_NO));


### PR DESCRIPTION
The generated id was passed over as document id, but was not set as an id field in the actual document data, causing all new inserted entities to have a missing id.

The first update after it sets the id, because the doc id is set in the entity when reading, but the isChanged detects the id is missing.

Fixes: SIRI-594