### PR TITLE
Properly emits condition blocks without parameters.

### DIFF
--- a/src/main/java/sirius/db/jdbc/Row.java
+++ b/src/main/java/sirius/db/jdbc/Row.java
@@ -53,6 +53,7 @@ public class Row {
      * @param key the name of the field to retrieve
      * @return the value associated with the given key wrapped as {@link sirius.kernel.commons.Value}
      * @throws java.lang.IllegalArgumentException if an unknown column key is requested
+     * @see #tryGetValue(Object)
      */
     @Nonnull
     public Value getValue(@Nonnull Object key) {
@@ -60,6 +61,20 @@ public class Row {
         if (!fields.containsKey(upperCaseKey)) {
             throw new IllegalArgumentException(Strings.apply("Unknown column: %s in %s", upperCaseKey, this));
         }
+        return Value.of(fields.get(upperCaseKey).getSecond());
+    }
+
+    /**
+     * Returns the value associated with the given key, returns an empty <tt>Value</tt> if the row doesn't contain the
+     * value at all.
+     *
+     * @param key the name of the field to retrieve
+     * @return the value associated with the given key wrapped as {@link sirius.kernel.commons.Value}
+     * @see #getValue(Object)
+     */
+    @Nonnull
+    public Value tryGetValue(@Nonnull Object key) {
+        String upperCaseKey = key.toString().toUpperCase();
         return Value.of(fields.get(upperCaseKey).getSecond());
     }
 

--- a/src/main/java/sirius/db/jdbc/Row.java
+++ b/src/main/java/sirius/db/jdbc/Row.java
@@ -75,7 +75,13 @@ public class Row {
     @Nonnull
     public Value tryGetValue(@Nonnull Object key) {
         String upperCaseKey = key.toString().toUpperCase();
-        return Value.of(fields.get(upperCaseKey).getSecond());
+
+        Tuple<String, Object> value = fields.get(upperCaseKey);
+        if (value == null) {
+            return Value.EMPTY;
+        }
+
+        return Value.of(value.getSecond());
     }
 
     /**


### PR DESCRIPTION
Previously blocks without any parameters were skipped. Now, a block like `[:enabled WHERE x=1]` should be
output (if `enabled` is true), even it it doesn't reference any variable.