### PR TITLE
Removes null byte char in Strings when loading SQL results into Row

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-32.0.0</sirius.kernel>
+        <sirius.kernel>dev-33.0.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
@@ -158,6 +158,8 @@ public abstract class BaseSQLQuery {
             Object obj = rs.getObject(col);
             if (obj instanceof Blob blob) {
                 writeBlobToParameter(fieldName, blob);
+            } else if (obj instanceof String string) {
+                row.fields.put(fieldName.toUpperCase(), Tuple.create(fieldName, string.replace("\0", "")));
             } else {
                 row.fields.put(fieldName.toUpperCase(), Tuple.create(fieldName, obj));
             }


### PR DESCRIPTION
**BREAKING**: Includes breaking version upgrade of sirius-kernel.

ClickHouse pads FixedStrings internally with null-byte chars internally and sadly returns them when querying via jdbc.

Fixes: SIRI-636