### PR TITLE
Improve the SmartQuery#streamBlockwise

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -392,7 +392,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             return parent.getDescriptor().getProperty(mapping.getName()).getValue(parent);
         }
 
-        private static BaseEntity<?> findParent(Mapping mapping, BaseEntity<?> entity) {
+        private BaseEntity<?> findParent(Mapping mapping, BaseEntity<?> entity) {
             if (mapping.getParent() != null) {
                 BaseEntity<?> parentEntity = findParent(mapping.getParent(), entity);
                 if (parentEntity.getDescriptor()

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -370,7 +370,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             for (Tuple<Mapping, Boolean> sorting : effectiveQuery.orderBys) {
                 Mapping sortColumn = sorting.getFirst();
                 boolean sortAscending = sorting.getSecond().booleanValue();
-                Object value = lastValue.getDescriptor().getProperty(sortColumn).getValue(lastValue);
+                Object value = lastValue.getDescriptor().getPropertyValue(sortColumn, lastValue, false);
                 if (sortAscending) {
                     // the order by is ascending -> COLUMN > lastvalue.column
                     leftHandSide.addComponent(sortColumn);

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -387,7 +387,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             return effectiveQuery.where(OMA.FILTERS.gt(leftHandSide, rightHandSide)).queryList();
         }
 
-        private static Object getPropertyValue(Mapping mapping, BaseEntity<?> entity) {
+        private Object getPropertyValue(Mapping mapping, BaseEntity<?> entity) {
             BaseEntity<?> parent = findParent(mapping, entity);
             return parent.getDescriptor().getProperty(mapping.getName()).getValue(parent);
         }

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -1071,7 +1071,12 @@ public class EntityDescriptor {
         Property property = getProperty(mapping.getName());
         if (property instanceof BaseEntityRefProperty<?, ?, ?> ref) {
             BaseEntityRef<?, ?> entityRef = ref.getEntityRef(entity);
-            return resolveJoins ? entityRef.fetchValue() : entityRef.getValueIfPresent().orElseThrow();
+            return resolveJoins ? entityRef.fetchValue() : entityRef.getValueIfPresent().orElseThrow(() -> {
+                return new IllegalArgumentException(Strings.apply(
+                        "The BaseEntityRef `%s` is not loaded, but is requested by the mapping `%s`.",
+                        entityRef.getUniqueObjectName(),
+                        mapping));
+            });
         }
         return property.getValue(entity);
     }

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -1053,12 +1053,13 @@ public class EntityDescriptor {
      * If the mapping contains joins, they are only resolved if (a) they are already fetched from the database, or (b)
      * the parameter value of {@code resolveJoins} evaluates to {@code true}. In all other cases, an Exception is thrown.
      * <p>
-     * Usually, this can be achieved using {@link #getProperty(Mapping)}.{@link Property#getValue(Object)}. However, no
-     * property can be created if the mapping is a JOIN-mapping.
+     * Usually, this can be achieved using <p>
+     * {@link #getProperty(Mapping)}{@code .}{@link Property#getValue(Object) getValue(Object)}<p>
+     * However, no property can be created if the mapping is a JOIN-mapping, rendering this method useless in that case.
      *
      * @param mapping      the mapping; may contain joins
      * @param entity       the entity
-     * @param resolveJoins whether to load joined columns from the database
+     * @param resolveJoins whether to load joined columns from the database instead of throwing
      * @return the value of the mapping
      */
     public Object getPropertyValue(Mapping mapping, Object entity, boolean resolveJoins) {

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -24,11 +24,9 @@ import sirius.db.mixing.annotations.SkipDefaultValue;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.TranslationSource;
 import sirius.db.mixing.annotations.Versioned;
-import sirius.db.mixing.properties.BaseEntityRefProperty;
 import sirius.db.mixing.properties.LocalDateTimeProperty;
 import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.Constraint;
-import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Explain;
@@ -1045,40 +1043,6 @@ public class EntityDescriptor {
         }
 
         return prop;
-    }
-
-    /**
-     * Get the value of a mapping for an entity.
-     * <p>
-     * If the mapping contains joins, they are only resolved if (a) they are already fetched from the database, or (b)
-     * the parameter value of {@code resolveJoins} evaluates to {@code true}. In all other cases, an Exception is thrown.
-     * <p>
-     * Usually, this can be achieved using <p>
-     * {@link #getProperty(Mapping)}{@code .}{@link Property#getValue(Object) getValue(Object)}<p>
-     * However, no property can be created if the mapping is a JOIN-mapping, rendering this method useless in that case.
-     *
-     * @param mapping      the mapping; may contain joins
-     * @param entity       the entity
-     * @param resolveJoins whether to load joined columns from the database instead of throwing
-     * @return the value of the mapping
-     */
-    public Object getPropertyValue(Mapping mapping, Object entity, boolean resolveJoins) {
-        if (mapping.getParent() != null) {
-            Object parent = getPropertyValue(mapping.getParent(), entity, resolveJoins);
-            return mixing.getDescriptor(parent.getClass())
-                         .getPropertyValue(Mapping.named(mapping.getName()), parent, resolveJoins);
-        }
-        Property property = getProperty(mapping.getName());
-        if (property instanceof BaseEntityRefProperty<?, ?, ?> ref) {
-            BaseEntityRef<?, ?> entityRef = ref.getEntityRef(entity);
-            return resolveJoins ? entityRef.fetchValue() : entityRef.getValueIfPresent().orElseThrow(() -> {
-                return new IllegalArgumentException(Strings.apply(
-                        "The BaseEntityRef `%s` is not loaded, but is requested by the mapping `%s`.",
-                        entityRef.getUniqueObjectName(),
-                        mapping));
-            });
-        }
-        return property.getValue(entity);
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -142,8 +142,16 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
      */
     protected abstract Optional<E> find(Class<E> type, Value value);
 
+    /**
+     * Resolve the referenced EntityRef
+     * <p>
+     * In contrast to {@link #find(Class, Value)}, this does not do a database lookup right away.
+     *
+     * @param entity the entity that contains the entity ref
+     * @return the entity ref
+     */
     @SuppressWarnings("unchecked")
-    protected R getEntityRef(Object entity) {
+    public R getEntityRef(Object entity) {
         try {
             return (R) super.getValueFromField(entity);
         } catch (Exception e) {

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -143,9 +143,10 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
     protected abstract Optional<E> find(Class<E> type, Value value);
 
     /**
-     * Resolves the referenced entity.
+     * Resolves the corresponding entity ref.
      * <p>
-     * In contrast to {@link #find(Class, Value)}, this does not do a database lookup right away.
+     * In contrast to {@link #find(Class, Value)}, this does not do a database lookup right away, and instead returns
+     * the EntityRef. The caller can decide by himself if he wants to fetch the object, or just use its id etc.
      *
      * @param entity the entity that contains the entity ref
      * @return the entity ref

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -143,7 +143,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
     protected abstract Optional<E> find(Class<E> type, Value value);
 
     /**
-     * Resolve the referenced EntityRef
+     * Resolves the referenced entity.
      * <p>
      * In contrast to {@link #find(Class, Value)}, this does not do a database lookup right away.
      *


### PR DESCRIPTION
Previously, we required the querys ORDER BY clauses did not contain JOINed mappings. Now we can support these