### PR TITLE
SIRI-677: Allows for COUNT(DISTINCT ...) statements for only one distinct field.

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -852,19 +852,17 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         Compiler c = new Compiler(descriptor);
         c.getSELECTBuilder().append("SELECT COUNT(");
 
-        if (fields.size() > 1) {
-            if (distinct) {
-                c.getSELECTBuilder().append("DISTINCT ");
-                appendFieldList(c, false);
-            } else {
-                throw Exceptions.createHandled()
-                                .to(OMA.LOG)
-                                .withSystemErrorMessage("Only use multiple arguments in 'fields' and 'count' in "
-                                                        + "combination with the 'distinct' statement")
-                                .handle();
-            }
-        } else {
+        if (fields.isEmpty() || (fields.size() == 1 && !distinct)) {
             c.getSELECTBuilder().append("*");
+        } else if (distinct) {
+            c.getSELECTBuilder().append("DISTINCT ");
+            appendFieldList(c, false);
+        } else {
+            throw Exceptions.createHandled()
+                            .to(OMA.LOG)
+                            .withSystemErrorMessage("Only use multiple arguments in 'fields' and 'count' in "
+                                                    + "combination with the 'distinct' statement")
+                            .handle();
         }
 
         c.getSELECTBuilder().append(")");

--- a/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
@@ -252,9 +252,8 @@ class SmartQuerySpec extends BaseSpecification {
     def "automatic joins work when sorting by a referenced field"() {
         given:
         SmartQuery<SmartQueryTestChildEntity> qry = oma.select(SmartQueryTestChildEntity.class)
-                                                       .
-                                                               orderAsc(SmartQueryTestChildEntity.PARENT.join(
-                                                                       SmartQueryTestParentEntity.NAME))
+                                                       .orderAsc(SmartQueryTestChildEntity.PARENT.join(
+                                                               SmartQueryTestParentEntity.NAME))
         when:
         def result = qry.queryList()
         then:
@@ -304,9 +303,9 @@ class SmartQuerySpec extends BaseSpecification {
         when:
         def result = qry.queryList()
         then:
-        result.stream().
-                map({ x -> x.getParent().fetchValue().getName() + x.getOtherParent().fetchValue().getName() } as Function).
-                collect(Collectors.toList()) == ["Parent 1Parent 2", "Parent 2Parent 1"]
+        result.stream()
+              .map({ x -> x.getParent().fetchValue().getName() + x.getOtherParent().fetchValue().getName() } as Function)
+              .collect(Collectors.toList()) == ["Parent 1Parent 2", "Parent 2Parent 1"]
     }
 
     def "automatic joins work across several tables"() {
@@ -483,7 +482,8 @@ class SmartQuerySpec extends BaseSpecification {
     def "eq with row values works"() {
         when:
         def items = oma.select(SmartQueryTestEntity.class).
-                where(OMA.FILTERS.eq(new CompoundValue(SmartQueryTestEntity.VALUE).addComponent(SmartQueryTestEntity.TEST_NUMBER),
+                where(OMA.FILTERS.eq(new CompoundValue(SmartQueryTestEntity.VALUE).addComponent(SmartQueryTestEntity
+                                                                                                        .TEST_NUMBER),
                                      new CompoundValue("Test").addComponent(1))).queryList()
         then:
         items.size() == 1

--- a/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SmartQuerySpec.groovy
@@ -14,6 +14,7 @@ import sirius.db.mixing.Mixing
 import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Strings
 import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
 
 import java.util.function.Function
 import java.util.stream.Collectors
@@ -28,10 +29,12 @@ class SmartQuerySpec extends BaseSpecification {
         oma.select(SmartQueryTestParentEntity.class).delete()
         oma.select(SmartQueryTestChildEntity.class).delete()
         oma.select(SmartQueryTestChildChildEntity.class).delete()
+        oma.select(SmartQueryTestCountEntity.class).delete()
 
         fillSmartQueryTestEntity()
         fillSmartQueryTestChildAndParentEntity()
         fillSmartQueryTestLargeTableEntity()
+        fillSmartQueryCountEntity()
     }
 
     private void fillSmartQueryTestEntity() {
@@ -84,6 +87,28 @@ class SmartQuerySpec extends BaseSpecification {
             e.setTestNumber(i)
             oma.update(e)
         }
+    }
+
+    private void fillSmartQueryCountEntity() {
+        SmartQueryTestCountEntity e1 = new SmartQueryTestCountEntity();
+        e1.setFieldOne("1")
+        e1.setFieldTwo("1")
+        oma.update(e1)
+
+        SmartQueryTestCountEntity e2 = new SmartQueryTestCountEntity();
+        e2.setFieldOne("1")
+        e2.setFieldTwo("2")
+        oma.update(e2)
+
+        SmartQueryTestCountEntity e3 = new SmartQueryTestCountEntity();
+        e3.setFieldOne("3")
+        e3.setFieldTwo("3")
+        oma.update(e3)
+
+        SmartQueryTestCountEntity e4 = new SmartQueryTestCountEntity();
+        e4.setFieldOne("3")
+        e4.setFieldTwo("3")
+        oma.update(e4)
     }
 
     def "queryList returns all entities"() {
@@ -488,5 +513,48 @@ class SmartQuerySpec extends BaseSpecification {
         items.get(0).testNumber == 1
         and:
         items.get(1).testNumber == 3
+    }
+
+
+    def "count distinct for one field returns a correct number of entities"() {
+        given:
+        SmartQuery<SmartQueryTestCountEntity> qry = oma.select(SmartQueryTestCountEntity.class)
+                                                       .distinctFields(SmartQueryTestCountEntity.FIELD_ONE)
+        when:
+        def result = qry.count()
+        then:
+        result == 2
+    }
+
+    def "count distinct for two fields returns a correct number of entities"() {
+        given:
+        SmartQuery<SmartQueryTestCountEntity> qry = oma.select(SmartQueryTestCountEntity.class)
+                                                       .distinctFields(SmartQueryTestCountEntity.FIELD_ONE,
+                                                                       SmartQueryTestCountEntity.FIELD_TWO)
+        when:
+        def result = qry.count()
+        then:
+        result == 3
+    }
+
+    def "count for one field without distinct modifier returns a correct number of entities"() {
+        given:
+        SmartQuery<SmartQueryTestCountEntity> qry = oma.select(SmartQueryTestCountEntity.class)
+                                                       .fields(SmartQueryTestCountEntity.FIELD_ONE)
+        when:
+        def result = qry.count()
+        then:
+        result == 4
+    }
+
+    def "count for two fields without distinct modifier throws an exception"() {
+        given:
+        SmartQuery<SmartQueryTestCountEntity> qry = oma.select(SmartQueryTestCountEntity.class)
+                                                       .fields(SmartQueryTestCountEntity.FIELD_ONE,
+                                                               SmartQueryTestCountEntity.FIELD_TWO)
+        when:
+        def result = qry.count()
+        then:
+        thrown(HandledException)
     }
 }

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestCountEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestCountEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.ComplexDelete;
+import sirius.db.mixing.annotations.Length;
+
+/**
+ * Test entity for SmartQuerySpec concerning distinct and not distinct counts
+ */
+@ComplexDelete(false)
+public class SmartQueryTestCountEntity extends SQLEntity {
+
+    public static final Mapping FIELD_ONE = Mapping.named("fieldOne");
+    @Length(50)
+    private String fieldOne;
+
+    public static final Mapping FIELD_TWO = Mapping.named("fieldTwo");
+    @Length(50)
+    private String fieldTwo;
+
+    public String getFieldOne() {
+        return fieldOne;
+    }
+
+    public void setFieldOne(String fieldOne) {
+        this.fieldOne = fieldOne;
+    }
+
+    public String getFieldTwo() {
+        return fieldTwo;
+    }
+
+    public void setFieldTwo(String fieldTwo) {
+        this.fieldTwo = fieldTwo;
+    }
+}


### PR DESCRIPTION
Before the change, the SmartQuery#count method would execute a COUNT(*) statement if the query would select one or zero fields independent of a possible DISTINCT modifier. Now, calling SmartQuery#count for 1 non distinct field still works as before (for compatibility with already existing logic), but counting on 1 distinct field now results in the expected behaviour. Invoking SmartQuery#count with 2 or more non distinct fields still throw an exception just like before.