### PR TITLE
Relaxes "is active" aborts

### DIFF
--- a/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
@@ -125,7 +125,7 @@ public abstract class BaseSQLQuery {
      * Executes the given query returning the first matching row.
      * <p>
      * If the resulting row contains a {@link Blob} an {@link OutputStream} as to be passed in as parameter
-     * with the name name as the column. The contents of the blob will then be written into the given
+     * with the name as the column. The contents of the blob will then be written into the given
      * output stream (without closing it).
      *
      * @return the first matching row for the given query or <tt>null</tt> if no matching row was found

--- a/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
@@ -95,8 +95,9 @@ public abstract class BaseSQLQuery {
     protected void processResultSet(Predicate<Row> handler,
                                     Limit effectiveLimit,
                                     ResultSet resultSet,
-                                    TaskContext taskContext) throws SQLException {
-        while (resultSet.next() && taskContext.isActive()) {
+                                    TaskContext taskContext,
+                                    boolean longRunning) throws SQLException {
+        while (resultSet.next() && (taskContext.isActive() && longRunning)) {
             Row row = loadIntoRow(resultSet);
             if (effectiveLimit.nextRow() && !handler.test(row)) {
                 return;

--- a/src/main/java/sirius/db/jdbc/SQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/SQLQuery.java
@@ -123,7 +123,7 @@ public class SQLQuery extends BaseSQLQuery {
                 try (ResultSet rs = stmt.executeQuery()) {
                     w.submitMicroTiming(MICROTIMING_KEY, "ITERATE: " + sql);
                     TaskContext tc = TaskContext.get();
-                    processResultSet(handler, effectiveLimit, rs, tc);
+                    processResultSet(handler, effectiveLimit, rs, tc, longRunning || effectiveLimit == Limit.UNLIMITED);
                 }
             }
         }

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -486,15 +486,15 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                                Compiler compiler,
                                Limit limit,
                                boolean nativeLimit,
-                               ResultSet rs,
+                               ResultSet resultSet,
                                boolean longRunning) throws Exception {
-        TaskContext tc = TaskContext.get();
-        Set<String> columns = dbs.readColumns(rs);
-        while (rs.next() && (tc.isActive() || !longRunning)) {
+        TaskContext taskContext = TaskContext.get();
+        Set<String> columns = dbs.readColumns(resultSet);
+        while (resultSet.next() && (taskContext.isActive() || !longRunning)) {
             if (nativeLimit || limit.nextRow()) {
-                SQLEntity e = makeEntity(descriptor, null, columns, rs);
-                compiler.executeJoinFetches(e, columns, rs);
-                if (!handler.test((E) e)) {
+                SQLEntity entity = makeEntity(descriptor, null, columns, resultSet);
+                compiler.executeJoinFetches(entity, columns, resultSet);
+                if (!handler.test((E) entity)) {
                     return;
                 }
             }

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -396,18 +396,19 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             if (mapping.getParent() != null) {
                 BaseEntity<?> parentEntity = findParent(mapping.getParent(), entity);
                 if (parentEntity.getDescriptor()
-                                .getProperty(mapping.getParent().getName()) instanceof BaseEntityRefProperty<?, ?, ?> ref) {
+                                .getProperty(mapping.getParent()
+                                                    .getName()) instanceof BaseEntityRefProperty<?, ?, ?> ref) {
                     BaseEntityRef<?, ?> entityRef = ref.getEntityRef(parentEntity);
-                return entityRef.getValueIfPresent().orElseThrow(() -> {
-                    return new IllegalArgumentException(Strings.apply(
-                            "The BaseEntityRef `%s` is not loaded, but is requested by the mapping `%s`.",
-                            entityRef.getUniqueObjectName(),
+                    return entityRef.getValueIfPresent().orElseThrow(() -> {
+                        return new IllegalArgumentException(Strings.apply(
+                                "The BaseEntityRef `%s` is not loaded, but is requested by the mapping `%s`.",
+                                entityRef.getUniqueObjectName(),
                                 mapping.getParent()));
-                });
+                    });
                 } else {
                     throw new IllegalArgumentException(Strings.apply("You cannot join on the non-ref property `%s`",
                                                                      mapping.getParent()));
-            }
+                }
             }
             return entity;
         }

--- a/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
@@ -34,13 +34,13 @@ public class BatchSQLQuery extends BaseSQLQuery {
 
     @Override
     public void iterate(Predicate<Row> handler, @Nullable Limit limit) throws SQLException {
-        Watch w = Watch.start();
+        Watch watch = Watch.start();
 
         try (PreparedStatement preparedStatement = query.prepareStmt()) {
-            ResultSet rs = preparedStatement.executeQuery();
-            query.average.addValue(w.elapsedMillis());
-            TaskContext tc = TaskContext.get();
-            processResultSet(handler, limit, rs, tc, true);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            query.average.addValue(watch.elapsedMillis());
+            TaskContext taskContext = TaskContext.get();
+            processResultSet(handler, limit, resultSet, taskContext, true);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
@@ -16,6 +16,7 @@ import sirius.kernel.commons.Watch;
 
 import javax.annotation.Nullable;
 import java.sql.Blob;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.Predicate;
@@ -35,7 +36,8 @@ public class BatchSQLQuery extends BaseSQLQuery {
     public void iterate(Predicate<Row> handler, @Nullable Limit limit) throws SQLException {
         Watch w = Watch.start();
 
-        try (ResultSet rs = query.prepareStmt().executeQuery()) {
+        try (PreparedStatement preparedStatement = query.prepareStmt()) {
+            ResultSet rs = preparedStatement.executeQuery();
             query.average.addValue(w.elapsedMillis());
             TaskContext tc = TaskContext.get();
             processResultSet(handler, limit, rs, tc, true);

--- a/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
@@ -38,7 +38,7 @@ public class BatchSQLQuery extends BaseSQLQuery {
         try (ResultSet rs = query.prepareStmt().executeQuery()) {
             query.average.addValue(w.elapsedMillis());
             TaskContext tc = TaskContext.get();
-            processResultSet(handler, limit, rs, tc);
+            processResultSet(handler, limit, rs, tc, true);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
@@ -141,9 +141,9 @@ public class ExternalBatchQuery extends BaseSQLQuery {
 
     @Override
     public void iterate(Predicate<Row> handler, @Nullable Limit limit) throws SQLException {
-        try (ResultSet rs = statement.executeQuery()) {
-            TaskContext tc = TaskContext.get();
-            processResultSet(handler, limit, rs, tc, true);
+        try (ResultSet resultSet = statement.executeQuery()) {
+            TaskContext taskContext = TaskContext.get();
+            processResultSet(handler, limit, resultSet, taskContext, true);
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
@@ -143,7 +143,7 @@ public class ExternalBatchQuery extends BaseSQLQuery {
     public void iterate(Predicate<Row> handler, @Nullable Limit limit) throws SQLException {
         try (ResultSet rs = statement.executeQuery()) {
             TaskContext tc = TaskContext.get();
-            processResultSet(handler, limit, rs, tc);
+            processResultSet(handler, limit, rs, tc, true);
         }
     }
 

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -318,7 +318,7 @@ public class Finder extends QueryBuilder<Finder> {
             }
 
             boolean keepGoing = processor.test(new Doc(doc));
-            if (!keepGoing || !taskContext.isActive()) {
+            if (!keepGoing || (!taskContext.isActive() && longRunning)) {
                 return;
             }
         }


### PR DESCRIPTION
Use case: 
- when a job gets aborted on UI, we want to quickly abort the processing
- but: the previous state prevented some quickly runnings db request to occur that might be required after the abort
- now we detect longer running requests, and only abort those
- means e.g. a queryOne or queryList can still run on a aborted job/task

