### PR TITLE
Allows to prioritize handlers similar to BeforeSave

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -39,6 +39,7 @@ import sirius.kernel.commons.ValueSupplier;
 import sirius.kernel.di.Injector;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.PriorityParts;
+import sirius.kernel.di.std.Priorized;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
@@ -134,12 +135,28 @@ public class EntityDescriptor {
     /**
      * A list of all additional handlers to be executed once an entity is about to be deleted
      */
-    protected final List<Consumer<Object>> beforeDeleteHandlers = new ArrayList<>();
+    protected List<Consumer<Object>> sortedBeforeDeleteHandlers;
+
+    /**
+     * Collects handlers which are executed once an entity is about to be deleted. Some checks might depend on others,
+     * so {@link BeforeDelete} permits to specify a property which is used to here to sort the handlers.
+     * <p>
+     * {@link #sortedBeforeDeleteHandlers} will be filled when first accessed and provide a properly sorted list
+     */
+    protected PriorityCollector<Consumer<Object>> beforeDeleteHandlerCollector = PriorityCollector.create();
 
     /**
      * A list of all additional handlers to be executed once an entity was successfully deleted
      */
-    protected final List<Consumer<Object>> afterDeleteHandlers = new ArrayList<>();
+    protected List<Consumer<Object>> sortedAfterDeleteHandlers;
+
+    /**
+     * Collects handlers which are executed once an entity was successfully deleted. Some checks might depend on others,
+     * so {@link AfterDelete} permits to specify a property which is used to here to sort the handlers.
+     * <p>
+     * {@link #sortedAfterDeleteHandlers} will be filled when first accessed and provide a properly sorted list
+     */
+    protected PriorityCollector<Consumer<Object>> afterDeleteHandlerCollector = PriorityCollector.create();
 
     /**
      * A list of all additional handlers to be executed once an entity is about to be saved
@@ -147,22 +164,39 @@ public class EntityDescriptor {
     protected List<Consumer<Object>> sortedBeforeSaveHandlers;
 
     /**
-     * Collects handlers which are executed before entity is saved, need to be in order (some checks might depend on others),
-     * {@link BeforeSave} permits to specify a property which is used to here to sort the handlers.
+     * Collects handlers which are executed once an entity is about to be saved. Some checks might depend on others,
+     * so {@link BeforeSave} permits to specify a property which is used to here to sort the handlers.
      * <p>
-     * <tt>sortedBeforeSaveHandlers</tt> will be filled when first accessed and provide a properly sorted list
+     * {@link #sortedBeforeSaveHandlers} will be filled when first accessed and provide a properly sorted list
      */
     protected PriorityCollector<Consumer<Object>> beforeSaveHandlerCollector = PriorityCollector.create();
 
     /**
      * A list of all additional handlers to be executed once an entity is saved
      */
-    protected final List<Consumer<Object>> afterSaveHandlers = new ArrayList<>();
+    protected List<Consumer<Object>> sortedAfterSaveHandlers;
+
+    /**
+     * Collects handlers which are executed once an entity is saved. Some checks might depend on others,
+     * so {@link AfterSave} permits to specify a property which is used to here to sort the handlers.
+     * <p>
+     * {@link #sortedAfterSaveHandlers} will be filled when first accessed and provide a properly sorted list
+     */
+    protected PriorityCollector<Consumer<Object>> afterSaveHandlerCollector = PriorityCollector.create();
 
     /**
      * A list of all handlers to be executed once an entity is validated
      */
-    protected final List<BiConsumer<Object, Consumer<String>>> validateHandlers = new ArrayList<>();
+    protected List<BiConsumer<Object, Consumer<String>>> sortedValidateHandlers;
+
+    /**
+     * Collects handlers which are executed once an entity is validated. Some checks might depend on others,
+     * so {@link OnValidate} permits to specify a property which is used to here to sort the handlers.
+     * <p>
+     * {@link #sortedValidateHandlers} will be filled when first accessed and provide a properly sorted list
+     */
+    protected PriorityCollector<BiConsumer<Object, Consumer<String>>> onValidateHandlerCollector =
+            PriorityCollector.create();
 
     /**
      * Contains all known property factories. These are used to transform fields defined by entity classes to
@@ -508,7 +542,7 @@ public class EntityDescriptor {
      * @param entity the entity which was saved
      */
     public void afterSave(Object entity) {
-        for (Consumer<Object> handler : afterSaveHandlers) {
+        for (Consumer<Object> handler : getSortedAfterSaveHandlers()) {
             if (handler != null) {
                 handler.accept(entity);
             }
@@ -524,6 +558,19 @@ public class EntityDescriptor {
                 asBaseEntity(entity).persistedData.put(p, p.getValueAsCopy(entity));
             }
         }
+    }
+
+    private List<Consumer<Object>> getSortedAfterSaveHandlers() {
+        if (sortedAfterSaveHandlers == null) {
+            synchronized (this) {
+                if (afterSaveHandlerCollector != null) {
+                    sortedAfterSaveHandlers = afterSaveHandlerCollector.getData();
+                    afterSaveHandlerCollector = null;
+                }
+            }
+        }
+
+        return sortedAfterSaveHandlers;
     }
 
     private BaseEntity<?> asBaseEntity(Object entity) {
@@ -542,7 +589,7 @@ public class EntityDescriptor {
      */
     public List<String> validate(Object entity) {
         List<String> warnings = new ArrayList<>();
-        for (BiConsumer<Object, Consumer<String>> validator : validateHandlers) {
+        for (BiConsumer<Object, Consumer<String>> validator : getSortedValidateHandlers()) {
             if (validator != null) {
                 validator.accept(entity, warnings::add);
             }
@@ -562,7 +609,7 @@ public class EntityDescriptor {
      * @return <tt>true</tt> if there are validation warnings, <tt>false</tt> otherwise
      */
     public boolean hasValidationWarnings(Object entity) {
-        for (BiConsumer<Object, Consumer<String>> validator : validateHandlers) {
+        for (BiConsumer<Object, Consumer<String>> validator : getSortedValidateHandlers()) {
             ValueHolder<Boolean> hasWarnings = ValueHolder.of(false);
             validator.accept(entity, warning -> hasWarnings.accept(true));
             if (Boolean.TRUE.equals(hasWarnings.get())) {
@@ -571,6 +618,19 @@ public class EntityDescriptor {
         }
 
         return false;
+    }
+
+    private List<BiConsumer<Object, Consumer<String>>> getSortedValidateHandlers() {
+        if (sortedValidateHandlers == null) {
+            synchronized (this) {
+                if (onValidateHandlerCollector != null) {
+                    sortedValidateHandlers = onValidateHandlerCollector.getData();
+                    onValidateHandlerCollector = null;
+                }
+            }
+        }
+
+        return sortedValidateHandlers;
     }
 
     /**
@@ -585,7 +645,7 @@ public class EntityDescriptor {
                 property.onBeforeDelete(entity);
             }
         }
-        for (Consumer<Object> handler : beforeDeleteHandlers) {
+        for (Consumer<Object> handler : getSortedBeforeDeleteHandlers()) {
             if (handler != null && context.isActive()) {
                 handler.accept(entity);
             }
@@ -595,6 +655,19 @@ public class EntityDescriptor {
                 handler.accept(entity);
             }
         }
+    }
+
+    private List<Consumer<Object>> getSortedBeforeDeleteHandlers() {
+        if (sortedBeforeDeleteHandlers == null) {
+            synchronized (this) {
+                if (beforeDeleteHandlerCollector != null) {
+                    sortedBeforeDeleteHandlers = beforeDeleteHandlerCollector.getData();
+                    beforeDeleteHandlerCollector = null;
+                }
+            }
+        }
+
+        return sortedBeforeDeleteHandlers;
     }
 
     /**
@@ -634,11 +707,24 @@ public class EntityDescriptor {
         for (Property property : properties.values()) {
             property.onAfterDelete(entity);
         }
-        for (Consumer<Object> handler : afterDeleteHandlers) {
+        for (Consumer<Object> handler : getSortedAfterDeleteHandlers()) {
             if (handler != null) {
                 handler.accept(entity);
             }
         }
+    }
+
+    private List<Consumer<Object>> getSortedAfterDeleteHandlers() {
+        if (sortedAfterDeleteHandlers == null) {
+            synchronized (this) {
+                if (afterDeleteHandlerCollector != null) {
+                    sortedAfterDeleteHandlers = afterDeleteHandlerCollector.getData();
+                    afterDeleteHandlerCollector = null;
+                }
+            }
+        }
+
+        return sortedAfterDeleteHandlers;
     }
 
     /**
@@ -733,18 +819,38 @@ public class EntityDescriptor {
                                                       createInvokeHandler(accessPath, method));
         }
         if (method.isAnnotationPresent(AfterSave.class)) {
-            descriptor.afterSaveHandlers.add(createInvokeHandler(accessPath, method));
+            assertNotYetCollected(descriptor.afterSaveHandlerCollector,
+                                  AfterSave.class.getSimpleName(),
+                                  descriptor.getType().getName(),
+                                  method);
+            descriptor.afterSaveHandlerCollector.add(method.getAnnotation(AfterSave.class).priority(),
+                                                     createInvokeHandler(accessPath, method));
         }
         if (method.isAnnotationPresent(BeforeDelete.class)) {
-            descriptor.beforeDeleteHandlers.add(createInvokeHandler(accessPath, method));
+            assertNotYetCollected(descriptor.beforeDeleteHandlerCollector,
+                                  BeforeDelete.class.getSimpleName(),
+                                  descriptor.getType().getName(),
+                                  method);
+            descriptor.beforeDeleteHandlerCollector.add(method.getAnnotation(BeforeDelete.class).priority(),
+                                                        createInvokeHandler(accessPath, method));
             handleComplexDelete(descriptor, method);
         }
         if (method.isAnnotationPresent(AfterDelete.class)) {
-            descriptor.afterDeleteHandlers.add(createInvokeHandler(accessPath, method));
+            assertNotYetCollected(descriptor.afterDeleteHandlerCollector,
+                                  AfterDelete.class.getSimpleName(),
+                                  descriptor.getType().getName(),
+                                  method);
+            descriptor.afterDeleteHandlerCollector.add(method.getAnnotation(AfterDelete.class).priority(),
+                                                       createInvokeHandler(accessPath, method));
             handleComplexDelete(descriptor, method);
         }
         if (method.isAnnotationPresent(OnValidate.class)) {
-            descriptor.validateHandlers.add(createValidator(accessPath, method));
+            assertNotYetCollected(descriptor.onValidateHandlerCollector,
+                                  OnValidate.class.getSimpleName(),
+                                  descriptor.getType().getName(),
+                                  method);
+            descriptor.onValidateHandlerCollector.add(method.getAnnotation(OnValidate.class).priority(),
+                                                      createValidator(accessPath, method));
         }
     }
 

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -139,7 +139,7 @@ public class EntityDescriptor {
 
     /**
      * Collects handlers which are executed once an entity is about to be deleted. Some checks might depend on others,
-     * so {@link BeforeDelete} permits to specify a property which is used to here to sort the handlers.
+     * so {@link BeforeDelete} permits to specify a property which is used here to sort the handlers.
      * <p>
      * {@link #sortedBeforeDeleteHandlers} will be filled when first accessed and provide a properly sorted list
      */
@@ -152,7 +152,7 @@ public class EntityDescriptor {
 
     /**
      * Collects handlers which are executed once an entity was successfully deleted. Some checks might depend on others,
-     * so {@link AfterDelete} permits to specify a property which is used to here to sort the handlers.
+     * so {@link AfterDelete} permits to specify a property which is used here to sort the handlers.
      * <p>
      * {@link #sortedAfterDeleteHandlers} will be filled when first accessed and provide a properly sorted list
      */
@@ -165,7 +165,7 @@ public class EntityDescriptor {
 
     /**
      * Collects handlers which are executed once an entity is about to be saved. Some checks might depend on others,
-     * so {@link BeforeSave} permits to specify a property which is used to here to sort the handlers.
+     * so {@link BeforeSave} permits to specify a property which is used here to sort the handlers.
      * <p>
      * {@link #sortedBeforeSaveHandlers} will be filled when first accessed and provide a properly sorted list
      */
@@ -178,7 +178,7 @@ public class EntityDescriptor {
 
     /**
      * Collects handlers which are executed once an entity is saved. Some checks might depend on others,
-     * so {@link AfterSave} permits to specify a property which is used to here to sort the handlers.
+     * so {@link AfterSave} permits to specify a property which is used here to sort the handlers.
      * <p>
      * {@link #sortedAfterSaveHandlers} will be filled when first accessed and provide a properly sorted list
      */
@@ -191,7 +191,7 @@ public class EntityDescriptor {
 
     /**
      * Collects handlers which are executed once an entity is validated. Some checks might depend on others,
-     * so {@link OnValidate} permits to specify a property which is used to here to sort the handlers.
+     * so {@link OnValidate} permits to specify a property which is used here to sort the handlers.
      * <p>
      * {@link #sortedValidateHandlers} will be filled when first accessed and provide a properly sorted list
      */

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -686,7 +686,14 @@ public class EntityDescriptor {
      * @param handler the handler to add
      */
     public void addBeforeDeleteHandler(Consumer<Object> handler) {
-        beforeDeleteHandlers.add(handler);
+        if (beforeDeleteHandlerCollector == null) {
+            throw Exceptions.handle()
+                            .to(Mixing.LOG)
+                            .withSystemErrorMessage("Cannot provide a before-delete-handler, as the sorted list was"
+                                                    + " already computed. Descriptor: %s", getType().getName())
+                            .handle();
+        }
+        beforeDeleteHandlerCollector.add(Priorized.DEFAULT_PRIORITY, handler);
     }
 
     /**
@@ -695,7 +702,14 @@ public class EntityDescriptor {
      * @param handler the handler to add
      */
     public void addValidationHandler(BiConsumer<Object, Consumer<String>> handler) {
-        validateHandlers.add(handler);
+        if (onValidateHandlerCollector == null) {
+            throw Exceptions.handle()
+                            .to(Mixing.LOG)
+                            .withSystemErrorMessage("Cannot provide an on-validate-handler, as the sorted list was"
+                                                    + " already computed. Descriptor: %s", getType().getName())
+                            .handle();
+        }
+        onValidateHandlerCollector.add(Priorized.DEFAULT_PRIORITY, handler);
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/annotations/AfterDelete.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterDelete.java
@@ -9,6 +9,7 @@
 package sirius.db.mixing.annotations;
 
 import sirius.db.mixing.Mixable;
+import sirius.kernel.di.std.Priorized;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -23,4 +24,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface AfterDelete {
+
+    /**
+     * Determines the execution order of all after delete handlers.
+     *
+     * @return the execution priority. Handlers will be executed in ascending order, the one with the lowest value
+     * will be executed first.
+     */
+    int priority() default Priorized.DEFAULT_PRIORITY;
 }

--- a/src/main/java/sirius/db/mixing/annotations/AfterSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterSave.java
@@ -10,6 +10,7 @@ package sirius.db.mixing.annotations;
 
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Mixable;
+import sirius.kernel.di.std.Priorized;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -26,4 +27,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface AfterSave {
+
+    /**
+     * Determines the execution order of all after save handlers.
+     *
+     * @return the execution priority. Handlers will be executed in ascending order, the one with the lowest value
+     * will be executed first.
+     */
+    int priority() default Priorized.DEFAULT_PRIORITY;
 }

--- a/src/main/java/sirius/db/mixing/annotations/BeforeDelete.java
+++ b/src/main/java/sirius/db/mixing/annotations/BeforeDelete.java
@@ -9,6 +9,7 @@
 package sirius.db.mixing.annotations;
 
 import sirius.db.mixing.Mixable;
+import sirius.kernel.di.std.Priorized;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -23,4 +24,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface BeforeDelete {
+
+    /**
+     * Determines the execution order of all before delete handlers.
+     *
+     * @return the execution priority. Handlers will be executed in ascending order, the one with the lowest value
+     * will be executed first.
+     */
+    int priority() default Priorized.DEFAULT_PRIORITY;
 }

--- a/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
@@ -31,7 +31,7 @@ public @interface BeforeSave {
     /**
      * Determines the execution order of all before save handlers.
      *
-     * @return the execution priority. Handlers will be executed in an ascending order, the one with the lowest value
+     * @return the execution priority. Handlers will be executed in ascending order, the one with the lowest value
      * will be executed first.
      */
     int priority() default Priorized.DEFAULT_PRIORITY;

--- a/src/main/java/sirius/db/mixing/annotations/OnValidate.java
+++ b/src/main/java/sirius/db/mixing/annotations/OnValidate.java
@@ -9,6 +9,7 @@
 package sirius.db.mixing.annotations;
 
 import sirius.db.mixing.Mixable;
+import sirius.kernel.di.std.Priorized;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -26,4 +27,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface OnValidate {
+
+    /**
+     * Determines the execution order of all validate handlers.
+     *
+     * @return the execution priority. Handlers will be executed in ascending order, the one with the lowest value
+     * will be executed first.
+     */
+    int priority() default Priorized.DEFAULT_PRIORITY;
 }


### PR DESCRIPTION
### Description

This applies to the following:
- AfterDelete
- AfterSave
- BeforeDelete
- OnValidate

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-767](https://scireum.myjetbrains.com/youtrack/issue/SIRI-767)

### Checklist

- [x] The code change has been tested and works locally
- [x] No commented-out code is introduced in this PR
- [x] No new Sonarlint issues were added (except for TODOs and Deprecations)
- [x] The code was formatted via IntelliJ and follows general best practices (see [CodeStyle / JavaDoc](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc))
- [x] Testing: No tests added or changed
- [x] Documentation: linked the handler collectors to their target lists via JavaDoc
