### PR TITLE
Implements an assert deletable method

### DIFF
--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -579,6 +579,20 @@ public class EntityDescriptor {
     }
 
     /**
+     * Invokes all <tt>rejectDeleteHandlers</tt> for the given entity.
+     *
+     * @param entity the entity which is about to be deleted
+     */
+    protected void invokeRejectDeleteHandlers(Object entity) {
+        TaskContext context = TaskContext.get();
+        for (Consumer<Object> handler : rejectDeleteHandlers) {
+            if (handler != null && context.isActive()) {
+                handler.accept(entity);
+            }
+        }
+    }
+
+    /**
      * Invokes all <tt>beforeDeleteHandlers</tt> and then all <tt>cascadeDeleteHandlers</tt> for the given entity.
      *
      * @param entity the entity which is about to be deleted

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -209,7 +209,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
             } else if (deleteHandler == BaseEntityRef.OnDelete.SET_NULL) {
                 getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteSetNull);
             } else if (deleteHandler == BaseEntityRef.OnDelete.REJECT) {
-                getReferencedDescriptor().addBeforeDeleteHandler(this::onDeleteReject);
+                getReferencedDescriptor().addRejectDeleteHandler(this::onDeleteReject);
             }
         } catch (Exception e) {
             Mixing.LOG.WARN("Error when linking property %s of %s: %s (%s)",

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -238,7 +238,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
 
                 getReferencedDescriptor().addCascadeDeleteHandler(this::onDeleteSetNull);
             } else if (deleteHandler == BaseEntityRef.OnDelete.REJECT) {
-                getReferencedDescriptor().addBeforeDeleteHandler(this::onDeleteReject);
+                getReferencedDescriptor().addRejectDeleteHandler(this::onDeleteReject);
             }
         } catch (Exception e) {
             Mixing.LOG.WARN("Error when linking property %s of %s: %s (%s)",


### PR DESCRIPTION
This can be used to assert that a deletion won't directly fail for complex-delete entities. This is useful if an entity is both referenced via CASCADE or SET_NULL, and REJECT delete modes.

Fixes: [SE-12557](https://scireum.myjetbrains.com/youtrack/issue/SE-12557)