### PR TITLE
Properly encapsulates qdrant matches

### DIFF
--- a/src/main/java/sirius/db/qdrant/Match.java
+++ b/src/main/java/sirius/db/qdrant/Match.java
@@ -21,16 +21,14 @@ public class Match {
     private final float score;
 
     /**
-     * Creates a new match with the given id, score and payload.
+     * Creates a new match from the given JSON response
      *
-     * @param id      the id of the matched point
-     * @param score   the score or distance of the match
-     * @param payload the payload of the matched point
+     * @param match the match as returned by qdrant
      */
-    public Match(String id, float score, JSONObject payload) {
-        this.id = id;
-        this.score = score;
-        this.payload = payload;
+    public Match(JSONObject match) {
+        this.id = match.getString("id");
+        this.score = match.getFloat("score");
+        this.payload = match.getJSONObject("payload");
     }
 
     public String getId() {

--- a/src/main/java/sirius/db/qdrant/Match.java
+++ b/src/main/java/sirius/db/qdrant/Match.java
@@ -1,0 +1,55 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.qdrant;
+
+import com.alibaba.fastjson.JSONObject;
+
+/**
+ * Represents a single match returned by a {@link Search}.
+ */
+public class Match {
+
+    private final String id;
+    private final JSONObject payload;
+
+    private final float score;
+
+    /**
+     * Creates a new match with the given id, score and payload.
+     *
+     * @param id      the id of the matched point
+     * @param score   the score or distance of the match
+     * @param payload the payload of the matched point
+     */
+    public Match(String id, float score, JSONObject payload) {
+        this.id = id;
+        this.score = score;
+        this.payload = payload;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Extracts the requested payload field and casts it to the given type.
+     *
+     * @param fieldType the expected field type
+     * @param field     the field to load
+     * @param <T>       the expected field type
+     * @return the value of the field or <tt>null</tt> if the field is not present
+     */
+    public <T> T getPayload(Class<T> fieldType, String field) {
+        return fieldType.cast(payload.get(field));
+    }
+
+    public float getScore() {
+        return score;
+    }
+}

--- a/src/main/java/sirius/db/qdrant/Search.java
+++ b/src/main/java/sirius/db/qdrant/Search.java
@@ -97,12 +97,7 @@ public class Search {
                                                      + "/points/search",
                                                      query);
         JSONArray points = response.getJSONArray("result");
-        return points.stream()
-                     .map(JSONObject.class::cast)
-                     .map(point -> new Match(point.getString("id"),
-                                             point.getFloat("score"),
-                                             point.getJSONObject("payload")))
-                     .toList();
+        return points.stream().map(JSONObject.class::cast).map(Match::new).toList();
     }
 
     private JSONArray buildConstraints(List<Tuple<String, Object>> filters) {

--- a/src/test/java/sirius/db/qdrant/QdrantSpec.groovy
+++ b/src/test/java/sirius/db/qdrant/QdrantSpec.groovy
@@ -52,7 +52,9 @@ class QdrantSpec extends BaseSpecification {
         ])
         and:
         def result = qdrant.db().query("test-search", Tensors.fromList([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-                           .queryPayload(Integer.class, "x", 2)
+                           .execute(2, "x").stream()
+                           .map { it.getPayload(Integer.class, "x") }
+                           .collect { it }
         then:
         result.size() == 2
         and:


### PR DESCRIPTION
We commonly need to extract multiple payloads and also want to have access to the score of each match.