### PR TITLE
Fixes some search issues (SIRI-801 & SIRI-800)

### DIFF
--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -255,9 +255,18 @@ public abstract class QueryCompiler<C extends Constraint> {
     private C parseExpression() {
         skipWhitespace();
 
-        if (reader.current().is('!') || reader.current().is('-')) {
-            reader.consume();
-            return factory.not(parseExpression());
+        if ((reader.current().is('!') || reader.current().is('-'))) {
+            if (reader.next().isWhitespace() ||reader.next()
+                                                     .isEndOfInput()) {
+                // If there is a single "-" or "!" in a string like "foo - bar", we simly skip the dash
+                // as it is ignored by the indexing tokenizer anyway...
+                reader.consume();
+                return null;
+            } else {
+                // A "-" or "!" right before a field name starts a negation...
+                reader.consume();
+                return factory.not(parseExpression());
+            }
         }
 
         if (reader.current().is('(')) {

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -19,6 +19,7 @@ import sirius.db.mixing.properties.LocalDateTimeProperty;
 import sirius.db.mixing.properties.LocalTimeProperty;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.db.mixing.query.constraints.FilterFactory;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -178,7 +179,7 @@ public abstract class QueryCompiler<C extends Constraint> {
     /**
      * Determines if the compiler was put into "debug mode".
      * <p>
-     * This can switched on by putting "??" in front of a query. Subsequent callers of the compiler can then
+     * This can be switched on by putting "??" in front of a query. Subsequent callers of the compiler can then
      * log the parsed query to help when tracing down problems.
      *
      * @return <tt>true</tt> if the compiler was put into debug mode, <tt>false</tt> otherwise
@@ -413,7 +414,7 @@ public abstract class QueryCompiler<C extends Constraint> {
      * an operation is created via {@link #parseOperation(Mapping, Property)}.
      * <p>
      * If the property cannot be resolved, the given <tt>token</tt> is passed into {@link #compileCustomField(String)}
-     * so that a sub class of the compiler can generate a constraint for a virtual field. If this also doesn't yield
+     * so that a subclass of the compiler can generate a constraint for a virtual field. If this also doesn't yield
      * a constraint, a regular search in the default fields is generated. This might be necessarry so that tokens like
      * an:value can be used as search term as long as no property named "an" exists.
      *

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -209,7 +209,8 @@ public abstract class QueryCompiler<C extends Constraint> {
     }
 
     private boolean isAtOR() {
-        return reader.current().is('o', 'O') && reader.next().is('r', 'R');
+        return reader.current().is('o', 'O') && reader.next().is('r', 'R') && (reader.next(2).isWhitespace()
+                                                                               || reader.next(2).is('('));
     }
 
     private C parseAND() {
@@ -242,8 +243,13 @@ public abstract class QueryCompiler<C extends Constraint> {
         return reader.current().is('&') && reader.next().is('&');
     }
 
+    @SuppressWarnings("java:S1067")
+    @Explain("We rather keep things in one check here...")
     private boolean isAtAND() {
-        return reader.current().is('a', 'A') && reader.next().is('n', 'N') && reader.next(2).is('d', 'D');
+        return reader.current().is('a', 'A')
+               && reader.next().is('n', 'N')
+               && reader.next(2).is('d', 'D')
+               && (reader.next(2).isWhitespace() || reader.next(2).is('('));
     }
 
     private C parseExpression() {

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -250,7 +250,7 @@ public abstract class QueryCompiler<C extends Constraint> {
         return reader.current().is('a', 'A')
                && reader.next().is('n', 'N')
                && reader.next(2).is('d', 'D')
-               && (reader.next(2).isWhitespace() || reader.next(2).is('('));
+               && (reader.next(3).isWhitespace() || reader.next(3).is('('));
     }
 
     private C parseExpression() {

--- a/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
@@ -281,4 +281,16 @@ class SQLQueryCompilerSpec extends BaseSpecification {
         then:
         queryCompiler.compile().toString() == "is = chat"
     }
+
+    def "compiling a field with OR in its name works"() {
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "firstname: x orderNumber: 1",
+                Collections.emptyList())
+        then:
+        queryCompiler.compile().toString() == "(firstname = x AND orderNumber = 1)"
+    }
+
 }

--- a/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
@@ -293,4 +293,15 @@ class SQLQueryCompilerSpec extends BaseSpecification {
         queryCompiler.compile().toString() == "(firstname = x AND orderNumber = 1)"
     }
 
+    def "compiling 'foo - bar' works as expected"() {
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "foo - bar",
+                Arrays.asList((QueryField.eq(TestEntity.FIRSTNAME))))
+        then:
+        queryCompiler.compile().toString() == "(firstname = foo AND firstname = bar)"
+    }
+
 }

--- a/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLQueryCompilerSpec.groovy
@@ -89,6 +89,28 @@ class SQLQueryCompilerSpec extends BaseSpecification {
         queryCompiler.compile().toString() == "NOT(firstname IS NULL)"
     }
 
+    def "compiling 'firstname:X OR lastname:Y' works as expected"() {
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "firstname:X OR lastname:Y",
+                Arrays.asList(QueryField.contains(TestEntity.FIRSTNAME)))
+        then:
+        queryCompiler.compile().toString() == "(firstname = X OR lastname = Y)"
+    }
+
+    def "compiling 'firstname:X AND lastname:Y' works as expected"() {
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "firstname:X AND lastname:Y",
+                Arrays.asList(QueryField.contains(TestEntity.FIRSTNAME)))
+        then:
+        queryCompiler.compile().toString() == "(firstname = X AND lastname = Y)"
+    }
+
     def "compiling '!firstname:X OR lastname:Y' works as expected"() {
         when:
         SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
@@ -291,6 +313,17 @@ class SQLQueryCompilerSpec extends BaseSpecification {
                 Collections.emptyList())
         then:
         queryCompiler.compile().toString() == "(firstname = x AND orderNumber = 1)"
+    }
+
+    def "compiling a field with AND in its name works"() {
+        when:
+        SQLQueryCompiler queryCompiler = new SQLQueryCompiler(
+                OMA.FILTERS,
+                mixing.getDescriptor(TestEntity.class),
+                "firstname: x andx: 1",
+                Collections.emptyList())
+        then:
+        queryCompiler.compile().toString() == "(firstname = x AND andx = 1)"
     }
 
     def "compiling 'foo - bar' works as expected"() {

--- a/src/test/java/sirius/db/jdbc/TestEntity.java
+++ b/src/test/java/sirius/db/jdbc/TestEntity.java
@@ -26,6 +26,10 @@ public class TestEntity extends SQLEntity {
     public static final Mapping AGE = Mapping.named("age");
     private int age;
 
+
+    public static final Mapping ORDER_NUMBER = Mapping.named("orderNumber");
+    private int orderNumber;
+
     public String getFirstname() {
         return firstname;
     }

--- a/src/test/java/sirius/db/jdbc/TestEntity.java
+++ b/src/test/java/sirius/db/jdbc/TestEntity.java
@@ -26,9 +26,11 @@ public class TestEntity extends SQLEntity {
     public static final Mapping AGE = Mapping.named("age");
     private int age;
 
-
     public static final Mapping ORDER_NUMBER = Mapping.named("orderNumber");
-    private int orderNumber;
+    private int orderNumber = 0;
+
+    public static final Mapping ANDX = Mapping.named("andx");
+    private int andx = 0;
 
     public String getFirstname() {
         return firstname;


### PR DESCRIPTION
Fields starting with OR or  AND are not supported (e.g. orderNumber). We previously misinterpret them as boolean operator.

"Free flying" "-" or "!" are now ignored instead of randomly inverting the next token. So "foo - bar" searches for foo + bar but "foo -bar" search for foo + NOT(bar) and "foo-bar" searches for foo-bar