### PR TITLE
Warns about wrong nullable annotation on entity properties

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -190,7 +190,22 @@ public abstract class Property extends Composable {
      * for primitive types).
      */
     protected void determineNullability() {
-        this.nullable = !field.getType().isPrimitive() && field.isAnnotationPresent(NullAllowed.class);
+        this.nullable = !field.getType().isPrimitive() && checkNullabilityAnnotation();
+    }
+
+    private boolean checkNullabilityAnnotation() {
+        if (Arrays.stream(field.getDeclaredAnnotations())
+                  .map(Annotation::annotationType)
+                  .map(Class::getSimpleName)
+                  .anyMatch("Nullable"::equals)) {
+            Mixing.LOG.WARN(
+                    "A @Nullable annotation was detected on field %s of entity %s. This is most likely a mistake. Please use @NullAllowed instead.",
+                    field.getName(),
+                    field.getDeclaringClass().getName());
+            // We warn about this, but we still accept it, because the intent of the annotation usage is clear.
+            return true;
+        }
+        return field.isAnnotationPresent(NullAllowed.class);
     }
 
     /**


### PR DESCRIPTION
Its a realistic error (that already happened in at least one case) that optional fields in an entity where annotated with Nullable instead of the mixing annotation NullAllowed. If we detect a wrong annotation we output a warning at system startup. As the intent by the developer that added the wrong is pretty clear we still act like the correct annotation was used in such cases to prevent wrong schemas from being created.

We check this by the annotation name instead of a specific implementation (like `javax.annotation.Nullable`) as there are quite a view packages offer annotations with the same name and using the wrong import is quite a common mistake. 

> WARNING [mixing - Property.java:201] A @Nullable annotation was detected on field code of entity oxomi.content.ContentEntity. This is most likely a mistake. Please use @NullAllowed instead.