### PR TITLE
ElasticSearch: More robust and useful query across multiple indices

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -703,6 +703,23 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     /**
+     * Creates a new query which can be used to fetch entities of the given types.
+     * <p>
+     * Note: All entities to query across must extend a common super class.
+     *
+     * @param commonSuperClass the common super class of all entities to query across
+     * @param types            the types of the entities to query across
+     * @param <E>              the generic common type of the entities to query across
+     * @return a new query which can be used to fetch entities of the given types
+     */
+    @SafeVarargs
+    public final <E extends ElasticEntity> ElasticQuery<E> selectMultiple(Class<E> commonSuperClass,
+                                                                          Class<? extends E>... types) {
+        return new ElasticQuery<E>(mixing.getDescriptor(types[0]),
+                                   getLowLevelClient()).withAdditionalIndices(Arrays.stream(types).skip(1));
+    }
+
+    /**
      * Creates a new suggestion query.
      * <p>
      * A suggestion query can be used to generate term or phrase suggestions for a given input text.

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -319,10 +319,8 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      * @param additionalEntitiesToQuery the additional entities to be queried
      * @return the query itself for fluent method calls
      */
-    @SafeVarargs
-    public final ElasticQuery<E> withAdditionalIndices(Class<? extends ElasticEntity>... additionalEntitiesToQuery) {
-        this.additionalDescriptors =
-                Arrays.stream(additionalEntitiesToQuery).map(type -> mixing.getDescriptor(type)).toList();
+    protected final ElasticQuery<E> withAdditionalIndices(Stream<Class<? extends E>> additionalEntitiesToQuery) {
+        this.additionalDescriptors = additionalEntitiesToQuery.map(type -> mixing.getDescriptor(type)).toList();
 
         return this;
     }

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -1052,7 +1052,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
                                       limit,
                                       buildPayload());
         for (JsonNode obj : Json.getArrayAt(this.response, HITS_POINTER)) {
-            // This is the mist common use case, so we handle it first...
+            // This is the most common use case, so we handle it first...
             if (additionalDescriptors == null || additionalDescriptors.isEmpty()) {
                 ElasticEntity entity = Elastic.make(descriptor, (ObjectNode) obj);
                 if (!handler.test((E) entity)) {


### PR DESCRIPTION
### BREAKING CHANGE

- Calls to `ElasticQuery::withAdditionalIndices` have to be replaced by a call to `Elastic::selectMultiple`

Example: 

```
elastic.selectMultiple(SearchableContent.class,
                       SearchableCatalog.class,
                       SearchableGallery.class,
                       SearchableVideo.class)
```

![image](https://github.com/scireum/sirius-db/assets/2427877/b91d4cce-4656-4538-811e-47f929f52f54)

Fixes: [OX-10043](https://scireum.myjetbrains.com/youtrack/issue/OX-10043)