### PR TITLE
ElasticSearch: Adds variant of selectMultiple that takes a list of types

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -720,6 +720,22 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
     }
 
     /**
+     * Creates a new query which can be used to fetch entities of the given types.
+     * <p>
+     * Note: All entities to query across must extend a common super class.
+     *
+     * @param commonSuperClass the common super class of all entities to query across
+     * @param types            the types of the entities to query across
+     * @param <E>              the generic common type of the entities to query across
+     * @return a new query which can be used to fetch entities of the given types
+     */
+    public final <E extends ElasticEntity> ElasticQuery<E> selectMultiple(Class<E> commonSuperClass,
+                                                                          List<Class<? extends E>> types) {
+        return new ElasticQuery<E>(mixing.getDescriptor(types.get(0)),
+                                   getLowLevelClient()).withAdditionalIndices(types.stream().skip(1));
+    }
+
+    /**
      * Creates a new suggestion query.
      * <p>
      * A suggestion query can be used to generate term or phrase suggestions for a given input text.


### PR DESCRIPTION
This sometimes is easier to work with than varargs, for example when dynamically generating the list of types.

Fixes: [OX-10074](https://scireum.myjetbrains.com/youtrack/issue/OX-10074)