### PR TITLE
Permits EntityRefs to fetch values using a secondary node

### DIFF
--- a/src/main/java/sirius/db/es/types/ElasticRef.java
+++ b/src/main/java/sirius/db/es/types/ElasticRef.java
@@ -69,6 +69,11 @@ public class ElasticRef<E extends ElasticEntity> extends BaseEntityRef<String, E
     }
 
     @Override
+    protected Optional<E> findInSecondary(Class<E> type, String id) {
+        return find(type, id);
+    }
+
+    @Override
     protected String coerceToId(Object id) {
         return id.toString();
     }

--- a/src/main/java/sirius/db/jdbc/SQLEntityRef.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntityRef.java
@@ -84,6 +84,11 @@ public class SQLEntityRef<E extends SQLEntity> extends BaseEntityRef<Long, E> {
     }
 
     @Override
+    protected Optional<E> findInSecondary(Class<E> type, Long id) {
+        return oma.findInSecondary(type, id);
+    }
+
+    @Override
     protected Long coerceToId(Object id) {
         try {
             if (id instanceof Long number) {

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -224,6 +224,8 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
 
     /**
      * Performs the lookup of the entity with the given id using a secondary node of a DB cluster.
+     * <p>
+     * DBs not supporting this falls back to {@link #find(Class, Serializable)}.
      *
      * @param type the type to search for
      * @param id   the id to lookup

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -169,15 +169,18 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
      */
     public E fetchValue() {
-        if (value == null && id != null) {
-            Optional<E> entity = find(type, id);
-            if (entity.isPresent()) {
-                value = entity.get();
-            } else {
-                id = null;
-            }
-        }
-        return value;
+        return fetchValue(false);
+    }
+
+    /**
+     * Returns the effective entity object which is referenced using a secondary node of a DB cluster.
+     * <p>
+     * Note, this might cause a database lookup if the entity is not prefetched.
+     *
+     * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     */
+    public E fetchValueFromSecondary() {
+        return fetchValue(true);
     }
 
     /**
@@ -301,5 +304,17 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
         } else {
             return "(empty)";
         }
+    }
+
+    private E fetchValue(boolean useSecondary) {
+        if (value == null && id != null) {
+            Optional<E> entity = useSecondary ? findInSecondary(type, id) : find(type, id);
+            if (entity.isPresent()) {
+                value = entity.get();
+            } else {
+                id = null;
+            }
+        }
+        return value;
     }
 }

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -169,18 +169,34 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
      */
     public E fetchValue() {
-        return fetchValue(false);
+        if (value == null && id != null) {
+            Optional<E> entity = find(type, id);
+            if (entity.isPresent()) {
+                value = entity.get();
+            } else {
+                id = null;
+            }
+        }
+        return value;
     }
 
     /**
      * Returns the effective entity object which is referenced using a secondary node of a DB cluster.
      * <p>
-     * Note, this might cause a database lookup if the entity is not prefetched.
+     * Note, this values returned by this method will never be cached and a new lookup is always performed.
      *
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
      */
     public E fetchValueFromSecondary() {
-        return fetchValue(true);
+        if (value == null && id != null) {
+            Optional<E> entity = findInSecondary(type, id);
+            if (entity.isPresent()) {
+                return entity.get();
+            } else {
+                id = null;
+            }
+        }
+        return value;
     }
 
     /**
@@ -304,17 +320,5 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
         } else {
             return "(empty)";
         }
-    }
-
-    private E fetchValue(boolean useSecondary) {
-        if (value == null && id != null) {
-            Optional<E> entity = useSecondary ? findInSecondary(type, id) : find(type, id);
-            if (entity.isPresent()) {
-                value = entity.get();
-            } else {
-                id = null;
-            }
-        }
-        return value;
     }
 }

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -190,11 +190,7 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
     public E fetchValueFromSecondary() {
         if (value == null && id != null) {
             Optional<E> entity = findInSecondary(type, id);
-            if (entity.isPresent()) {
-                return entity.get();
-            } else {
-                id = null;
-            }
+            return entity.orElse(null);
         }
         return value;
     }

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -204,6 +204,15 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
     protected abstract Optional<E> find(Class<E> type, I id);
 
     /**
+     * Performs the lookup of the entity with the given id using a secondary node of a DB cluster.
+     *
+     * @param type the type to search for
+     * @param id   the id to lookup
+     * @return the matching entity wrapped as optional or an empty optional of the entity doesn't exist
+     */
+    protected abstract Optional<E> findInSecondary(Class<E> type, I id);
+
+    /**
      * Sets the entity being referenced.
      *
      * @param value the entity being referenced or <tt>null</tt> if no entity is referenced.

--- a/src/main/java/sirius/db/mongo/types/MongoRef.java
+++ b/src/main/java/sirius/db/mongo/types/MongoRef.java
@@ -69,6 +69,11 @@ public class MongoRef<E extends MongoEntity> extends BaseEntityRef<String, E> {
     }
 
     @Override
+    protected Optional<E> findInSecondary(Class<E> type, String id) {
+        return mango.findInSecondary(type, id);
+    }
+
+    @Override
     protected String coerceToId(Object id) {
         return id.toString();
     }


### PR DESCRIPTION
...of a clustered DB setup.

Note that calling EntityRef.fetchFromSecondary always performs a lookup and the value returned (if any) will not be cached.