### PR TITLE
ES: Uses more consistent naming for custom sorting functions

### DIFF
--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -97,6 +97,14 @@ public class AggregationBuilder {
     public static final String VALUE_COUNT = "value_count";
 
     /**
+     * Type string for bucket sort aggregations.
+     *
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-sort-aggregation.html">
+     * ElasticSearch reference page for bucket sort aggregations</a>
+     */
+    public static final String BUCKET_SORT = "bucket_sort";
+
+    /**
      * Type string for composite aggregations
      *
      * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html">
@@ -176,6 +184,16 @@ public class AggregationBuilder {
      */
     public static AggregationBuilder createValueCount(String name, Mapping field) {
         return new AggregationBuilder(VALUE_COUNT, null, name).field(field);
+    }
+
+    /**
+     * Creates a bucket sort aggregation builder.
+     *
+     * @param name the name of the aggregation
+     * @return the builder itself for fluent method calls
+     */
+    public static AggregationBuilder createBucketSort(String name, boolean asc) {
+        return new AggregationBuilder(BUCKET_SORT, null, name).field(field);
     }
 
     /**

--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.mixing.Mapping;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 
@@ -121,10 +120,10 @@ public class AggregationBuilder {
     private static final String MIN_DOC_COUNT = "min_doc_count";
     private static final String AFTER = "after";
 
-    private String name;
-    private String type;
+    private final String name;
+    private final String type;
     private ObjectNode body = Json.createObject();
-    private String path;
+    private final String path;
     private List<AggregationBuilder> subAggregations;
     private List<AggregationBuilder> sourceAggregations;
 
@@ -298,8 +297,6 @@ public class AggregationBuilder {
      * @param body the body to use
      * @return the builder itself for fluent method calls
      */
-    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
-    @Explain("We do not create an extra copy here for performance reasons, as the scope is quite limited")
     public AggregationBuilder withBody(ObjectNode body) {
         this.body = body;
         return this;

--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -97,14 +97,6 @@ public class AggregationBuilder {
     public static final String VALUE_COUNT = "value_count";
 
     /**
-     * Type string for bucket sort aggregations.
-     *
-     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-sort-aggregation.html">
-     * ElasticSearch reference page for bucket sort aggregations</a>
-     */
-    public static final String BUCKET_SORT = "bucket_sort";
-
-    /**
      * Type string for composite aggregations
      *
      * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html">
@@ -184,16 +176,6 @@ public class AggregationBuilder {
      */
     public static AggregationBuilder createValueCount(String name, Mapping field) {
         return new AggregationBuilder(VALUE_COUNT, null, name).field(field);
-    }
-
-    /**
-     * Creates a bucket sort aggregation builder.
-     *
-     * @param name the name of the aggregation
-     * @return the builder itself for fluent method calls
-     */
-    public static AggregationBuilder createBucketSort(String name, boolean asc) {
-        return new AggregationBuilder(BUCKET_SORT, null, name).field(field);
     }
 
     /**

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -23,7 +23,6 @@ import sirius.db.mixing.query.Query;
 import sirius.db.mixing.query.constraints.FilterFactory;
 import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.async.TaskContext;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.PullBasedSpliterator;
 import sirius.kernel.commons.Strings;
@@ -1199,8 +1198,6 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      *
      * @return the response as JSON
      */
-    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
-    @Explain("Performing a deep copy of the whole object is most probably an overkill here.")
     public ObjectNode getRawResponse() {
         if (response == null) {
             if (accessBlockWise()) {

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -575,9 +575,46 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      *
      * @param sortBuilder a sort builder
      * @return the query itself for fluent method calls
+     * @deprecated use {@link #orderBy(SortBuilder)} instead
      */
+    @Deprecated(forRemoval = true)
     public ElasticQuery<E> sort(SortBuilder sortBuilder) {
-        return sort(sortBuilder.build());
+        return orderBy(sortBuilder.build());
+    }
+
+    /**
+     * Adds a sort statement to the query.
+     *
+     * @param sortSpec a JSON object describing a sort requirement
+     * @return the query itself for fluent method calls
+     * @deprecated use {@link #orderBy(ObjectNode)} instead
+     */
+    @Deprecated(forRemoval = true)
+    public ElasticQuery<E> sort(ObjectNode sortSpec) {
+        return orderBy(sortSpec);
+    }
+
+    /**
+     * Adds a sort statement for the given field to the query.
+     *
+     * @param field    the field to sort by
+     * @param sortSpec a JSON object describing a sort requirement
+     * @return the query itself for fluent method calls
+     * @deprecated use {@link #orderBy(Mapping, ObjectNode)} instead
+     */
+    @Deprecated(forRemoval = true)
+    public ElasticQuery<E> sort(Mapping field, ObjectNode sortSpec) {
+        return orderBy(Json.createObject().set(field.toString(), sortSpec));
+    }
+
+    /**
+     * Adds a sort statement to the query.
+     *
+     * @param sortBuilder a sort builder
+     * @return the query itself for fluent method calls
+     */
+    public ElasticQuery<E> orderBy(SortBuilder sortBuilder) {
+        return orderBy(sortBuilder.build());
     }
 
     /**
@@ -586,7 +623,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      * @param sortSpec a JSON object describing a sort requirement
      * @return the query itself for fluent method calls
      */
-    public ElasticQuery<E> sort(ObjectNode sortSpec) {
+    public ElasticQuery<E> orderBy(ObjectNode sortSpec) {
         this.sorts = autoinit(this.sorts);
         sorts.add(sortSpec);
         return this;
@@ -599,8 +636,8 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      * @param sortSpec a JSON object describing a sort requirement
      * @return the query itself for fluent method calls
      */
-    public ElasticQuery<E> sort(Mapping field, ObjectNode sortSpec) {
-        return sort(Json.createObject().set(field.toString(), sortSpec));
+    public ElasticQuery<E> orderBy(Mapping field, ObjectNode sortSpec) {
+        return orderBy(Json.createObject().set(field.toString(), sortSpec));
     }
 
     /**
@@ -611,7 +648,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      */
     @Override
     public ElasticQuery<E> orderAsc(Mapping field) {
-        return sort(field, Json.createObject().put(KEY_ORDER, KEY_ASC));
+        return orderBy(field, Json.createObject().put(KEY_ORDER, KEY_ASC));
     }
 
     /**
@@ -622,7 +659,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
      */
     @Override
     public ElasticQuery<E> orderDesc(Mapping field) {
-        return sort(field, Json.createObject().put(KEY_ORDER, KEY_DESC));
+        return orderBy(field, Json.createObject().put(KEY_ORDER, KEY_DESC));
     }
 
     /**

--- a/src/main/java/sirius/db/es/SortBuilder.java
+++ b/src/main/java/sirius/db/es/SortBuilder.java
@@ -14,7 +14,7 @@ import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;
 
 /**
- * Helper class which generates sorts for elasticsearch which can be used via {@link ElasticQuery#order(SortBuilder)}.
+ * Helper class which generates sorts for elasticsearch which can be used via {@link ElasticQuery#orderBy(SortBuilder)}.
  */
 public class SortBuilder {
 
@@ -65,8 +65,8 @@ public class SortBuilder {
         MEDIAN
     }
 
-    private String field;
-    private ObjectNode body = Json.createObject();
+    private final String field;
+    private final ObjectNode body = Json.createObject();
 
     private SortBuilder(String field) {
         this.field = field;

--- a/src/main/java/sirius/db/es/SortBuilder.java
+++ b/src/main/java/sirius/db/es/SortBuilder.java
@@ -14,7 +14,7 @@ import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;
 
 /**
- * Helper class which generates sorts for elasticsearch which can be used via {@link ElasticQuery#sort(SortBuilder)}.
+ * Helper class which generates sorts for elasticsearch which can be used via {@link ElasticQuery#order(SortBuilder)}.
  */
 public class SortBuilder {
 

--- a/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
@@ -97,8 +97,8 @@ class ElasticQuerySpec extends BaseSpecification {
         elastic.refresh(QueryTestEntity.class)
         def entities = elastic.select(QueryTestEntity.class)
                               .eq(QueryTestEntity.VALUE, "SORT")
-                              .order(SortBuilder.on(QueryTestEntity.COUNTER)
-                                                .order(SortBuilder.Order.DESC))
+                              .orderBy(SortBuilder.on(QueryTestEntity.COUNTER)
+                                                  .order(SortBuilder.Order.DESC))
                               .queryList()
         then:
         entities.size() == 100

--- a/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
+++ b/src/test/java/sirius/db/es/ElasticQuerySpec.groovy
@@ -97,8 +97,8 @@ class ElasticQuerySpec extends BaseSpecification {
         elastic.refresh(QueryTestEntity.class)
         def entities = elastic.select(QueryTestEntity.class)
                               .eq(QueryTestEntity.VALUE, "SORT")
-                              .sort(SortBuilder.on(QueryTestEntity.COUNTER)
-                                               .order(SortBuilder.Order.DESC))
+                              .order(SortBuilder.on(QueryTestEntity.COUNTER)
+                                                .order(SortBuilder.Order.DESC))
                               .queryList()
         then:
         entities.size() == 100
@@ -322,9 +322,9 @@ class ElasticQuerySpec extends BaseSpecification {
         elastic.refresh(QueryTestEntity.class)
         when:
         def result = elastic.select(QueryTestEntity.class)
-                           .eq(QueryTestEntity.VALUE, "NAMED-OR")
-                           .where(Elastic.FILTERS.namedOr("namedOr", Elastic.FILTERS.eq(QueryTestEntity.COUNTER, 1),
-                                                          Elastic.FILTERS.eq(QueryTestEntity.COUNTER, 2))).queryList()
+                            .eq(QueryTestEntity.VALUE, "NAMED-OR")
+                            .where(Elastic.FILTERS.namedOr("namedOr", Elastic.FILTERS.eq(QueryTestEntity.COUNTER, 1),
+                                                           Elastic.FILTERS.eq(QueryTestEntity.COUNTER, 2))).queryList()
         then:
         result.size() == 2
         result.get(0).isMatchedNamedQuery("namedOr")


### PR DESCRIPTION
#### BREAKING CHANGE

* Calls to any of the now deprecated `sort` variants in Tagliatelle templates could break tests.

The inherited methods that ElasticQuery has to implement are named `orderByAsc`, ... So also naming these methods `orderBy` makes them a lot more discoverable in the API structure. The old ones are left intact and marked as deprecated and call the new variants internally.

Fixes: [OX-10079](https://scireum.myjetbrains.com/youtrack/issue/OX-10079)