### PR TITLE
ES: Correctly checks entity index name when trying to convert entity

### DIFF
--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -1102,8 +1102,8 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
 
         String indexName = jsonEntity.get("_index").asText(null);
         return additionalDescriptors.stream()
-                                    .filter(additionalDescriptor -> additionalDescriptor.getRelationName()
-                                                                                        .equals(indexName))
+                                    .filter(additionalDescriptor -> Strings.areEqual(elastic.determineEffectiveIndex(
+                                            additionalDescriptor), indexName))
                                     .findFirst()
                                     .map(matchingDescriptor -> Elastic.make(matchingDescriptor,
                                                                             (ObjectNode) jsonEntity))


### PR DESCRIPTION
This compares the value given by ES in the _index field with the effective index we mapped when an alias is used (after a re-index for example). Previously we would fail to map such entities which resulted in them being converted to the wrong Java type.

Fixes: [OX-10079](https://scireum.myjetbrains.com/youtrack/issue/OX-10079)