### PR TITLE
Allows to define shared validators for properties

### DIFF
--- a/src/main/java/sirius/db/mixing/PropertyValidator.java
+++ b/src/main/java/sirius/db/mixing/PropertyValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing;
+
+import sirius.kernel.di.std.AutoRegister;
+import sirius.kernel.di.std.Named;
+
+import java.util.function.Consumer;
+
+/**
+ * Permits to validate a property before it is written to the database.
+ */
+@AutoRegister
+public interface PropertyValidator extends Named {
+
+    /**
+     * Validates the given value and reports any warnings/errors to the given consumer.
+     *
+     * @param value              the value to validate
+     * @param validationConsumer can be used to report validation errors
+     */
+    void validate(Object value, Consumer<String> validationConsumer);
+
+    /**
+     * Validates the given value and reports any warnings/errors to the given consumer.
+     * <p>
+     * Throwing any exception will abort the write operation.
+     *
+     * @param value the value to validate
+     */
+    void beforeSave(Object value);
+}

--- a/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
+++ b/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing.annotations;
+
+import sirius.db.mixing.PropertyValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows to specify a custom {@link PropertyValidator} for a property.
+ * <p>
+ * This validator will be invoked before the property is written to the database.
+ * It can be used to perform custom validation that is the same for fields across multiple entities.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ValidatedBy {
+
+    /**
+     * Specifies the validator to use.
+     */
+    Class<? extends PropertyValidator> value();
+}

--- a/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
+++ b/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
@@ -1,0 +1,26 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo;
+
+import sirius.db.mixing.annotations.ValidatedBy;
+import sirius.db.mongo.validators.StringTestPropertyValidator;
+
+public class ValidatedByTestEntity extends MongoEntity {
+
+    @ValidatedBy(StringTestPropertyValidator.class)
+    private String stringTest;
+
+    public String getStringTest() {
+        return stringTest;
+    }
+
+    public void setStringTest(String stringTest) {
+        this.stringTest = stringTest;
+    }
+}

--- a/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
+++ b/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.validators;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+
+import javax.annotation.Nonnull;
+import java.util.function.Consumer;
+
+@Register
+public class StringTestPropertyValidator implements sirius.db.mixing.PropertyValidator {
+    @Override
+    public void validate(Object value, Consumer<String> validationConsumer) {
+        if (isInvalidTestString(value)) {
+            validationConsumer.accept("Invalid value!");
+        }
+    }
+
+    @Override
+    public void beforeSave(Object value) {
+        if (isInvalidTestString(value)) {
+            throw Exceptions.createHandled().withSystemErrorMessage("Invalid value!").handle();
+        }
+    }
+
+    private static boolean isInvalidTestString(Object value) {
+        return value instanceof String text && "invalid".equals(text);
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "string-test";
+    }
+}

--- a/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mixing.annotations
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.db.mongo.Mango
+import sirius.db.mongo.ValidatedByTestEntity
+import sirius.kernel.SiriusExtension
+import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
+import kotlin.test.assertEquals
+
+@ExtendWith(SiriusExtension::class)
+class ValidatedByTest {
+
+    @Test
+    fun `PropertyValidator blocks storing invalid value`() {
+        // Store Test Entity to Mongo.
+        val test = ValidatedByTestEntity()
+        test.stringTest = "invalid"
+
+        val warnings = mango.validate(test)
+        assertEquals(1, warnings.size)
+        assertEquals("Invalid value!", warnings[0])
+
+        assertThrows<HandledException> {
+            mango.update(test)
+        }
+    }
+
+    @Test
+    fun `PropertyValidator allows storing valid value`() {
+        // Store Test Entity to Mongo.
+        val test = ValidatedByTestEntity()
+        test.stringTest = "valid"
+
+        mango.update(test)
+    }
+
+    companion object {
+        @Part
+        private lateinit var mango: Mango
+    }
+}

--- a/src/test/resources/test_de.properties
+++ b/src/test/resources/test_de.properties
@@ -4,3 +4,4 @@ Model.shortStringList=Model.shortStringList
 MongoIntEntity.testIntPositive=MongoIntEntity.testIntPositive
 MongoIntEntity.testIntMaxHundred=MongoIntEntity.testIntMaxHundred
 MongoIntEntity.testIntMinHundred=MongoIntEntity.testIntMinHundred
+ValidatedByTestEntity.stringTest=ValidatedByTestEntity.stringTest


### PR DESCRIPTION
This allows to define common validations that are used on fields across multiple entities. Example could be something like email validation.
The alternative of wrapping single fields in composites can be kind of cumbersome and lead to ugly field names and fragmentation.

With the new `ValidatedBy` annotation a validator can be named that should be called in the validation and before-save phases of the property/entity lifecycle. The validator has to be globally registered and implement the `PropertyValidator` interface while specifying a unique name.