### PR TITLE
Passes validated property to the validator

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -717,7 +717,7 @@ public abstract class Property extends Composable {
         checkNullability(propertyValue);
 
         if (propertyValidator != null) {
-            propertyValidator.beforeSave(getValue(entity));
+            propertyValidator.beforeSave(this, getValue(entity));
         }
 
         if (entity instanceof BaseEntity<?> && (((BaseEntity<?>) entity).isNew() || ((BaseEntity<?>) entity).isChanged(
@@ -737,7 +737,7 @@ public abstract class Property extends Composable {
      */
     protected void onValidate(Object entity, Consumer<String> validationConsumer) {
         if (propertyValidator != null) {
-            propertyValidator.validate(getValue(entity), validationConsumer);
+            propertyValidator.validate(this, getValue(entity), validationConsumer);
         }
     }
 

--- a/src/main/java/sirius/db/mixing/PropertyValidator.java
+++ b/src/main/java/sirius/db/mixing/PropertyValidator.java
@@ -25,7 +25,7 @@ public interface PropertyValidator extends Named {
      * @param value              the value to validate
      * @param validationConsumer can be used to report validation errors
      */
-    void validate(Object value, Consumer<String> validationConsumer);
+    void validate(Property property, Object value, Consumer<String> validationConsumer);
 
     /**
      * Validates the given value and reports any warnings/errors to the given consumer.
@@ -34,5 +34,5 @@ public interface PropertyValidator extends Named {
      *
      * @param value the value to validate
      */
-    void beforeSave(Object value);
+    void beforeSave(Property property, Object value);
 }

--- a/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
+++ b/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
@@ -8,6 +8,7 @@
 
 package sirius.db.mongo.validators;
 
+import sirius.db.mixing.Property;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 
@@ -17,14 +18,14 @@ import java.util.function.Consumer;
 @Register
 public class StringTestPropertyValidator implements sirius.db.mixing.PropertyValidator {
     @Override
-    public void validate(Object value, Consumer<String> validationConsumer) {
+    public void validate(Property property, Object value, Consumer<String> validationConsumer) {
         if (isInvalidTestString(value)) {
             validationConsumer.accept("Invalid value!");
         }
     }
 
     @Override
-    public void beforeSave(Object value) {
+    public void beforeSave(Property property, Object value) {
         if (isInvalidTestString(value)) {
             throw Exceptions.createHandled().withSystemErrorMessage("Invalid value!").handle();
         }


### PR DESCRIPTION
## **BREAKING CHANGE**

* If `PropertyValidator`s are already implemented their method signatures have to be expanded by the `Property` parameter. But this is actually unlikely in this short time-frame.

---

This way the validator can for example use the label of the property to generate more meaningful error messages.

Fixes: [SIRI-854](https://scireum.myjetbrains.com/youtrack/issue/SIRI-854)