### PR TITLE
Improves log entries for cascading deletion

### DIFF
--- a/src/main/resources/db_de.properties
+++ b/src/main/resources/db_de.properties
@@ -1,6 +1,6 @@
 BaseEntityRefProperty.cannotDeleteEntityWithChild = Das Objekt kann nicht gelöscht werden. Es gibt noch eine Referenz in '${source}' (Feld: ${field}).
 BaseEntityRefProperty.cannotDeleteEntityWithChildren = Das Objekt kann nicht gelöscht werden. Es gibt noch ${count} Referenzen in '${source}' (Feld: ${field}).
-BaseEntityRefProperty.cascadeDelete = Lösche Objekte vom Typ '${type}' die '${owner}' im Feld '${field}' enthalten.
+BaseEntityRefProperty.cascadeDelete = Lösche Objekte vom Typ '${type}' die '${owner}' im Feld '${field}' enthalten. Falls keine zugehörigen Objekte gefunden werden, wird nichts gelöscht.
 BaseEntityRefProperty.cascadeSetNull = Entferne '${owner}' aus dem Feld '${field}' für alle Objekte vom Typ '${type}'.
 BaseEntityRefProperty.cascadedDelete = Kaskadierte Löschung
 BaseEntityRefProperty.cascadedSetNull = Feld geleert


### PR DESCRIPTION
It has been noticed that the log entry is somewhat misleading, since it occurs even when there are no objects to be deleted. Therefore, the log output has been adjusted a bit.

Fixes: [SIRI-862](https://scireum.myjetbrains.com/youtrack/issue/SIRI-862)