### PR TITLE
Introduces a non-strict validation mode

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -136,6 +136,12 @@ public abstract class Property extends Composable {
     protected boolean nullable;
 
     protected PropertyValidator propertyValidator;
+
+    /**
+     * Determines if the {@link #propertyValidator} should be also executed when the value has not changed.
+     * <p>
+     * This is only relevant when a validator was specified via {@link ValidatedBy}.
+     */
     protected boolean strictValidation = true;
 
     /**

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -136,6 +136,7 @@ public abstract class Property extends Composable {
     protected boolean nullable;
 
     protected PropertyValidator propertyValidator;
+    protected boolean strictValidation = true;
 
     /**
      * Creates a new property for the given descriptor, access path and field.
@@ -215,6 +216,7 @@ public abstract class Property extends Composable {
                                 field.getName(),
                                 field.getDeclaringClass().getName());
             } else {
+                this.strictValidation = field.getAnnotation(ValidatedBy.class).strictValidation();
                 this.propertyValidator = validator;
             }
         }
@@ -716,12 +718,14 @@ public abstract class Property extends Composable {
         Object propertyValue = getValue(entity);
         checkNullability(propertyValue);
 
-        if (propertyValidator != null) {
+        boolean valueChanged = entity instanceof BaseEntity<?> && (((BaseEntity<?>) entity).isNew()
+                                                                   || ((BaseEntity<?>) entity).isChanged(nameAsMapping));
+        if (propertyValidator != null && (strictValidation || valueChanged)) {
+            // Only enforce validity if the value actually changed or in strict validation mode
             propertyValidator.beforeSave(this, getValue(entity));
         }
 
-        if (entity instanceof BaseEntity<?> && (((BaseEntity<?>) entity).isNew() || ((BaseEntity<?>) entity).isChanged(
-                nameAsMapping))) {
+        if (valueChanged) {
             // Only enforce uniqueness if the value actually changed...
             checkUniqueness(entity, propertyValue);
         }

--- a/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
+++ b/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
@@ -31,4 +31,15 @@ public @interface ValidatedBy {
      * Specifies the validator to use.
      */
     Class<? extends PropertyValidator> value();
+
+    /**
+     * Specifies if the validator should be invoked in strict mode. Strict mode means that the validator gets
+     * always executed. Non-strict mode means that the validator is only executed if the property value has changed.
+     * <p>
+     * The non-strict mode might be useful e.g. for properties that have persisted legacy data which is not valid
+     * and when validity is not mandatory.
+     *
+     * @return <tt>true</tt> for strict validation, <tt>false</tt> otherwise
+     */
+    boolean strictValidation() default true;
 }

--- a/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
+++ b/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
@@ -8,19 +8,48 @@
 
 package sirius.db.mongo;
 
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.ValidatedBy;
 import sirius.db.mongo.validators.StringTestPropertyValidator;
 
 public class ValidatedByTestEntity extends MongoEntity {
 
+    public static final Mapping STRICT_STRING_TEST = Mapping.named("strictStringTest");
+    @NullAllowed
     @ValidatedBy(StringTestPropertyValidator.class)
-    private String stringTest;
+    private String strictStringTest;
 
-    public String getStringTest() {
-        return stringTest;
+    public static final Mapping LENIENT_STRING_TEST = Mapping.named("lenientStringTest");
+    @NullAllowed
+    @ValidatedBy(value = StringTestPropertyValidator.class, strictValidation = false)
+    private String lenientStringTest;
+
+    public static final Mapping UNVALIDATED_STRING_TEST = Mapping.named("unvalidatedStringTest");
+    @NullAllowed
+    private String unvalidatedStringTest;
+
+    public String getStrictStringTest() {
+        return strictStringTest;
     }
 
-    public void setStringTest(String stringTest) {
-        this.stringTest = stringTest;
+    public void setStrictStringTest(String strictStringTest) {
+        this.strictStringTest = strictStringTest;
+    }
+
+    public String getLenientStringTest() {
+        return lenientStringTest;
+    }
+
+    public void setLenientStringTest(String lenientStringTest) {
+        this.lenientStringTest = lenientStringTest;
+    }
+
+    public String getUnvalidatedStringTest() {
+        return unvalidatedStringTest;
+    }
+
+    public void setUnvalidatedStringTest(String unvalidatedStringTest) {
+        this.unvalidatedStringTest = unvalidatedStringTest;
     }
 }

--- a/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import sirius.db.mongo.Mango
+import sirius.db.mongo.Mongo
 import sirius.db.mongo.ValidatedByTestEntity
 import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
@@ -25,7 +26,7 @@ class ValidatedByTest {
     fun `PropertyValidator blocks storing invalid value`() {
         // Store Test Entity to Mongo.
         val test = ValidatedByTestEntity()
-        test.stringTest = "invalid"
+        test.strictStringTest = "invalid"
 
         val warnings = mango.validate(test)
         assertEquals(1, warnings.size)
@@ -40,13 +41,71 @@ class ValidatedByTest {
     fun `PropertyValidator allows storing valid value`() {
         // Store Test Entity to Mongo.
         val test = ValidatedByTestEntity()
-        test.stringTest = "valid"
+        test.strictStringTest = "valid"
 
+        mango.update(test)
+    }
+
+    @Test
+    fun `PropertyValidator in strict mode prevents updating an entity with invalid value already stored`() {
+        // Store Test Entity to Mongo.
+        var test = ValidatedByTestEntity()
+        test.strictStringTest = "valid"
+        mango.update(test)
+
+        // Set the strict field to an invalid value directly in the database.
+        mongo.update()
+                .where(ValidatedByTestEntity.ID, test.id)
+                .set(ValidatedByTestEntity.STRICT_STRING_TEST, "invalid")
+                .executeForOne(ValidatedByTestEntity::class.java)
+
+        // Retrieve it back from Mongo.
+        test = mango.refreshOrFail(test)
+        // Update an unrelated and unvalidated field.
+        test.unvalidatedStringTest = "test"
+
+        // We did not touch the strictly validated field, but the strict mode still prevents updating.
+        val warnings = mango.validate(test)
+        assertEquals(1, warnings.size)
+        assertEquals("Invalid value!", warnings[0])
+
+        assertThrows<HandledException> {
+            mango.update(test)
+        }
+    }
+
+    @Test
+    fun `PropertyValidator without strict mode allows updating an entity with invalid value already stored`() {
+        // Store Test Entity to Mongo.
+        var test = ValidatedByTestEntity()
+        test.lenientStringTest = "valid"
+        mango.update(test)
+
+        // Set the strict field to an invalid value directly in the database.
+        mongo.update()
+                .where(ValidatedByTestEntity.ID, test.id)
+                .set(ValidatedByTestEntity.LENIENT_STRING_TEST, "invalid")
+                .executeForOne(ValidatedByTestEntity::class.java)
+
+        // Retrieve it back from Mongo.
+        test = mango.refreshOrFail(test)
+        // Update an unrelated and unvalidated field.
+        test.unvalidatedStringTest = "test"
+
+        // The warning for the leniently validated field should be returned.
+        val warnings = mango.validate(test)
+        assertEquals(1, warnings.size)
+        assertEquals("Invalid value!", warnings[0])
+
+        // But as we did not alter the leniently validated field, the update should be allowed.
         mango.update(test)
     }
 
     companion object {
         @Part
         private lateinit var mango: Mango
+
+        @Part
+        private lateinit var mongo: Mongo
     }
 }

--- a/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
@@ -54,9 +54,7 @@ class ValidatedByTest {
         mango.update(test)
 
         // Set the strict field to an invalid value directly in the database.
-        mongo.update()
-                .where(ValidatedByTestEntity.ID, test.id)
-                .set(ValidatedByTestEntity.STRICT_STRING_TEST, "invalid")
+        mongo.update().where(ValidatedByTestEntity.ID, test.id).set(ValidatedByTestEntity.STRICT_STRING_TEST, "invalid")
                 .executeForOne(ValidatedByTestEntity::class.java)
 
         // Retrieve it back from Mongo.
@@ -82,8 +80,7 @@ class ValidatedByTest {
         mango.update(test)
 
         // Set the strict field to an invalid value directly in the database.
-        mongo.update()
-                .where(ValidatedByTestEntity.ID, test.id)
+        mongo.update().where(ValidatedByTestEntity.ID, test.id)
                 .set(ValidatedByTestEntity.LENIENT_STRING_TEST, "invalid")
                 .executeForOne(ValidatedByTestEntity::class.java)
 


### PR DESCRIPTION
Some fields do not have a strong need need for validity. E.g. Legacy data for phone numbers like "123 or 456" might be acceptable. 
This is where non-strict validation comes into place. Non-strict validation only applies the validation on changed field values. Actually untouched legacy data (that might be invalid) will not be validated and so does not prevent the update of other fields. 

Fixes: SIRI-869