### PR TITLE
Returns the proper constraint.

### DIFF
--- a/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
@@ -420,7 +420,7 @@ public class ElasticFilterFactory extends FilterFactory<ElasticConstraint> {
         }
 
         if (effectiveConstraints.size() == 1) {
-            return constraints.get(0);
+            return effectiveConstraints.get(0);
         }
 
         ArrayNode queries = Json.createArray();


### PR DESCRIPTION
We previously did return from the unfiltered list, therefore the first constraint might have been null.