### PR TITLE
BREAKING CHANGE: SIRI-881: – Store empty StringList fields as null for certain SQL DBs

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/StringListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringListProperty.java
@@ -182,6 +182,9 @@ public class StringListProperty extends Property implements ESPropertyInfo, SQLP
             return ((Collection<String>) object).toArray();
         }
         String data = Strings.join((Collection<?>) object, ",");
+        if (data.isEmpty()) {
+            return null;
+        }
         if (length > 0 && data.length() > length) {
             throw Exceptions.handle()
                             .to(Mixing.LOG)

--- a/src/test/java/sirius/db/jdbc/SQLStringListNonNullAllowedPropertyEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLStringListNonNullAllowedPropertyEntity.java
@@ -10,26 +10,16 @@ package sirius.db.jdbc;
 
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Length;
-import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.StringList;
 
-public class SQLStringListPropertyEntity extends SQLEntity {
+public class SQLStringListNonNullAllowedPropertyEntity extends SQLEntity {
 
     public static final Mapping STRING_LIST = Mapping.named("stringList");
-    @NullAllowed
     @Length(4096)
     private final StringList stringList = new StringList();
 
-    public static final Mapping SHORT_STRING_LIST = Mapping.named("shortStringList");
-    @NullAllowed
-    @Length(20)
-    private final StringList shortStringList = new StringList();
 
     public StringList getStringList() {
         return stringList;
-    }
-
-    public StringList getShortStringList() {
-        return shortStringList;
     }
 }

--- a/src/test/java/sirius/db/jdbc/SQLStringListPropertyEntitySpec.groovy
+++ b/src/test/java/sirius/db/jdbc/SQLStringListPropertyEntitySpec.groovy
@@ -66,4 +66,14 @@ class SQLStringListPropertyEntitySpec extends BaseSpecification {
         e.getMessage() == "Der Wert 'test1,test2,test3,test4' im Feld 'Model.shortStringList' ist mit 23 Zeichen zu " +
                 "lang. Maximal sind 20 Zeichen erlaubt."
     }
+
+    def "test exception is thrown for empty lists, if the list is non null-allowed"() {
+        when:
+        SQLStringListNonNullAllowedPropertyEntity entity = new SQLStringListNonNullAllowedPropertyEntity()
+        and:
+        oma.update(entity)
+        then:
+        def e = thrown(HandledException.class)
+        e.getMessage().contains("'stringList' doesn't have a default value")
+    }
 }

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
@@ -33,6 +33,7 @@ public class SQLFieldLookUpTestEntity extends SQLEntity {
 
     public static final Mapping SUPER_POWERS = Mapping.named("superPowers");
     @Length(100)
+    @NullAllowed
     private final StringList superPowers = new StringList();
 
     public int getAge() {

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
@@ -12,6 +12,7 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixable;
 import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.Mixin;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.types.StringList;
 
 @Mixin(SQLFieldLookUpTestEntity.class)
@@ -22,6 +23,7 @@ public class SQLSuperHeroTestMixin extends Mixable {
 
     public static final Mapping SUPER_POWERS = Mapping.named("superPowers");
     @Length(100)
+    @NullAllowed
     private final StringList superPowers = new StringList();
 
     public NameFieldsTestComposite getHeroNames() {


### PR DESCRIPTION
This change affects entities with StringList fields which are stored in an SQL based database which does not have the list capability (e.g. MariaDB). This change does not affect MongoDB or databases like Clickhouse which have the lists capability.

**Breaking Change 1:** StringList fields for SQL-based entities without list support (e.g. MariaDB, but not Clickhouse) need to be updated from an empty string to null.
**Breaking Change 2:** StringList fields without the NullAllowed annotation are now throwing an exception if an entity update tries to update the field with an empty list.

Fixes: SIRI-881
