### PR TITLE
Use streamBlockwise for cascadeDelete

### DIFF
--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -1424,7 +1424,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
 
     @Override
     public void delete(@Nullable Consumer<E> entityCallback) {
-        iterateAll(entity -> {
+        streamBlockwise().forEach(entity -> {
             if (entityCallback != null) {
                 entityCallback.accept(entity);
             }

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -427,7 +427,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     /**
      * Creates a sql constraint for sorting purposes.
      * </p>
-     * In MySQL/MariaDB, NULL is considered as a 'missing, unkonwn value'. Any arithmetic comparison with NULL
+     * In MySQL/MariaDB, NULL is considered as a 'missing, unknown value'. Any arithmetic comparison with NULL
      * returns false e.g. NULL != 'any' returns false.
      * Therefore, comparisons with NULL values must be treated specially.
      *

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -180,7 +180,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
     /**
      * Returns the {@link EntityDescriptor} of the referenced entity.
      *
-     * @return the referenced entity drescriptor
+     * @return the referenced entity descriptor
      */
     public EntityDescriptor getReferencedDescriptor() {
         if (referencedDescriptor == null) {
@@ -241,7 +241,8 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
             referenceInstance.getMapper()
                              .select(referenceInstance.getClass())
                              .eq(nameAsMapping, idBeingDeleted)
-                             .iterateAll(other -> cascadeSetNull(taskContext, idBeingDeleted, other));
+                             .streamBlockwise()
+                             .forEach(other -> cascadeSetNull(taskContext, idBeingDeleted, other));
         }
     }
 
@@ -264,7 +265,8 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
                          .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
-                         .iterateAll(other -> cascadeDelete(taskContext, other));
+                         .streamBlockwise()
+                         .forEach(other -> cascadeDelete(taskContext, other));
     }
 
     private void cascadeDelete(TaskContext taskContext, BaseEntity<?> other) {

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -74,7 +74,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
     /**
      * Returns the {@link EntityDescriptor} of the referenced entity.
      *
-     * @return the referenced entity drescriptor
+     * @return the referenced entity descriptor
      */
     public EntityDescriptor getReferencedDescriptor() {
         if (referencedDescriptor == null) {
@@ -253,7 +253,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
                                                  EntityDescriptor referencedDescriptor,
                                                  BaseEntityRef.OnDelete deleteHandler) {
         // If a cascade delete handler is present and the referenced entity is not explicitly marked as
-        // "non complex" and we're within the IDE or running as a test, we force the system to compute / lookup
+        // "non-complex" and we're within the IDE or running as a test, we force the system to compute / lookup
         // the associated NLS keys which might be required to generated appropriate deletion logs or rejection
         // errors (otherwise this might be missed while developing or testing the system).
         if ((referencedDescriptor.getAnnotation(ComplexDelete.class).map(ComplexDelete::value).orElse(true)
@@ -286,7 +286,8 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
                          .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
-                         .iterateAll(other -> cascadeSetNull(taskContext, other));
+                         .streamBlockwise()
+                         .forEach(other -> cascadeSetNull(taskContext, other));
     }
 
     private void cascadeSetNull(TaskContext taskContext, BaseEntity<?> other) {
@@ -309,7 +310,8 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
                          .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
-                         .iterateAll(other -> cascadeDelete(taskContext, other));
+                         .streamBlockwise()
+                         .forEach(other -> cascadeDelete(taskContext, other));
     }
 
     private void cascadeDelete(TaskContext taskContext, BaseEntity<?> other) {

--- a/src/main/java/sirius/db/mixing/query/Query.java
+++ b/src/main/java/sirius/db/mixing/query/Query.java
@@ -131,6 +131,7 @@ public abstract class Query<Q, E extends BaseEntity<?>, C extends Constraint> ex
      * Deletes all matches using the {@link BaseMapper#delete(BaseEntity)} of the appropriate mapper.
      * <p>
      * Be aware that this might be slow for very large result sets.
+     * Attention: Some implementations (especially mongo) does not support deleting via streamBlockwise with a sort order.
      *
      * @param entityCallback a callback to be invoked for each entity to be deleted
      */

--- a/src/main/java/sirius/db/mixing/query/Query.java
+++ b/src/main/java/sirius/db/mixing/query/Query.java
@@ -32,9 +32,9 @@ public abstract class Query<Q, E extends BaseEntity<?>, C extends Constraint> ex
     }
 
     /**
-     * Applies the given contraints to the query.
+     * Applies the given constraints to the query.
      *
-     * @param constraint the constraint which has to be fullfilled
+     * @param constraint the constraint which has to be fulfilled
      * @return the query itself for fluent method calls
      */
     public abstract Q where(C constraint);

--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -331,7 +331,7 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
 
     @Override
     public void delete(@Nullable Consumer<E> entityCallback) {
-        iterateAll(entity -> {
+        streamBlockwise().forEach(entity -> {
             if (entityCallback != null) {
                 entityCallback.accept(entity);
             }

--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -114,7 +114,7 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
      * Adds a limit to the query.
      *
      * @param skip  the number of items to skip (used for pagination).
-     * @param limit the max. number of items to return (exluding those who have been skipped).
+     * @param limit the max. number of items to return (excluding those who have been skipped).
      * @return the builder itself for fluent method calls
      */
     public MongoQuery<E> limit(int skip, int limit) {
@@ -282,7 +282,7 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
     }
 
     /**
-     * Aggregates the documents in the result of the given query with an sum operator.
+     * Aggregates the documents in the result of the given query with a sum operator.
      * <p>
      * Note that limits are ignored for this query.
      *
@@ -294,7 +294,7 @@ public class MongoQuery<E extends MongoEntity> extends Query<MongoQuery<E>, E, M
     }
 
     /**
-     * Aggregates the documents in the result of the given query with an an average operator.
+     * Aggregates the documents in the result of the given query with an average operator.
      * <p>
      * Note that limits are ignored for this query.
      *

--- a/src/main/resources/component-060-db.conf
+++ b/src/main/resources/component-060-db.conf
@@ -148,9 +148,6 @@ jdbc {
     # Every connection which lasts longer will be logged to "db-slow" on level INFO
     logConnectionThreshold = 30 seconds
 
-    # The default timeout at which a running query will get interrupted and restarted at the current position
-    queryIterateTimeout = 15 minutes
-
     # A profile provides a template for database connections.
     # Each value of the profile serves as backup or default value for the one in the database secion.
     # Also a profile value can reference properties defined in one of both sections like this: ${name}.

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,8 +1,6 @@
 docker.file = ["src/test/resources/docker-db.yml"]
 
 jdbc {
-    # a very aggressive timeout finds more potential problems
-    queryIterateTimeout = 1s
 
     database {
         test {


### PR DESCRIPTION
in some cases the DB-connection timed out on too many cascading-deletes in the iterateAll

### What TODO?
- Do not use delete() with sorted in Mongo or skip/limit in Mongo/Elastic anymore.

## Background
- until now streamBlockwise does not support sorting in Mongo
- also skip and limit is not supported in Mongo/Elastic-querys for streamBlockwise.
- Details see sirius.db.es.ElasticQuery#streamBlockwise or sirius.db.mongo.MongoQuery#streamBlockwise



- fixes: SIRI-915