### PR TITLE
update some dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <artifactId>sirius-db</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-40.0.0</sirius.kernel>
+        <sirius.kernel>dev-42.0.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.7.1</version>
+            <version>4.11.1</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>
@@ -67,19 +67,12 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>8.4.1</version>
+            <version>8.11.2</version>
         </dependency>
-        <!-- Required as the version brought by elasticsearch-rest-client contains security issues -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.0.6</version>
+            <version>3.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>11.3.0</version>
+        <version>11.5.0</version>
     </parent>
     <artifactId>sirius-db</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>

--- a/src/main/java/sirius/db/jdbc/Database.java
+++ b/src/main/java/sirius/db/jdbc/Database.java
@@ -353,7 +353,7 @@ public class Database {
             ds.setMaxIdle(maxIdle);
             ds.setTestOnBorrow(testOnBorrow);
             ds.setValidationQuery(validationQuery);
-            ds.setMaxWait(Duration.ofMillis(1000));
+            ds.setMaxWait(Duration.ofSeconds(1));
         }
     }
 

--- a/src/main/java/sirius/db/jdbc/Database.java
+++ b/src/main/java/sirius/db/jdbc/Database.java
@@ -353,7 +353,7 @@ public class Database {
             ds.setMaxIdle(maxIdle);
             ds.setTestOnBorrow(testOnBorrow);
             ds.setValidationQuery(validationQuery);
-            ds.setMaxWaitMillis(1000);
+            ds.setMaxWait(Duration.ofMillis(1000));
         }
     }
 

--- a/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
+++ b/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
@@ -8,7 +8,7 @@
 
 package sirius.db.testutil
 
-import io.mockk.spyk
+import org.mockito.Mockito.spy
 import sirius.db.mixing.types.BaseEntityRef
 import sirius.db.mongo.MongoEntity
 import sirius.db.mongo.types.MongoRef
@@ -21,12 +21,9 @@ class MongoMocks {
         /**
          * Wrap an entity as a MongoRef
          * @param entity which is to be wrapped
-         */        /**
-         * Wrap an entity as a MongoRef
-         * @param entity which is to be wrapped
          */
         fun <E : MongoEntity> asMongoRef(entity: E): MongoRef<E> {
-            val mongoRef = spyk(MongoRef.on(entity.javaClass, BaseEntityRef.OnDelete.IGNORE))
+            val mongoRef = spy(MongoRef.on(entity.javaClass, BaseEntityRef.OnDelete.IGNORE))
             mongoRef.setValue(entity)
             return mongoRef
         }

--- a/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
+++ b/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
@@ -8,7 +8,7 @@
 
 package sirius.db.testutil
 
-import org.mockito.Mockito.spy
+import io.mockk.spyk
 import sirius.db.mixing.types.BaseEntityRef
 import sirius.db.mongo.MongoEntity
 import sirius.db.mongo.types.MongoRef
@@ -23,7 +23,7 @@ class MongoMocks {
          * @param entity which is to be wrapped
          */
         fun <E : MongoEntity> asMongoRef(entity: E): MongoRef<E> {
-            val mongoRef = spy(MongoRef.on(entity.javaClass, BaseEntityRef.OnDelete.IGNORE))
+            val mongoRef = spyk(MongoRef.on(entity.javaClass, BaseEntityRef.OnDelete.IGNORE))
             mongoRef.setValue(entity)
             return mongoRef
         }


### PR DESCRIPTION
httpclient is now included in the newer elasticsearch-rest-client in the until now provided version so we can remove it. setMaxWaitMillis is deprecated so we use setMaxWait now (which is internally the same)

- fixes: SIRI-920