### PR TITLE
Upgrades the mongo container to 6.0.13

### DIFF
--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -8,7 +8,7 @@ services:
     hostname: redis
 
   mongo:
-    image: mongo:4.4.8
+    image: mongo:6.0.13
     ports:
     - "27017"
     hostname: mongo


### PR DESCRIPTION
This only affects the container in which tests cases are executed against.

Fixes: [DO-139](https://scireum.myjetbrains.com/youtrack/issue/DO-139)