### PR TITLE
Fixes StringProperty not detecting changes to empty string properly

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -125,6 +125,14 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
     }
 
     @Override
+    protected boolean isConsideredNull(Object propertyValue) {
+        if (trim) {
+            return Strings.isEmpty(Strings.trim(propertyValue));
+        }
+        return Strings.isEmpty(propertyValue);
+    }
+
+    @Override
     public Object transformValue(Value value) {
         if (value.isFilled()) {
             return value.asString();

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -23,6 +23,7 @@ import sirius.db.mixing.Mixable;
 import sirius.db.mixing.Mixing;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyFactory;
+import sirius.db.mixing.annotations.DefaultValue;
 import sirius.db.mixing.annotations.Lob;
 import sirius.db.mixing.annotations.LowerCase;
 import sirius.db.mixing.annotations.Trim;
@@ -130,6 +131,17 @@ public class StringProperty extends Property implements SQLPropertyInfo, ESPrope
             return Strings.isEmpty(Strings.trim(propertyValue));
         }
         return Strings.isEmpty(propertyValue);
+    }
+
+    @Override
+    protected void determineDefaultValue() {
+        DefaultValue defaultValueAnnotation = field.getAnnotation(DefaultValue.class);
+        if (defaultValueAnnotation != null) {
+            this.defaultValue = Value.of(transformValueFromImport(Value.of(defaultValueAnnotation.value())));
+        } else {
+            Object initialValue = getValue(getDescriptor().getReferenceInstance());
+            this.defaultValue = Value.of(initialValue);
+        }
     }
 
     @Override

--- a/src/test/java/sirius/db/jdbc/DataTypesEntity.java
+++ b/src/test/java/sirius/db/jdbc/DataTypesEntity.java
@@ -12,6 +12,7 @@ import sirius.db.mixing.annotations.DefaultValue;
 import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Numeric;
+import sirius.db.mixing.annotations.Trim;
 import sirius.kernel.commons.Amount;
 
 import java.time.LocalDate;
@@ -35,6 +36,11 @@ public class DataTypesEntity extends SQLEntity {
     @Length(255)
     @NullAllowed
     private String stringValue;
+
+    @Trim
+    @Length(255)
+    @NullAllowed
+    private String stringValueNoDefault;
 
     @DefaultValue("300")
     @NullAllowed
@@ -85,6 +91,14 @@ public class DataTypesEntity extends SQLEntity {
 
     public void setStringValue(String stringValue) {
         this.stringValue = stringValue;
+    }
+
+    public String getStringValueNoDefault() {
+        return stringValueNoDefault;
+    }
+
+    public void setStringValueNoDefault(String stringValueNoDefault) {
+        this.stringValueNoDefault = stringValueNoDefault;
     }
 
     public Amount getAmountValue() {

--- a/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
@@ -16,6 +16,7 @@ import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part
 import java.time.Duration
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(SiriusExtension::class)
@@ -31,6 +32,18 @@ class DataTypesTest {
         test = oma.refreshOrFail(test)
 
         assertEquals(Long.MAX_VALUE, test.longValue)
+    }
+
+    @Test
+    fun `StringProperty detects changes to empty values properly`() {
+        var test = DataTypesEntity()
+        test.stringValueNoDefault = ""
+
+        oma.update(test)
+        val afterFirstSave = oma.refreshOrFail(test)
+
+        afterFirstSave.stringValueNoDefault = ""
+        assertFalse { afterFirstSave.isAnyMappingChanged }
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/mixing/properties/DefaultValuesTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/DefaultValuesTest.kt
@@ -41,9 +41,9 @@ class DefaultValuesTest {
     @MethodSource("provideParametersForValuesTransformed")
     fun `column default values are properly transformed`(propertyName: String, expectedDefault: String?) {
         assertEquals(
-                expectedDefault,
                 mixing.getDescriptor(SQLDefaultValuesEntity::class.java).findProperty(propertyName)
-                        ?.getColumnDefaultValue()
+                        ?.getColumnDefaultValue(),
+                expectedDefault,
         )
     }
 


### PR DESCRIPTION
- sirius.db.mixing.properties.StringProperty#setValueToField and sirius.db.mixing.properties.StringProperty#transformValue transform "" be persisted as null
- this transformation must be considered when checking for null as well

Fixes: SIRI-939