### PR TITLE
Optimizes some system generates queries based on casing annotations

### DIFF
--- a/src/main/java/sirius/db/mixing/annotations/LowerCase.java
+++ b/src/main/java/sirius/db/mixing/annotations/LowerCase.java
@@ -17,7 +17,8 @@ import java.lang.annotation.Target;
 /**
  * Marks a string property as auto lower-cased.
  * <p>
- * The value of this property will be lower-cased before it is written to the database.
+ * The value of this property will be lower-cased before it is written to the database. Also, it is used to optimize
+ * some system generated queries.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/sirius/db/mixing/annotations/UpperCase.java
+++ b/src/main/java/sirius/db/mixing/annotations/UpperCase.java
@@ -17,7 +17,8 @@ import java.lang.annotation.Target;
 /**
  * Marks a string property as auto upper-cased.
  * <p>
- * The value of this property will be upper-cased before it is written to the database.
+ * The value of this property will be upper-cased before it is written to the database. Also, it is used to optimize
+ * some system generated queries.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -11,6 +11,8 @@ package sirius.db.mixing.query;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Property;
+import sirius.db.mixing.annotations.LowerCase;
+import sirius.db.mixing.annotations.UpperCase;
 import sirius.db.mixing.properties.BaseEntityRefListProperty;
 import sirius.db.mixing.properties.BaseEntityRefProperty;
 import sirius.db.mixing.properties.LocalDateProperty;
@@ -35,6 +37,7 @@ import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -788,5 +791,23 @@ public abstract class QueryCompiler<C extends Constraint> {
         }
 
         return null;
+    }
+
+    /**
+     * Returns the optimized value for the given field respecting the Sirius DB casing annotations.
+     *
+     * @param field the field to query for
+     * @param value the value to query
+     * @return the optimized value to use in a constraint if any, or an Optional.empty() if no optimization is possible
+     */
+    protected Optional<String> getCaseOptimizedValue(Mapping field, String value) {
+        Property property = resolveProperty(field.toString()).getSecond();
+        if (property.isAnnotationPresent(LowerCase.class)) {
+            return Optional.of(value.toLowerCase());
+        }
+        if (property.isAnnotationPresent(UpperCase.class)) {
+            return Optional.of(value.toUpperCase());
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -260,8 +260,7 @@ public abstract class QueryCompiler<C extends Constraint> {
         skipWhitespace();
 
         if ((reader.current().is('!') || reader.current().is('-'))) {
-            if (reader.next().isWhitespace() ||reader.next()
-                                                     .isEndOfInput()) {
+            if (reader.next().isWhitespace() || reader.next().isEndOfInput()) {
                 // If there is a single "-" or "!" in a string like "foo - bar", we simly skip the dash
                 // as it is ignored by the indexing tokenizer anyway...
                 reader.consume();

--- a/src/main/java/sirius/db/mixing/query/QueryField.java
+++ b/src/main/java/sirius/db/mixing/query/QueryField.java
@@ -24,8 +24,8 @@ public class QueryField {
         EQUAL, LIKE, PREFIX, CONTAINS
     }
 
-    private Mapping field;
-    private Mode mode;
+    private final Mapping field;
+    private final Mode mode;
 
     private QueryField(Mapping field, Mode mode) {
         this.field = field;

--- a/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
@@ -31,7 +31,7 @@ public class MongoQueryCompiler extends QueryCompiler<MongoConstraint> {
     private static final Mapping FULLTEXT_MAPPING = Mapping.named("$text");
 
     /**
-     * Represents an artificial field which generates a search using a <tt>$text</tt> filter. Therefore
+     * Represents an artificial field which generates a search using a <tt>$text</tt> filter. Therefore,
      * an appropriate <b>text</b> index has to be present.
      */
     public static final QueryField FULLTEXT = QueryField.contains(FULLTEXT_MAPPING);

--- a/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
@@ -58,7 +58,7 @@ public class MongoQueryCompiler extends QueryCompiler<MongoConstraint> {
         }
 
         if (mode == QueryField.Mode.EQUAL) {
-            return factory.eq(field, value);
+            return factory.eq(field, getCaseOptimizedValue(field, value).orElse(value));
         } else if (mode == QueryField.Mode.PREFIX) {
             return QueryBuilder.FILTERS.prefix(field, value);
         } else {


### PR DESCRIPTION
 Uses lowercase and uppercase field annotations to optimize queries

- When all values stored in a field are stored e.g. lowercased, we do not need
  to query case-insensitively. This can give a small speedup.
- When all values in a field are stored e.g. lowercased, we do not need
  to query with an value containing upper case characters. We apply auto-magical
  case adaption on some cases where the framework generates queries. So we create
  the chance of actually finding an result, even if the input did not match the actual db field.
  This is relevant, e.g. for the Sirius biz virtual filesystem backend ui. There, the normalized
  filename field of a sql blob containing only lowercase characters might get queried by user input
  containing the exact filename. By this adaption, we are able to find the blob.
- For regular API usage, such magic from framework is not desired. If required, apply it by
  yourself when creating queries.