### PR TITLE
Reference to Raw Mongo Object

### DIFF
--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -263,6 +263,9 @@ public class Mango extends SecondaryCapableMapper<MongoEntity, MongoConstraint, 
             E result = (E) descriptor.make(Mango.class,
                                            null,
                                            key -> doc.getUnderlyingObject().containsKey(key) ? doc.get(key) : null);
+
+            result.setMongoDocument(doc);
+
             if (descriptor.isVersioned()) {
                 result.setVersion(doc.get(VERSION).asInt(0));
             }

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -246,25 +246,28 @@ public class Mango extends SecondaryCapableMapper<MongoEntity, MongoConstraint, 
                         mongo.find(entityDescriptor.getRealm());
         return finder.where(MongoEntity.ID, id.toString())
                      .singleIn(entityDescriptor.getRelationName())
-                     .map(doc -> make(entityDescriptor, doc));
+                     .map(doc -> make(entityDescriptor, doc, false));
     }
 
     /**
      * Creates a new entity for the given descriptor based on the given doc.
      *
-     * @param descriptor the descriptor of the entity to create
-     * @param doc        the document to read the values from
-     * @param <E>        the effective type of the generated entity
+     * @param descriptor        the descriptor of the entity to create
+     * @param doc               the document to read the values from
+     * @param retainRawDocument whether to retain the raw database document in the entity
+     * @param <E>               the effective type of the generated entity
      * @return the generated entity
      */
     @SuppressWarnings("unchecked")
-    public static <E extends MongoEntity> E make(EntityDescriptor descriptor, Doc doc) {
+    public static <E extends MongoEntity> E make(EntityDescriptor descriptor, Doc doc, boolean retainRawDocument) {
         try {
             E result = (E) descriptor.make(Mango.class,
                                            null,
                                            key -> doc.getUnderlyingObject().containsKey(key) ? doc.get(key) : null);
 
-            result.setMongoDocument(doc);
+            if (retainRawDocument) {
+                result.setMongoDocument(doc);
+            }
 
             if (descriptor.isVersioned()) {
                 result.setVersion(doc.get(VERSION).asInt(0));

--- a/src/main/java/sirius/db/mongo/MongoEntity.java
+++ b/src/main/java/sirius/db/mongo/MongoEntity.java
@@ -36,6 +36,9 @@ public abstract class MongoEntity extends BaseEntity<String> {
     @Transient
     protected int version = 0;
 
+    @Transient
+    protected Doc mongoDocument;
+
     @Part
     protected static Mongo mongo;
 
@@ -98,5 +101,19 @@ public abstract class MongoEntity extends BaseEntity<String> {
      */
     public void setVersion(int version) {
         this.version = version;
+    }
+
+    /**
+     * Returns the underlying {@linkplain Doc Mongo document}. Be aware that this is only available after loading the
+     * {@linkplain MongoEntity entity} from the database, and the document is not updated automatically.
+     *
+     * @return the underlying Mongo document
+     */
+    public Doc getMongoDocument() {
+        return mongoDocument;
+    }
+
+    protected void setMongoDocument(Doc mongoDocument) {
+        this.mongoDocument = mongoDocument;
     }
 }


### PR DESCRIPTION
### Description

When parsing a Mongo object into a Mango entity, we now retain a reference to the raw document. This is similar to our implementation of the Elastic adapter.