### PR TITLE
Smart Query - Adds the possibility to use index hints

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -125,7 +125,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     }
 
     /**
-     * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
+     * Adds a "USE INDEX" hint for a table that recommends an index to the optimizer.
      *
      * @param table     the table for which the index should be used.
      * @param forHint   the action for which the index should be used. Can be null.
@@ -139,7 +139,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     }
 
     /**
-     * Adds a "FORCE INDEX" hint for a table that forces an index to te optimizer.
+     * Adds a "FORCE INDEX" hint for a table that forces an index to the optimizer.
      *
      * @param table     the table for wh index to use.
      * @param indexName the name of the index to use.

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -79,7 +79,18 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * Indicates the "FOR" hint for the optimizer, when used with "USE INDEX" and "IGNORE INDEX".
      */
     public enum IndexForHint {
-        JOIN, ORDER_BY, GROUP_BY
+        /**
+         * Indicates to the optimizer that the index should be used, when the table is joined with another table.
+         */
+        JOIN,
+        /**
+         * Indicates to the optimizer that the index should be used, when the table is ordered.
+         */
+        ORDER_BY,
+        /**
+         * Indicates to the optimizer that the index should be used, when the results are grouped.
+         */
+        GROUP_BY
     }
 
     /**
@@ -114,9 +125,10 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     }
 
     /**
-     * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
+     * Adds a "USE INDEX" hint for a table that recommends an index to the optimizer.
      *
      * @param table     the table for which the index should be used.
+     * @param forHint   the {@link IndexForHint} for which the index should be used.
      * @param indexName the name of the index to use.
      * @param <T>       the type of the entities being queried.
      * @return the query itself for fluent method calls.
@@ -168,7 +180,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * Adds a "IGNORE INDEX" hint for a table that makes the optimizer to not consider the given index.
      *
      * @param table     the table for which the index should be used.
-     * @param forHint   the action for which the index should be used. Can be null.
+     * @param forHint   the {@link IndexForHint} for which the index should be used. Can be null.
      * @param indexName the name of the index to use.
      * @param <T>       the type of the entities being queried.
      * @return the query itself for fluent method calls
@@ -183,7 +195,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      *
      * @param table     the table for which the index should be used.
      * @param type      the type of the hint. Can be "USE", "FORCE" or "IGNORE".
-     * @param forHint   the clause for which the index should be used. Can be null.
+     * @param forHint   the {@link IndexForHint} for which the index should be used. Can be null.
      * @param indexName the name of the index to use.
      * @param <T>       the type of entities being queried.
      */

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -117,12 +117,24 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
      *
      * @param table     the table for which the index should be used.
-     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
      * @param indexName the name of the index to use.
-     * @param <T>       the type of entities being queried.
+     * @param <T>       the type of the entities being queried.
      * @return the query itself for fluent method calls.
      */
-    public <T extends SQLEntity> SmartQuery<E> useIndex(Class<T> table, String forHint, String indexName) {
+    public <T extends SQLEntity> SmartQuery<E> useIndex(Class<T> table, String indexName) {
+        return useIndex(table, null, indexName);
+    }
+
+    /**
+     * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
+     *
+     * @param table     the table for which the index should be used.
+     * @param forHint   the action for which the index should be used. Can be null.
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of the entities being queried.
+     * @return the query itself for fluent method calls.
+     */
+    public <T extends SQLEntity> SmartQuery<E> useIndex(Class<T> table, IndexForHint forHint, String indexName) {
         indexHint(table, "USE", forHint, indexName);
         return this;
     }
@@ -131,8 +143,8 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * Adds a "FORCE INDEX" hint for a table that forces an index to te optimizer.
      *
      * @param table     the table for wh index to use.
-     *                  * @param <T>       the type of entiich the index should be used.
-     * @param indexName the name of theties being queried.
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of the entities the index should be used.
      * @return the query itself for fluent method calls.
      */
     public <T extends SQLEntity> SmartQuery<E> forceIndex(Class<T> table, String indexName) {
@@ -144,12 +156,24 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * Adds a "IGNORE INDEX" hint for a table that makes the optimizer to not consider the given index.
      *
      * @param table     the table for which the index should be used.
-     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
      * @param indexName the name of the index to use.
-     * @param <T>       the type of entities being queried.
+     * @param <T>       the type of the entities being queried.
      * @return the query itself for fluent method calls
      */
-    public <T extends SQLEntity> SmartQuery<E> ignoreIndex(Class<T> table, String forHint, String indexName) {
+    public <T extends SQLEntity> SmartQuery<E> ignoreIndex(Class<T> table, String indexName) {
+        return ignoreIndex(table, null, indexName);
+    }
+
+    /**
+     * Adds a "IGNORE INDEX" hint for a table that makes the optimizer to not consider the given index.
+     *
+     * @param table     the table for which the index should be used.
+     * @param forHint   the action for which the index should be used. Can be null.
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of the entities being queried.
+     * @return the query itself for fluent method calls
+     */
+    public <T extends SQLEntity> SmartQuery<E> ignoreIndex(Class<T> table, IndexForHint forHint, String indexName) {
         indexHint(table, "IGNORE", forHint, indexName);
         return this;
     }

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -158,7 +158,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      */
     private <T extends SQLEntity> void indexHint(Class<T> table, String type, String forHint, String indexName) {
         indexHints.put(mixing.getDescriptor(table).getRelationName(),
-                       " " + type + " INDEX (" + (forHint != null ? forHint + " " : "") + indexName + ")");
+                       " " + type + " INDEX " + (forHint != null ? "FOR " + forHint + " (" : "(") + indexName + ")");
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -106,6 +106,61 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
         return this;
     }
 
+    /**
+     * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
+     *
+     * @param table     the table for which the index should be used.
+     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of entities being queried.
+     * @return the query itself for fluent method calls.
+     */
+    public <T extends SQLEntity> SmartQuery<E> useIndex(Class<T> table, String forHint, String indexName) {
+        indexHint(table, "USE", forHint, indexName);
+        return this;
+    }
+
+    /**
+     * Adds a "FORCE INDEX" hint for a table that forces an index to te optimizer.
+     *
+     * @param table     the table for wh index to use.
+     *                  * @param <T>       the type of entiich the index should be used.
+     * @param indexName the name of theties being queried.
+     * @return the query itself for fluent method calls.
+     */
+    public <T extends SQLEntity> SmartQuery<E> forceIndex(Class<T> table, String indexName) {
+        indexHint(table, "FORCE", null, indexName);
+        return this;
+    }
+
+    /**
+     * Adds a "IGNORE INDEX" hint for a table that makes the optimizer to not consider the given index.
+     *
+     * @param table     the table for which the index should be used.
+     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of entities being queried.
+     * @return the query itself for fluent method calls
+     */
+    public <T extends SQLEntity> SmartQuery<E> ignoreIndex(Class<T> table, String forHint, String indexName) {
+        indexHint(table, "IGNORE", forHint, indexName);
+        return this;
+    }
+
+    /**
+     * Adds a hint for a table that is used by the optimizer.
+     *
+     * @param table     the table for which the index should be used.
+     * @param type      the type of the hint. Can be "USE", "FORCE" or "IGNORE".
+     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
+     * @param indexName the name of the index to use.
+     * @param <T>       the type of entities being queried.
+     */
+    private <T extends SQLEntity> void indexHint(Class<T> table, String type, String forHint, String indexName) {
+        indexHints.put(mixing.getDescriptor(table).getRelationName(),
+                       type + " INDEX " + (forHint != null ? forHint + " " : "") + indexName);
+    }
+
     @Override
     public FilterFactory<SQLConstraint> filters() {
         return oma.filters();

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -158,7 +158,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      */
     private <T extends SQLEntity> void indexHint(Class<T> table, String type, String forHint, String indexName) {
         indexHints.put(mixing.getDescriptor(table).getRelationName(),
-                       type + " INDEX " + (forHint != null ? forHint + " " : "") + indexName);
+                       " " + type + " INDEX (" + (forHint != null ? forHint + " " : "") + indexName + ")");
     }
 
     @Override

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -125,19 +125,6 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     }
 
     /**
-     * Adds a "USE INDEX" hint for a table that recommends an index to the optimizer.
-     *
-     * @param table     the table for which the index should be used.
-     * @param forHint   the {@link IndexForHint} for which the index should be used.
-     * @param indexName the name of the index to use.
-     * @param <T>       the type of the entities being queried.
-     * @return the query itself for fluent method calls.
-     */
-    public <T extends SQLEntity> SmartQuery<E> useIndex(Class<T> table, String indexName) {
-        return useIndex(table, null, indexName);
-    }
-
-    /**
      * Adds a "USE INDEX" hint for a table that recommends an index to te optimizer.
      *
      * @param table     the table for which the index should be used.
@@ -162,18 +149,6 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     public <T extends SQLEntity> SmartQuery<E> forceIndex(Class<T> table, String indexName) {
         indexHint(table, "FORCE", null, indexName);
         return this;
-    }
-
-    /**
-     * Adds a "IGNORE INDEX" hint for a table that makes the optimizer to not consider the given index.
-     *
-     * @param table     the table for which the index should be used.
-     * @param indexName the name of the index to use.
-     * @param <T>       the type of the entities being queried.
-     * @return the query itself for fluent method calls
-     */
-    public <T extends SQLEntity> SmartQuery<E> ignoreIndex(Class<T> table, String indexName) {
-        return ignoreIndex(table, null, indexName);
     }
 
     /**

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -76,6 +76,13 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
     protected Map<String, String> indexHints = new HashMap<>();
 
     /**
+     * Indicates the "FOR" hint for the optimizer, when used with "USE INDEX" and "IGNORE INDEX".
+     */
+    public enum IndexForHint {
+        JOIN, ORDER_BY, GROUP_BY
+    }
+
+    /**
      * Creates a new query instance.
      * <p>
      * Use {@link OMA#select(Class)} to create a new query.
@@ -152,13 +159,19 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      *
      * @param table     the table for which the index should be used.
      * @param type      the type of the hint. Can be "USE", "FORCE" or "IGNORE".
-     * @param forHint   the clause for which the index should be used. Can be null, "JOIN", "ORDER BY" or "GROUP BY".
+     * @param forHint   the clause for which the index should be used. Can be null.
      * @param indexName the name of the index to use.
      * @param <T>       the type of entities being queried.
      */
-    private <T extends SQLEntity> void indexHint(Class<T> table, String type, String forHint, String indexName) {
-        indexHints.put(mixing.getDescriptor(table).getRelationName(),
-                       " " + type + " INDEX " + (forHint != null ? "FOR " + forHint + " (" : "(") + indexName + ")");
+    private <T extends SQLEntity> void indexHint(Class<T> table, String type, IndexForHint forHint, String indexName) {
+        StringBuilder indexHint = new StringBuilder();
+        indexHint.append(" ").append(type).append(" INDEX");
+        if (forHint != null) {
+            indexHint.append(" FOR ");
+            indexHint.append(forHint.name().replace("_", " "));
+        }
+        indexHint.append(" (").append(indexName).append(")");
+        indexHints.put(mixing.getDescriptor(table).getRelationName(), indexHint.toString());
     }
 
     @Override


### PR DESCRIPTION
Adds the possibility to use index hints like "USE INDEX", "FORCE INDEX" or "IGNORE INDEX" in the Smart Query.
This enables the option to add hints for a query, when the db optimizer is using sub optimal indexes or ignores specific indexes.

Fixes: SIRI-947
