### PR TITLE
Upgrades Jedis library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>4.2.3</version>
+            <version>5.1.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>


### PR DESCRIPTION
### Description
- upgrades Jedis to 5.1.3
- fixes Jedis usage for Jupiter by applying an disabled ClientSetInfoConfig
- see https://redis.io/docs/latest/commands/client-setinfo/ and https://github.com/redis/jedis/pull/3356 (has follow-ups)


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-921](https://scireum.myjetbrains.com/youtrack/issue/SIRI-921)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
