### PR TITLE
Handles large bulk ES requests

### DIFF
--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import sirius.db.KeyGenerator;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.es.constraints.ElasticFilterFactory;
@@ -169,11 +168,6 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
         if (client == null) {
             Elastic.LOG.INFO("Initializing Elasticsearch client against: %s", hosts);
 
-            // Fixes an Elastic bug that results in TimeoutExceptions
-            // Remove this, once ES is updated to at least 6.3.1
-            RestClientBuilder.RequestConfigCallback configCallback =
-                    requestConfigBuilder -> requestConfigBuilder.setConnectionRequestTimeout(0);
-
             HttpHost[] httpHosts = Arrays.stream(this.hosts.split(","))
                                          .map(String::trim)
                                          .map(host -> Strings.splitAtLast(host, ":"))
@@ -181,7 +175,7 @@ public class Elastic extends BaseMapper<ElasticEntity, ElasticConstraint, Elasti
                                          .map(this::mapPort)
                                          .map(this::makeHttpHost)
                                          .toArray(size -> new HttpHost[size]);
-            client = new LowLevelClient(RestClient.builder(httpHosts).setRequestConfigCallback(configCallback).build());
+            client = new LowLevelClient(RestClient.builder(httpHosts).build());
 
             // If we're using a docker container (most probably for testing), we give ES some time
             // to fully boot up. Otherwise, strange connection issues might arise.

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -246,7 +246,8 @@ class RequestBuilder {
 
     protected ObjectNode extractErrorJSON(ResponseException e) {
         try {
-            ObjectNode response = Json.parseObject(EntityUtils.toString(e.getResponse().getEntity()));
+            HttpEntity httpEntity = e.getResponse().getEntity();
+            ObjectNode response = Json.parseObject(EntityUtils.toString(httpEntity));
             return Json.getObject(response, PARAM_ERROR);
         } catch (IOException ex) {
             Exceptions.handle(Elastic.LOG, ex);

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -247,6 +247,9 @@ class RequestBuilder {
     protected ObjectNode extractErrorJSON(ResponseException e) {
         try {
             HttpEntity httpEntity = e.getResponse().getEntity();
+            if (e.getResponse().getEntity().getContentLength() == 0) {
+                return null;
+            }
             ObjectNode response = Json.parseObject(EntityUtils.toString(httpEntity));
             return Json.getObject(response, PARAM_ERROR);
         } catch (IOException ex) {


### PR DESCRIPTION
### Description

Elasticsearch establishes a default max request size of 100MB. Bulking large documents can exceed this limit before we reach our established queue size of 1024 "commands".

### Drive-By

- Removes an obsolete workaround during client initialization
- Improves parsing ES responses which do not deliver a real JSON payload, eg: HTTP response 413 (Content Too large).

#### Before
```
sirius.kernel.health.HandledException:
Ein unerwarteter Fehler ist aufgetreten: No content to map due to end-of-input
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1] (com.fasterxml.jackson.databind.exc.MismatchedInputException)

Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException:
No content to map due to end-of-input
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1]
```

#### After
```
sirius.kernel.health.HandledException:
Ein Fehler ist aufgetreten: Elasticsearch (http://127.0.0.1:55345) reported an error: unknown (-)

Caused by: org.elasticsearch.client.ResponseException:
method [POST], host [http://127.0.0.1:55345], URI [_bulk?refresh=false], status line [HTTP/1.1 413 Request Entity Too Large]
```

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11111](https://scireum.myjetbrains.com/youtrack/issue/OX-11111)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
