### PR TITLE
Add a metric for ES memory pressure

### DIFF
--- a/src/main/java/sirius/db/es/ElasticMetricsProvider.java
+++ b/src/main/java/sirius/db/es/ElasticMetricsProvider.java
@@ -70,7 +70,7 @@ public class ElasticMetricsProvider implements MetricProvider {
     public int getCurrentMaxMemoryPressure() {
         return elastic.getLowLevelClient()
                       .memoryStats()
-                      .get("nodes")
+                      .path("nodes")
                       .properties()
                       .stream()
                       .map(Map.Entry::getValue)
@@ -81,8 +81,8 @@ public class ElasticMetricsProvider implements MetricProvider {
 
     private int calculateMemoryPressure(JsonNode memoryStats) {
         JsonNode oldGenStats = memoryStats.at(OLD_GEN_STATS_POINTER);
-        int usedInBytes = oldGenStats.get("used_in_bytes").intValue();
-        int maxInBytes = oldGenStats.get("max_in_bytes").intValue();
+        int usedInBytes = oldGenStats.path("used_in_bytes").asInt();
+        int maxInBytes = oldGenStats.path("max_in_bytes").asInt();
 
         return (int) (100f * usedInBytes / maxInBytes);
     }

--- a/src/main/java/sirius/db/es/ElasticMetricsProvider.java
+++ b/src/main/java/sirius/db/es/ElasticMetricsProvider.java
@@ -84,6 +84,10 @@ public class ElasticMetricsProvider implements MetricProvider {
         int usedInBytes = oldGenStats.path("used_in_bytes").asInt();
         int maxInBytes = oldGenStats.path("max_in_bytes").asInt();
 
+        if (maxInBytes == 0) {
+            return 0;
+        }
+
         return (int) (100f * usedInBytes / maxInBytes);
     }
 }

--- a/src/main/java/sirius/db/es/ElasticMetricsProvider.java
+++ b/src/main/java/sirius/db/es/ElasticMetricsProvider.java
@@ -8,17 +8,24 @@
 
 package sirius.db.es;
 
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.metrics.Metric;
 import sirius.kernel.health.metrics.MetricProvider;
 import sirius.kernel.health.metrics.MetricsCollector;
+
+import java.util.Map;
 
 /**
  * Provides metrics for Elasticsearch (if configured).
  */
-@Register
+@Register(classes = {ElasticMetricsProvider.class, MetricProvider.class})
 public class ElasticMetricsProvider implements MetricProvider {
+
+    private static final JsonPointer OLD_GEN_STATS_POINTER = JsonPointer.compile("/jvm/mem/pools/old");
 
     @Part
     private Elastic elastic;
@@ -43,6 +50,40 @@ public class ElasticMetricsProvider implements MetricProvider {
                              "ES Unassigned Shards",
                              health.path("unassigned_shards").asInt(),
                              null);
+            collector.metric("es_memory_pressure",
+                             "es-memory-pressure",
+                             "Elasticsearch Memory Pressure",
+                             getCurrentMaxMemoryPressure(),
+                             Metric.UNIT_PERCENT);
         }
+    }
+
+    /**
+     * Determines the current maximum memory pressure of all ES nodes.
+     * <p>
+     * The memory pressure is defined as the usage in percent of the old gen memory pool.
+     *
+     * @return the current maximum memory pressure
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/high-jvm-memory-pressure.html">
+     * ElasticSearch reference page for JVM memory pressure</a>
+     */
+    public int getCurrentMaxMemoryPressure() {
+        return elastic.getLowLevelClient()
+                      .memoryStats()
+                      .get("nodes")
+                      .properties()
+                      .stream()
+                      .map(Map.Entry::getValue)
+                      .mapToInt(this::calculateMemoryPressure)
+                      .max()
+                      .orElse(0);
+    }
+
+    private int calculateMemoryPressure(JsonNode memoryStats) {
+        JsonNode oldGenStats = memoryStats.at(OLD_GEN_STATS_POINTER);
+        int usedInBytes = oldGenStats.get("used_in_bytes").intValue();
+        int maxInBytes = oldGenStats.get("max_in_bytes").intValue();
+
+        return (int) (100f * usedInBytes / maxInBytes);
     }
 }

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -50,6 +50,7 @@ public class LowLevelClient {
     private static final String API_REFRESH = "/_refresh";
     private static final String API_SETTINGS = "/_settings";
     private static final String API_CLUSTER_HEALTH = "/_cluster/health";
+    private static final String API_JVM_MEMORY_STATS = "/_nodes/stats?pretty&filter_path=nodes.*.jvm.mem";
     private static final String API_STATS = "/_stats";
     private static final String API_MAPPING = "/_mapping";
     private static final String API_BULK = "_bulk";
@@ -577,6 +578,15 @@ public class LowLevelClient {
      */
     public ObjectNode clusterHealth() {
         return performGet().execute(API_CLUSTER_HEALTH).response();
+    }
+
+    /**
+     * Fetches the JVM memory statistics.
+     *
+     * @return a JSON object as returned by <tt>/_nodes/stats?pretty&filter_path=nodes.*.jvm.mem</tt>
+     */
+    public ObjectNode memoryStats() {
+        return performGet().execute(API_JVM_MEMORY_STATS).response();
     }
 
     /**

--- a/src/main/resources/component-060-db.conf
+++ b/src/main/resources/component-060-db.conf
@@ -112,6 +112,11 @@ health {
         es-unassigned-shards.warning = 0
         es-unassigned-shards.error = 1
 
+        # Warns about old-gen memory pressure in Elasticsearch
+        es-memory-pressure.gray = 50
+        es-memory-pressure.warning = 75
+        es-memory-pressure.error = 85
+
         # Number of calls against qdrant
         qdrant-calls.gray = 10
         qdrant-calls.warning = 0


### PR DESCRIPTION
### Description

The memory pressure of Elasticsearch is supposed to be a good indicator for the performance of the cluster. It is calculated as the usage in percent of the old gen memory pool, as described in https://www.elastic.co/guide/en/elasticsearch/reference/current/high-jvm-memory-pressure.html

We also make the metric available over a public method. This can be used to slow down or pause time-uncritical tasks.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14021](https://scireum.myjetbrains.com/youtrack/issue/SE-14021)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
