### PR TITLE
Improves the BaseEntityCache and BaseEntityRef

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -102,7 +102,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
 
     @Override
     public String getValueForUserMessage(Object entity) {
-        return NLS.toUserString(getEntityRef(accessPath.apply(entity)).fetchValue());
+        return NLS.toUserString(getEntityRef(accessPath.apply(entity)).fetchCachedValue());
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -200,12 +200,25 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      *
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
      */
-    public E fetchValueFromSecondary() {
+    public E fetchCachedValueFromSecondary() {
         if (value == null && id != null) {
             Optional<E> entity = findInSecondary(type, id);
             return entity.orElse(null);
         }
         return value;
+    }
+
+    /**
+     * Returns the effective entity object which is referenced using a secondary node of a DB cluster.
+     * <p>
+     * Note, this values returned by this method will never be cached and a new lookup is always performed.
+     *
+     * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     * @deprecated use {@link #fetchCachedValueFromSecondary()} instead
+     */
+    @Deprecated
+    public E fetchValueFromSecondary() {
+        return fetchCachedValueFromSecondary();
     }
 
     /**

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -167,7 +167,7 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      * Note, this might cause a database lookup if the entity is not prefetched.
      *
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
-     * @deprecated use {@link #fetchCachedValue()} instead
+     * @deprecated use {@link #fetchCachedValue()} or {@link #forceFetchValue()} instead
      */
     @Deprecated
     public E fetchValue() {
@@ -235,7 +235,7 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      * Note, this values returned by this method will never be cached and a new lookup is always performed.
      *
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
-     * @deprecated use {@link #fetchCachedValueFromSecondary()} instead
+     * @deprecated use {@link #fetchCachedValueFromSecondary()} or {@link #forceFetchValueFromSecondary()} instead
      */
     @Deprecated
     public E fetchValueFromSecondary() {

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -167,8 +167,21 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
      * Note, this might cause a database lookup if the entity is not prefetched.
      *
      * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     * @deprecated use {@link #fetchCachedValue()} instead
      */
+    @Deprecated
     public E fetchValue() {
+        return fetchCachedValue();
+    }
+
+    /**
+     * Returns the effective entity object which is referenced.
+     * <p>
+     * Note, this might cause a database lookup if the entity is not prefetched.
+     *
+     * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     */
+    public E fetchCachedValue() {
         if (value == null && id != null) {
             Optional<E> entity = find(type, id);
             if (entity.isPresent()) {

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -194,6 +194,16 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
     }
 
     /**
+     * Returns the effective entity object which is referenced by forcing a fresh database lookup.
+     *
+     * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     */
+    public E forceFetchValue() {
+        value = null;
+        return fetchCachedValue();
+    }
+
+    /**
      * Returns the effective entity object which is referenced using a secondary node of a DB cluster.
      * <p>
      * Note, this values returned by this method will never be cached and a new lookup is always performed.
@@ -206,6 +216,17 @@ public abstract class BaseEntityRef<I extends Serializable, E extends BaseEntity
             return entity.orElse(null);
         }
         return value;
+    }
+
+    /**
+     * Returns the effective entity object which is referenced by forcing a fresh database lookup using a secondary node
+     * of a DB cluster.
+     *
+     * @return the entity being referenced or <tt>null</tt> if no entity is referenced.
+     */
+    public E forceFetchValueFromSecondary() {
+        value = null;
+        return fetchCachedValueFromSecondary();
     }
 
     /**

--- a/src/main/java/sirius/db/util/BaseEntityCache.java
+++ b/src/main/java/sirius/db/util/BaseEntityCache.java
@@ -85,16 +85,13 @@ public abstract class BaseEntityCache<I extends Serializable, E extends BaseEnti
     }
 
     /**
-     * Fetches the entity in the given ref from the cache and returns it.
+     * Fetches the entity with {@link BaseEntity#ID id} stored in the given ref from the cache and returns it.
      *
      * @param entityRef the ref pointing to the entity to fetch
      * @return the cached entity wrapped in an Optional or an empty Optional
      */
     @Nonnull
     public Optional<E> fetch(@Nonnull BaseEntityRef<I, E> entityRef) {
-        if (entityRef.isValueLoaded()) {
-            return entityRef.getValueIfPresent();
-        }
         return fetchById(entityRef.getIdAsString());
     }
 

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
@@ -31,24 +31,24 @@ class SmartQueryKotlinTest {
     @Test
     fun `queryList returns all entities`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(
-                listOf("Test", "Hello", "World"),
-                result.stream().map { x -> x.value }.collect(Collectors.toList())
+            listOf("Test", "Hello", "World"),
+            result.stream().map { x -> x.value }.collect(Collectors.toList())
         )
     }
 
     @Test
     fun `streamBlockwise() works`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .fields(SmartQueryTestEntity.VALUE)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .fields(SmartQueryTestEntity.VALUE)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
 
         assertEquals(
-                listOf("Test", "Hello", "World"),
-                smartQueryTestEntity.copy().streamBlockwise().map { it.value }.collect(Collectors.toList())
+            listOf("Test", "Hello", "World"),
+            smartQueryTestEntity.copy().streamBlockwise().map { it.value }.collect(Collectors.toList())
         )
         assertThrows<UnsupportedOperationException> {
             smartQueryTestEntity.copy().skip(1).limit(1).streamBlockwise().count()
@@ -60,7 +60,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `count returns the number of entity`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.count()
 
         assertEquals(3, result)
@@ -69,7 +69,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `exists returns a correct value`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.exists()
 
         assertTrue { result }
@@ -78,7 +78,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `exists doesn't screw up the internals of the query`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.exists()
 
         assertTrue { result }
@@ -91,7 +91,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `queryFirst returns the first entity`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.queryFirst()
 
         assertEquals("Test", result.value)
@@ -100,7 +100,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `first returns the first entity`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.first()
 
         assertEquals("Test", result.get().value)
@@ -109,7 +109,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `queryFirst returns null for an empty result`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .eq(SmartQueryTestEntity.VALUE, "xxx")
+            .eq(SmartQueryTestEntity.VALUE, "xxx")
         val result = smartQueryTestEntity.queryFirst()
 
         assertNull(result)
@@ -118,7 +118,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `first returns an empty optional for an empty result`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .eq(SmartQueryTestEntity.VALUE, "xxx")
+            .eq(SmartQueryTestEntity.VALUE, "xxx")
         val result = smartQueryTestEntity.first()
 
         assertNotNull(result)
@@ -127,7 +127,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `limit works on a plain list`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .skip(1).limit(2).orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .skip(1).limit(2).orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf("Hello", "World"), result.stream().map { x -> x.value }.collect(Collectors.toList()))
@@ -144,7 +144,7 @@ class SmartQueryKotlinTest {
         FieldUtils.writeField(newOMA, "schema", mockk<Schema>(), true)
         every { newOMA.getDatabase(Mixing.DEFAULT_REALM) } returns noCapsDB
         val smartQueryTestEntity = newOMA.select(SmartQueryTestEntity::class.java)
-                .skip(1).limit(2).orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .skip(1).limit(2).orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf("Hello", "World"), result.stream().map { x -> x.value }.collect(Collectors.toList()))
@@ -153,11 +153,11 @@ class SmartQueryKotlinTest {
     @Test
     fun `automatic joins work when sorting by a referenced field`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestChildEntity::class.java)
-                .orderAsc(
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            .orderAsc(
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
+            )
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf("Child 1", "Child 2"), result.stream().map { x -> x.name }.collect(Collectors.toList()))
@@ -166,31 +166,31 @@ class SmartQueryKotlinTest {
     @Test
     fun `automatic joins work when fetching a referenced field`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestChildEntity::class.java)
-                .fields(
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            .fields(
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
-                .orderAsc(
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            )
+            .orderAsc(
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
+            )
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf("Parent 1", "Parent 2"), result.stream().map { x -> x.parent.fetchCachedValue().name }
-                .collect(Collectors.toList()))
+            .collect(Collectors.toList()))
     }
 
     @Test
     fun `ids are properly propagated in join fetches `() {
         val smartQueryTestEntity = oma.select(SmartQueryTestChildEntity::class.java)
-                .fields(
-                        SmartQueryTestChildEntity.PARENT,
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            .fields(
+                SmartQueryTestChildEntity.PARENT,
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
+            )
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf(1L, 2L), result.stream().map { x -> x.parent.id }.collect(Collectors.toList()))
@@ -199,23 +199,23 @@ class SmartQueryKotlinTest {
     @Test
     fun `automatic joins work when referencing one table in two relations`() {
         val smartQueryTestChildEntity = oma.select(SmartQueryTestChildEntity::class.java)
-                .fields(
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        ),
-                        SmartQueryTestChildEntity.OTHER_PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            .fields(
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
+                ),
+                SmartQueryTestChildEntity.OTHER_PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
-                .orderAsc(
-                        SmartQueryTestChildEntity.PARENT.join(
-                                SmartQueryTestParentEntity.NAME
-                        )
+            )
+            .orderAsc(
+                SmartQueryTestChildEntity.PARENT.join(
+                    SmartQueryTestParentEntity.NAME
                 )
+            )
         val result = smartQueryTestChildEntity.queryList()
 
         assertEquals(
-                listOf("Parent 1Parent 2", "Parent 2Parent 1"), result.stream()
+            listOf("Parent 1Parent 2", "Parent 2Parent 1"), result.stream()
                 .map { x ->
                     x.parent.fetchCachedValue().name + x.otherParent.fetchCachedValue().name
                 }
@@ -226,30 +226,30 @@ class SmartQueryKotlinTest {
     @Test
     fun `automatic joins work across several tables`() {
         val smartQueryTestChildChildEntity = oma.select(SmartQueryTestChildChildEntity::class.java).fields(
-                SmartQueryTestChildChildEntity.PARENT_CHILD.join(SmartQueryTestChildEntity.PARENT).join(
-                        SmartQueryTestParentEntity.NAME
-                )
+            SmartQueryTestChildChildEntity.PARENT_CHILD.join(SmartQueryTestChildEntity.PARENT).join(
+                SmartQueryTestParentEntity.NAME
+            )
         ).orderAsc(
-                SmartQueryTestChildChildEntity.PARENT_CHILD.join(SmartQueryTestChildEntity.PARENT).join(
-                        SmartQueryTestParentEntity.NAME
-                )
+            SmartQueryTestChildChildEntity.PARENT_CHILD.join(SmartQueryTestChildEntity.PARENT).join(
+                SmartQueryTestParentEntity.NAME
+            )
         )
         val result = smartQueryTestChildChildEntity.queryList()
 
         assertEquals(
-                listOf("Parent 1"),
-                result.stream().map { x -> x.parentChild.fetchCachedValue().parent.fetchCachedValue().name }
-                        .collect(Collectors.toList()))
+            listOf("Parent 1"),
+            result.stream().map { x -> x.parentChild.fetchCachedValue().parent.fetchCachedValue().name }
+                .collect(Collectors.toList()))
     }
 
     @Test
     fun `exists works when referencing a child entity`() {
         val smartQueryTestChildEntity = oma.select(SmartQueryTestParentEntity::class.java).where(
-                OMA.FILTERS.existsIn(
-                        SmartQueryTestParentEntity.ID,
-                        SmartQueryTestChildEntity::class.java,
-                        SmartQueryTestChildEntity.PARENT
-                )
+            OMA.FILTERS.existsIn(
+                SmartQueryTestParentEntity.ID,
+                SmartQueryTestChildEntity::class.java,
+                SmartQueryTestChildEntity.PARENT
+            )
         )
         val result = smartQueryTestChildEntity.queryList()
 
@@ -259,11 +259,11 @@ class SmartQueryKotlinTest {
     @Test
     fun `exists works when referencing a child entity with constraints`() {
         val smartQueryTestChildEntity = oma.select(SmartQueryTestParentEntity::class.java).where(
-                OMA.FILTERS.existsIn(
-                        SmartQueryTestParentEntity.ID,
-                        SmartQueryTestChildEntity::class.java,
-                        SmartQueryTestChildEntity.PARENT
-                ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
+            OMA.FILTERS.existsIn(
+                SmartQueryTestParentEntity.ID,
+                SmartQueryTestChildEntity::class.java,
+                SmartQueryTestChildEntity.PARENT
+            ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
         )
         val result = smartQueryTestChildEntity.queryList()
 
@@ -273,13 +273,13 @@ class SmartQueryKotlinTest {
     @Test
     fun `exists works when inverted`() {
         val smartQueryTestChildEntity = oma.select(SmartQueryTestParentEntity::class.java).where(
-                OMA.FILTERS.not(
-                        OMA.FILTERS.existsIn(
-                                SmartQueryTestParentEntity.ID,
-                                SmartQueryTestChildEntity::class.java,
-                                SmartQueryTestChildEntity.PARENT
-                        ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
-                )
+            OMA.FILTERS.not(
+                OMA.FILTERS.existsIn(
+                    SmartQueryTestParentEntity.ID,
+                    SmartQueryTestChildEntity::class.java,
+                    SmartQueryTestChildEntity.PARENT
+                ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
+            )
         )
         val result = smartQueryTestChildEntity.queryList()
 
@@ -289,14 +289,14 @@ class SmartQueryKotlinTest {
     @Test
     fun `exists works with complicated columns`() {
         val smartQueryTestChildEntity = oma.select(SmartQueryTestParentEntity::class.java).where(
-                OMA.FILTERS.existsIn(
-                        CompoundValue(SmartQueryTestParentEntity.ID).addComponent(SmartQueryTestParentEntity.NAME),
-                        SmartQueryTestChildEntity::class.java,
-                        CompoundValue(SmartQueryTestChildEntity.PARENT).addComponent(
-                                SmartQueryTestChildEntity
-                                        .PARENT_NAME
-                        )
-                ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
+            OMA.FILTERS.existsIn(
+                CompoundValue(SmartQueryTestParentEntity.ID).addComponent(SmartQueryTestParentEntity.NAME),
+                SmartQueryTestChildEntity::class.java,
+                CompoundValue(SmartQueryTestChildEntity.PARENT).addComponent(
+                    SmartQueryTestChildEntity
+                        .PARENT_NAME
+                )
+            ).where(OMA.FILTERS.eq(SmartQueryTestChildEntity.NAME, "Child 1"))
         )
         val result = smartQueryTestChildEntity.queryList()
 
@@ -306,13 +306,13 @@ class SmartQueryKotlinTest {
     @Test
     fun `copy of query does also copy fields`() {
         val smartQueryTestEntity = oma.select(SmartQueryTestEntity::class.java)
-                .fields(SmartQueryTestEntity.TEST_NUMBER, SmartQueryTestEntity.VALUE)
-                .copy()
-                .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
+            .fields(SmartQueryTestEntity.TEST_NUMBER, SmartQueryTestEntity.VALUE)
+            .copy()
+            .orderAsc(SmartQueryTestEntity.TEST_NUMBER)
         val result = smartQueryTestEntity.queryList()
 
         assertEquals(listOf("Test", "Hello", "World"), result.stream().map { x -> x.value }
-                .collect(Collectors.toList()))
+            .collect(Collectors.toList()))
     }
 
     @Test
@@ -321,12 +321,12 @@ class SmartQueryKotlinTest {
         testEntityWithNullRef.name = "bliblablub"
         oma.update(testEntityWithNullRef)
         val result = oma.select(TestEntityWithNullRef::class.java)
-                .fields(
-                        TestEntityWithNullRef.NAME,
-                        TestEntityWithNullRef.PARENT.join(SmartQueryTestParentEntity.NAME),
-                        TestEntityWithNullRef.PARENT.join(SmartQueryTestParentEntity.ID)
-                )
-                .eq(TestEntityWithNullRef.ID, testEntityWithNullRef.getId()).queryList()
+            .fields(
+                TestEntityWithNullRef.NAME,
+                TestEntityWithNullRef.PARENT.join(SmartQueryTestParentEntity.NAME),
+                TestEntityWithNullRef.PARENT.join(SmartQueryTestParentEntity.ID)
+            )
+            .eq(TestEntityWithNullRef.ID, testEntityWithNullRef.getId()).queryList()
         val found = result[0]
 
         assertTrue { found.parent.isEmpty }
@@ -344,11 +344,11 @@ class SmartQueryKotlinTest {
         oma.update(testEntityWithNullRef)
 
         val result = oma.select(TestEntityWithNullRef::class.java)
-                .fields(
-                        TestEntityWithNullRef.NAME,
-                        SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME)
-                )
-                .eq(TestEntityWithNullRef.ID, testEntityWithNullRef.getId()).queryList()
+            .fields(
+                TestEntityWithNullRef.NAME,
+                SmartQueryTestChildEntity.PARENT.join(SmartQueryTestParentEntity.NAME)
+            )
+            .eq(TestEntityWithNullRef.ID, testEntityWithNullRef.getId()).queryList()
         val found = result[0]
 
         assertTrue { found.parent.isFilled }
@@ -365,8 +365,8 @@ class SmartQueryKotlinTest {
         oma.update(smartQueryTestMixinEntity1)
 
         val smartQueryTestMixinEntity2 = oma.select(SmartQueryTestMixinEntity::class.java).eq(
-                SmartQueryTestMixinEntityMixin.MIXIN_VALUE.inMixin(SmartQueryTestMixinEntityMixin::class.java),
-                "mixinvalue1"
+            SmartQueryTestMixinEntityMixin.MIXIN_VALUE.inMixin(SmartQueryTestMixinEntityMixin::class.java),
+            "mixinvalue1"
         ).queryFirst()
 
         assertFalse { smartQueryTestMixinEntity1.isNew }
@@ -388,23 +388,23 @@ class SmartQueryKotlinTest {
     @Test
     fun `eq with row values works`() {
         var items = oma.select(SmartQueryTestEntity::class.java).where(
-                OMA.FILTERS.eq(
-                        CompoundValue(SmartQueryTestEntity.VALUE).addComponent(
-                                SmartQueryTestEntity
-                                        .TEST_NUMBER
-                        ),
-                        CompoundValue("Test").addComponent(1)
-                )
+            OMA.FILTERS.eq(
+                CompoundValue(SmartQueryTestEntity.VALUE).addComponent(
+                    SmartQueryTestEntity
+                        .TEST_NUMBER
+                ),
+                CompoundValue("Test").addComponent(1)
+            )
         ).queryList()
 
         assertEquals(1, items.size)
         assertEquals(1, items[0].testNumber)
 
         items = oma.select(SmartQueryTestEntity::class.java).where(
-                OMA.FILTERS.eq(
-                        CompoundValue("Test").addComponent(SmartQueryTestEntity.TEST_NUMBER),
-                        CompoundValue(SmartQueryTestEntity.VALUE).addComponent(1)
-                )
+            OMA.FILTERS.eq(
+                CompoundValue("Test").addComponent(SmartQueryTestEntity.TEST_NUMBER),
+                CompoundValue(SmartQueryTestEntity.VALUE).addComponent(1)
+            )
         ).queryList()
 
         assertEquals(1, items.size)
@@ -414,10 +414,10 @@ class SmartQueryKotlinTest {
     @Test
     fun `gt with row values works`() {
         val items = oma.select(SmartQueryTestEntity::class.java).where(
-                OMA.FILTERS.gt(
-                        CompoundValue(SmartQueryTestEntity.VALUE).addComponent(2),
-                        CompoundValue("Test").addComponent(SmartQueryTestEntity.TEST_NUMBER)
-                )
+            OMA.FILTERS.gt(
+                CompoundValue(SmartQueryTestEntity.VALUE).addComponent(2),
+                CompoundValue("Test").addComponent(SmartQueryTestEntity.TEST_NUMBER)
+            )
         ).orderAsc(SmartQueryTestEntity.VALUE).queryList()
 
         assertEquals(2, items.size)
@@ -429,7 +429,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `count distinct for one field returns a correct number of entities`() {
         val smartQueryTestCountEntity = oma.select(SmartQueryTestCountEntity::class.java)
-                .distinctFields(SmartQueryTestCountEntity.FIELD_ONE)
+            .distinctFields(SmartQueryTestCountEntity.FIELD_ONE)
         val result = smartQueryTestCountEntity.count()
 
         assertEquals(2, result)
@@ -438,10 +438,10 @@ class SmartQueryKotlinTest {
     @Test
     fun `count distinct for two fields returns a correct number of entities`() {
         val smartQueryTestCountEntity = oma.select(SmartQueryTestCountEntity::class.java)
-                .distinctFields(
-                        SmartQueryTestCountEntity.FIELD_ONE,
-                        SmartQueryTestCountEntity.FIELD_TWO
-                )
+            .distinctFields(
+                SmartQueryTestCountEntity.FIELD_ONE,
+                SmartQueryTestCountEntity.FIELD_TWO
+            )
         val result = smartQueryTestCountEntity.count()
 
         assertEquals(3, result)
@@ -450,7 +450,7 @@ class SmartQueryKotlinTest {
     @Test
     fun `count for one field without distinct modifier returns a correct number of entities`() {
         val smartQueryTestCountEntity = oma.select(SmartQueryTestCountEntity::class.java)
-                .fields(SmartQueryTestCountEntity.FIELD_ONE)
+            .fields(SmartQueryTestCountEntity.FIELD_ONE)
         val result = smartQueryTestCountEntity.count()
 
         assertEquals(4, result)
@@ -459,12 +459,30 @@ class SmartQueryKotlinTest {
     @Test
     fun `count for two fields without distinct modifier throws an exception`() {
         val smartQueryTestCountEntity = oma.select(SmartQueryTestCountEntity::class.java)
-                .fields(
-                        SmartQueryTestCountEntity.FIELD_ONE,
-                        SmartQueryTestCountEntity.FIELD_TWO
-                )
+            .fields(
+                SmartQueryTestCountEntity.FIELD_ONE,
+                SmartQueryTestCountEntity.FIELD_TWO
+            )
 
         assertThrows<HandledException> { smartQueryTestCountEntity.count() }
+    }
+
+    @Test
+    fun `fetchCachedValue and forceFetchCachedValue works`() {
+        val child = SmartQueryTestChildEntity()
+        child.parent.id = 3
+        var parent = child.parent.fetchCachedValue()
+        assertEquals("Parent 3", parent.name)
+
+        val freshParent = oma.find(SmartQueryTestParentEntity::class.java, 3).orElse(null)
+        freshParent.name = "Parent 3.1"
+        oma.update(freshParent)
+
+        parent = child.parent.fetchCachedValue()
+        assertEquals("Parent 3", parent.name)
+
+        parent = child.parent.forceFetchValue()
+        assertEquals("Parent 3.1", parent.name)
     }
 
     companion object {
@@ -511,6 +529,9 @@ class SmartQueryKotlinTest {
             val smartQueryTestParentEntity2 = SmartQueryTestParentEntity()
             smartQueryTestParentEntity2.name = "Parent 2"
             oma.update(smartQueryTestParentEntity2)
+            val smartQueryTestParentEntity3 = SmartQueryTestParentEntity()
+            smartQueryTestParentEntity3.name = "Parent 3"
+            oma.update(smartQueryTestParentEntity3)
 
             var smartQueryTestChildEntity = SmartQueryTestChildEntity()
             smartQueryTestChildEntity.name = "Child 1"

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
@@ -178,7 +178,7 @@ class SmartQueryKotlinTest {
                 )
         val result = smartQueryTestEntity.queryList()
 
-        assertEquals(listOf("Parent 1", "Parent 2"), result.stream().map { x -> x.parent.fetchValue().name }
+        assertEquals(listOf("Parent 1", "Parent 2"), result.stream().map { x -> x.parent.fetchCachedValue().name }
                 .collect(Collectors.toList()))
     }
 
@@ -217,7 +217,7 @@ class SmartQueryKotlinTest {
         assertEquals(
                 listOf("Parent 1Parent 2", "Parent 2Parent 1"), result.stream()
                 .map { x ->
-                    x.parent.fetchValue().name + x.otherParent.fetchValue().name
+                    x.parent.fetchCachedValue().name + x.otherParent.fetchCachedValue().name
                 }
                 .collect(Collectors.toList())
         )
@@ -238,7 +238,7 @@ class SmartQueryKotlinTest {
 
         assertEquals(
                 listOf("Parent 1"),
-                result.stream().map { x -> x.parentChild.fetchValue().parent.fetchValue().name }
+                result.stream().map { x -> x.parentChild.fetchCachedValue().parent.fetchCachedValue().name }
                         .collect(Collectors.toList()))
     }
 
@@ -352,8 +352,8 @@ class SmartQueryKotlinTest {
         val found = result[0]
 
         assertTrue { found.parent.isFilled }
-        assertFalse { found.parent.fetchValue().isNew }
-        assertTrue { Strings.isFilled(found.parent.fetchValue().name) }
+        assertFalse { found.parent.fetchCachedValue().isNew }
+        assertTrue { Strings.isFilled(found.parent.fetchCachedValue().name) }
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
@@ -283,7 +283,10 @@ class SmartQueryKotlinTest {
         )
         val result = smartQueryTestChildEntity.queryList()
 
-        assertEquals(listOf("Parent 2"), result.stream().map { x -> x.name }.collect(Collectors.toList()))
+        assertEquals(
+            listOf("Parent 2", "Parent 3"),
+            result.stream().map { x -> x.name.substring(0, 8) }.collect(Collectors.toList())
+        )
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
@@ -283,6 +283,8 @@ class SmartQueryKotlinTest {
         )
         val result = smartQueryTestChildEntity.queryList()
 
+        // Another test case will rename "Parent 3" to "Parent 3.1". Since we cannot guarantee the order in which
+        // they run, we strip the string to match both cases
         assertEquals(
             listOf("Parent 2", "Parent 3"),
             result.stream().map { x -> x.name.substring(0, 8) }.collect(Collectors.toList())


### PR DESCRIPTION
### Description

- BaseEntityCache
Always use the ID stored in the reference to retrieve an item from the cache. Previously, if the reference was pre-loaded, that value was delivered instead.
- BaseEntityRef
`fetchValue()` is now deprecated and replaced by `fetchCachedValue()` + `forceFetchValue()`. Same for the `*FromSecondary` variants.

Marked as **BREAKING** since usages of fetchValue() and fetchValueFromSecondary() in tagliatelle templates might lead to build warnings.

To keep the previous semantics, simply replace `fetchValue()` by `fetchCachedValue()` and `fetchValueFromSecondary()` by `fetchCachedValueFromSecondary()`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1039](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1039)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
