### PR TITLE
Fixes amount propery persistance scale handling

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -146,7 +146,7 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
         // else a schema change will be issued.
         NumberFormat format = getAnnotation(Numeric.class).map(numeric -> {
             return new NumberFormat(numeric.scale(), RoundingMode.HALF_UP, NLS.getMachineFormatSymbols(), false, null);
-        }).orElse(NumberFormat.MACHINE_THREE_DECIMAL_PLACES);
+        }).orElse(NumberFormat.MACHINE_NO_DECIMAL_PLACES);
         return Amount.of((BigDecimal) defaultData).toString(format).asString();
     }
 

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.Types;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -92,12 +93,22 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
     @Override
     public Object transformValue(Value value) {
         if (value.isFilled()) {
-            return NLS.parseUserString(Amount.class, value.asString()).round(getPersistanceNumberFormat());
+            return applyNumericRounding(NLS.parseUserString(Amount.class, value.asString()));
         }
         if (this.isNullable() || defaultValue.isEmptyString()) {
             return Amount.NOTHING;
         }
         return defaultValue.getAmount();
+    }
+
+    /**
+     * In case the property is annotated with {@link Numeric}, the value is rounded according to the annotation.
+     *
+     * @param amount the amount
+     * @return the rounded amount if the property is annotated with {@link Numeric}, otherwise the amount itself
+     */
+    private Amount applyNumericRounding(Amount amount) {
+        return getAnnotatedNumberFormat().map(amount::round).orElse(amount);
     }
 
     @Override
@@ -106,7 +117,7 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
             if (value.getAmount().isEmpty() && !this.isNullable()) {
                 return defaultValue.getAmount();
             }
-            return ((Amount) value.get()).round(getPersistanceNumberFormat());
+            return applyNumericRounding((Amount) value.get());
         }
 
         if (value.isFilled()) {
@@ -118,10 +129,10 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
 
     private Amount parseWithNLS(@Nonnull Value value) {
         try {
-            return Amount.ofMachineString(value.asString()).round(getPersistanceNumberFormat());
+            return applyNumericRounding(Amount.ofMachineString(value.asString()));
         } catch (IllegalArgumentException originalFormatException) {
             try {
-                return Amount.ofUserString(value.asString()).round(getPersistanceNumberFormat());
+                return applyNumericRounding(Amount.ofUserString(value.asString()));
             } catch (Exception ignored) {
                 throw originalFormatException;
             }
@@ -144,15 +155,15 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
         }
         // the resulting string needs to match the string representation in the DB exactly,
         // else a schema change will be issued.
-        NumberFormat format = getPersistanceNumberFormat();
+        NumberFormat format = getAnnotatedNumberFormat().orElse(NumberFormat.MACHINE_NO_DECIMAL_PLACES);
         return Amount.of((BigDecimal) defaultData).toString(format).asString();
     }
 
     @Nonnull
-    private NumberFormat getPersistanceNumberFormat() {
+    private Optional<NumberFormat> getAnnotatedNumberFormat() {
         return getAnnotation(Numeric.class).map(numeric -> {
             return new NumberFormat(numeric.scale(), RoundingMode.HALF_UP, NLS.getMachineFormatSymbols(), false, null);
-        }).orElse(NumberFormat.MACHINE_NO_DECIMAL_PLACES);
+        });
     }
 
     @Override

--- a/src/test/java/sirius/db/jdbc/DataTypesEntity.java
+++ b/src/test/java/sirius/db/jdbc/DataTypesEntity.java
@@ -20,6 +20,8 @@ import java.time.LocalTime;
 
 public class DataTypesEntity extends SQLEntity {
 
+    public static final int AMOUNT_SCALE = 3;
+
     public enum TestEnum {
         Test1, TestTest, Test2
     }
@@ -44,7 +46,7 @@ public class DataTypesEntity extends SQLEntity {
 
     @DefaultValue("300")
     @NullAllowed
-    @Numeric(precision = 20, scale = 3)
+    @Numeric(precision = 20, scale = AMOUNT_SCALE)
     private Amount amountValue = Amount.NOTHING;
 
     @DefaultValue("2018-01-01")

--- a/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
@@ -9,13 +9,20 @@
 package sirius.db.mongo.properties;
 
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.Numeric;
 import sirius.db.mongo.MongoEntity;
 import sirius.kernel.commons.Amount;
 
 public class MongoAmountEntity extends MongoEntity {
 
+    public static final int AMOUNT_SCALE = 3;
+
     public static final Mapping TEST_AMOUNT = Mapping.named("testAmount");
     private Amount testAmount = Amount.NOTHING;
+
+    public static final Mapping SCALED_AMOUNT = Mapping.named("scaledAmount");
+    @Numeric(precision = 20, scale = AMOUNT_SCALE)
+    private Amount scaledAmount = Amount.NOTHING;
 
     public Amount getTestAmount() {
         return testAmount;
@@ -23,5 +30,13 @@ public class MongoAmountEntity extends MongoEntity {
 
     public void setTestAmount(Amount testAmount) {
         this.testAmount = testAmount;
+    }
+
+    public Amount getScaledAmount() {
+        return scaledAmount;
+    }
+
+    public void setScaledAmount(Amount scaledAmount) {
+        this.scaledAmount = scaledAmount;
     }
 }

--- a/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
@@ -9,6 +9,7 @@
 package sirius.db.mongo.properties;
 
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Numeric;
 import sirius.db.mongo.MongoEntity;
 import sirius.kernel.commons.Amount;
@@ -21,6 +22,7 @@ public class MongoAmountEntity extends MongoEntity {
     private Amount testAmount = Amount.NOTHING;
 
     public static final Mapping SCALED_AMOUNT = Mapping.named("scaledAmount");
+    @NullAllowed
     @Numeric(precision = 20, scale = AMOUNT_SCALE)
     private Amount scaledAmount = Amount.NOTHING;
 

--- a/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
@@ -14,6 +14,7 @@ import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Amount
 import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part
+import java.math.RoundingMode
 import java.time.Duration
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -86,8 +87,24 @@ class DataTypesTest {
     }
 
     @Test
-    fun `default values work`() {
+    fun `AmountProperty scaling works as excepted`() {
+        var test = DataTypesEntity()
+        val unscaledValue = Value.of("1,2345")
 
+        val amountProperty = test.descriptor.getProperty("amountValue")
+        amountProperty.parseValue(test, unscaledValue)
+        oma.update(test)
+        test = oma.refreshOrFail(test)
+        val expectedAmount = unscaledValue.amount.round(DataTypesEntity.AMOUNT_SCALE, RoundingMode.HALF_UP)
+        assertEquals(expectedAmount, test.amountValue)
+
+        // Storing the same value twice must not trigger a change
+        amountProperty.parseValue(test, unscaledValue)
+        assertFalse { test.isAnyMappingChanged }
+    }
+
+    @Test
+    fun `default values work`() {
         var test = DataTypesEntity()
 
         oma.update(test)


### PR DESCRIPTION
### Description
When applying user input or import input data to an Amount field of an entity, we must apply the scale setting that would be applied by the database. So we are able to properly compare values of the field and detect changes to it.  

- Drive by: Fix scale of default value in case of missing Numeric annotation

Out of scope: 
- precision, as this is less significant (if you have to low precision you are screwed anyway) and harder to check/ensure

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1041](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1041)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
