### PR TITLE
SIRI-1042 fix not working unique-check on changing a within value

### DIFF
--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -821,10 +821,10 @@ public abstract class Property extends Composable {
         }
 
         List<Mapping> withinColumns = Arrays.stream(unique.within()).map(Mapping::named).toList();
-        List<Mapping> changedColumns = withinColumns.stream().filter(baseEntity::isChanged).toList();
+        List<Mapping> changedWithinColumns = withinColumns.stream().filter(baseEntity::isChanged).toList();
 
         // Only enforce uniqueness if the value has changed or if any of the within column values have changed
-        if (baseEntity.isChanged(nameAsMapping) || !changedColumns.isEmpty()) {
+        if (baseEntity.isChanged(nameAsMapping) || !changedWithinColumns.isEmpty()) {
             baseEntity.assertUnique(nameAsMapping, propertyValue, withinColumns.toArray(Mapping[]::new));
         }
     }

--- a/src/main/java/sirius/db/mixing/annotations/Unique.java
+++ b/src/main/java/sirius/db/mixing/annotations/Unique.java
@@ -26,9 +26,9 @@ import java.lang.annotation.Target;
 public @interface Unique {
 
     /**
-     * Names properties which must also match fro two entities to trigger the unique check.
+     * Names properties which must also match for two entities to trigger the unique check.
      *
-     * @return the list of properties which determine the scope of the uniqueness
+     * @return the array of properties which determine the scope of the uniqueness
      */
     String[] within() default {};
 

--- a/src/test/java/sirius/db/jdbc/TestEntity.java
+++ b/src/test/java/sirius/db/jdbc/TestEntity.java
@@ -11,17 +11,25 @@ package sirius.db.jdbc;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.NullAllowed;
+import sirius.db.mixing.annotations.Unique;
 
 @Index(name = "lastname", columns = "lastname")
 public class TestEntity extends SQLEntity {
 
     public static final Mapping FIRSTNAME = Mapping.named("firstname");
     @Length(50)
+    @Unique(within = "within")
     private String firstname;
 
     public static final Mapping LASTNAME = Mapping.named("lastname");
     @Length(50)
     private String lastname;
+
+    public static final Mapping WITHIN = Mapping.named("within");
+    @Length(50)
+    @NullAllowed
+    private String within;
 
     public static final Mapping AGE = Mapping.named("age");
     private int age;
@@ -46,6 +54,14 @@ public class TestEntity extends SQLEntity {
 
     public void setLastname(String lastname) {
         this.lastname = lastname;
+    }
+
+    public String getWithin() {
+        return within;
+    }
+
+    public void setWithin(String within) {
+        this.within = within;
     }
 
     public int getAge() {

--- a/src/test/kotlin/sirius/db/jdbc/OMATest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/OMATest.kt
@@ -33,6 +33,7 @@ class OMATest {
         assertEquals("Test", readBack.firstname)
         assertEquals("Entity", readBack.lastname)
         assertEquals(12, readBack.age)
+        oma.delete(testEntity)
     }
 
     @Test
@@ -71,6 +72,7 @@ class OMATest {
         assertEquals("Simpson", readBack.lastname)
         assertEquals("Jay", readBack.`as`(TestMixin::class.java).middleName)
         assertEquals("J", readBack.`as`(TestMixin::class.java).`as`(TestMixinMixin::class.java).initial)
+        oma.delete(testEntityWithMixin)
     }
 
     @Test
@@ -89,6 +91,7 @@ class OMATest {
         assertEquals("Marge", readBack.firstname)
         assertEquals("Simpson", readBack.lastname)
         assertEquals(43, readBack.age)
+        oma.delete(testEntity)
     }
 
     @Test
@@ -112,6 +115,7 @@ class OMATest {
         assertEquals("Marge", readBack.firstname)
         assertNull(readBack.lastname)
         assertEquals(43, readBack.age)
+        oma.delete(testEntity)
     }
 
     @Test
@@ -155,6 +159,7 @@ class OMATest {
             testEntityWithMixin.isAnyMappingChanged
             testEntityWithMixin.isChanged(TestMixin.MIDDLE_NAME.inMixin(TestMixin::class.java))
         }
+        oma.delete(testEntityWithMixin)
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
@@ -112,6 +112,8 @@ class BatchContextTest {
         assertEquals("Second", oma.refreshOrFail(testEntity2).firstname)
 
         batchContext.close()
+        oma.delete(testEntity)
+        oma.delete(testEntity2)
     }
 
     @Test
@@ -137,6 +139,8 @@ class BatchContextTest {
         assertEquals("Second", oma.refreshOrFail(testEntity2).within)
 
         batchContext.close()
+        oma.delete(testEntity)
+        oma.delete(testEntity2)
     }
 
     @Test
@@ -157,6 +161,7 @@ class BatchContextTest {
         assertEquals("Updated", oma.refreshOrFail(testEntity).firstname)
 
         batchContext.close()
+        oma.delete(testEntity)
     }
 
     @Test
@@ -180,6 +185,8 @@ class BatchContextTest {
         assertNotNull(find.find(notFound))
 
         batchContext.close()
+        oma.delete(testEntity)
+        oma.delete(found)
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
@@ -90,6 +90,56 @@ class BatchContextTest {
     }
 
     @Test
+    fun `unique check works on changing the value in an update`() {
+        val testEntity = TestEntity()
+        testEntity.firstname = "First"
+        testEntity.lastname = "First"
+        testEntity.within = "First"
+        oma.update(testEntity)
+        val testEntity2 = TestEntity();
+        testEntity2.firstname = "Second"
+        testEntity2.lastname = "First"
+        testEntity2.within = "First"
+        oma.update(testEntity2)
+        val batchContext = BatchContext({ "Test" }, Duration.ofMinutes(2))
+        val update = batchContext.updateByIdQuery(TestEntity::class.java, TestEntity.FIRSTNAME)
+
+        testEntity2.firstname = "First"
+        assertThrows<HandledException> {
+            update.update(testEntity2, true, false)
+        }
+
+        assertEquals("Second", oma.refreshOrFail(testEntity2).firstname)
+
+        batchContext.close()
+    }
+
+    @Test
+    fun `unique check works on changing the within-value in an update`() {
+        val testEntity = TestEntity()
+        testEntity.firstname = "First"
+        testEntity.lastname = "First"
+        testEntity.within = "First"
+        oma.update(testEntity)
+        val testEntity2 = TestEntity();
+        testEntity2.firstname = "First"
+        testEntity2.lastname = "First"
+        testEntity2.within = "Second"
+        oma.update(testEntity2)
+        val batchContext = BatchContext({ "Test" }, Duration.ofMinutes(2))
+        val update = batchContext.updateByIdQuery(TestEntity::class.java, TestEntity.WITHIN)
+
+        testEntity2.within = "First"
+        assertThrows<HandledException> {
+            update.update(testEntity2, true, false)
+        }
+
+        assertEquals("Second", oma.refreshOrFail(testEntity2).within)
+
+        batchContext.close()
+    }
+
+    @Test
     fun `batch update works`() {
         val testEntity = TestEntity()
         testEntity.firstname = "Updating"


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
If some has a unique-check with a within-column and the within-column value changes until now this was an available way to surround a unique-check on editing the value later... This will fix this buggy "workaround"

Also add some fitting test-cases for this use case

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1042](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1042)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
