### PR TITLE
introduce case-sensitive parameter for SQL QueryFields.

### DIFF
--- a/src/main/java/sirius/db/es/constraints/ElasticQueryCompiler.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticQueryCompiler.java
@@ -41,7 +41,7 @@ public class ElasticQueryCompiler extends QueryCompiler<ElasticConstraint> {
     }
 
     @Override
-    protected ElasticConstraint compileSearchToken(Mapping field, QueryField.Mode mode, String value) {
+    protected ElasticConstraint compileSearchToken(Mapping field, QueryField.Mode mode, boolean caseSensitive, String value) {
         if (mode == QueryField.Mode.EQUAL) {
             return factory.eq(field, value);
         }

--- a/src/main/java/sirius/db/jdbc/constraints/SQLQueryCompiler.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLQueryCompiler.java
@@ -42,19 +42,19 @@ public class SQLQueryCompiler extends QueryCompiler<SQLConstraint> {
     }
 
     @Override
-    protected SQLConstraint compileSearchToken(Mapping field, QueryField.Mode mode, String value) {
+    protected SQLConstraint compileSearchToken(Mapping field, QueryField.Mode mode, boolean caseSensitive, String value) {
         Optional<String> caseOptimizedValue = getCaseOptimizedValue(field, value);
         switch (mode) {
             case EQUAL:
                 return factory.eq(field, caseOptimizedValue.orElse(value));
             case LIKE:
-                if (caseOptimizedValue.isEmpty() && value.contains("*")) {
+                if ((caseOptimizedValue.isEmpty() && value.contains("*")) || !caseSensitive) {
                     return OMA.FILTERS.like(field).matches(value).ignoreCase().build();
                 } else {
                     return factory.eq(field, caseOptimizedValue.orElse(value));
                 }
             case PREFIX:
-                if (caseOptimizedValue.isEmpty() && value.contains("*")) {
+                if ((caseOptimizedValue.isEmpty() && value.contains("*")) || !caseSensitive) {
                     return OMA.FILTERS.like(field).startsWith(value).ignoreCase().build();
                 } else {
                     return OMA.FILTERS.like(field).startsWith(caseOptimizedValue.orElse(value)).build();

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -502,6 +502,7 @@ public abstract class QueryCompiler<C extends Constraint> {
             for (QueryField field : searchFields) {
                 fieldConstraints.add(compileSearchToken(field.getField(),
                                                         QueryField.Mode.EQUAL,
+                                                        field.isCaseSensitive(),
                                                         token.getValue().toString()));
             }
             constraints.add(factory.or(fieldConstraints));
@@ -509,7 +510,10 @@ public abstract class QueryCompiler<C extends Constraint> {
             for (String word : token.getValue().toString().split("\\s")) {
                 List<C> fieldConstraints = new ArrayList<>();
                 for (QueryField field : searchFields) {
-                    fieldConstraints.add(compileSearchToken(field.getField(), field.getMode(), word));
+                    fieldConstraints.add(compileSearchToken(field.getField(),
+                                                            field.getMode(),
+                                                            field.isCaseSensitive(),
+                                                            word));
                 }
                 constraints.add(factory.or(fieldConstraints));
             }
@@ -520,12 +524,13 @@ public abstract class QueryCompiler<C extends Constraint> {
     /**
      * Permits the subclasses to generate the appropriate search constraint.
      *
-     * @param field the field to search in
-     * @param mode  the mode to use
-     * @param value the value to search for
+     * @param field         the field to search in
+     * @param mode          the mode to use
+     * @param caseSensitive determines if the search should be case-sensitive
+     * @param value         the value to search for
      * @return an appropriate constraint for the given parameters
      */
-    protected abstract C compileSearchToken(Mapping field, QueryField.Mode mode, String value);
+    protected abstract C compileSearchToken(Mapping field, QueryField.Mode mode, boolean caseSensitive, String value);
 
     /**
      * Parses an operation on the given field.

--- a/src/main/java/sirius/db/mixing/query/QueryField.java
+++ b/src/main/java/sirius/db/mixing/query/QueryField.java
@@ -26,10 +26,12 @@ public class QueryField {
 
     private final Mapping field;
     private final Mode mode;
+    private final boolean caseSensitive;
 
-    private QueryField(Mapping field, Mode mode) {
+    private QueryField(Mapping field, Mode mode, boolean caseSensitive) {
         this.field = field;
         this.mode = mode;
+        this.caseSensitive = caseSensitive;
     }
 
     /**
@@ -41,7 +43,7 @@ public class QueryField {
      * @return the generated query field
      */
     public static QueryField eq(Mapping field) {
-        return new QueryField(field, Mode.EQUAL);
+        return new QueryField(field, Mode.EQUAL, true);
     }
 
     /**
@@ -55,20 +57,50 @@ public class QueryField {
      * @return the generated query field
      */
     public static QueryField like(Mapping field) {
-        return new QueryField(field, Mode.LIKE);
+        return new QueryField(field, Mode.LIKE, true);
     }
+
+    /**
+     * Informs the compiler, that by default, equality checks are used for this field.
+     * <p>
+     * However, if there are wildcards in the filter value, an expanding constraint can be generated.
+     * <p>
+     * Caveat: This method is case-insensitive and therefore will <b>not use an index</b> and should only be used for reasonably sized datasets.
+     *
+     * @param field the field to search in
+     * @return the generated query field
+     */
+    public static QueryField likeIgnoreCase(Mapping field) {
+        return new QueryField(field, Mode.LIKE, false);
+    }
+
 
     /**
      * Informs the compiler, that by default an expanding search like a prefix query may be generated for this field.
      * <p>
      * Depending on the underlying database an index might be used to support this query. If the database cannot
-     * execute prefix queries if may fallback to an equals constraint.
+     * execute prefix queries it may fall back to an equals-constraint.
      *
      * @param field the field to search in
      * @return the generated query field
      */
     public static QueryField startsWith(Mapping field) {
-        return new QueryField(field, Mode.PREFIX);
+        return new QueryField(field, Mode.PREFIX, true);
+    }
+
+    /**
+     * Informs the compiler, that by default an expanding search like a case-insensitive prefix query may be generated for this field.
+     * <p>
+     * Depending on the underlying database an index might be used to support this query. If the database cannot
+     * execute prefix queries it may fall back to an equals-constraint.
+     * <p>
+     * Caveat: This method is case-insensitive and therefore will <b>not use an index</b> and should only be used for reasonably sized datasets.
+     *
+     * @param field the field to search in
+     * @return the generated query field
+     */
+    public static QueryField startsWithIgnoreCase(Mapping field) {
+        return new QueryField(field, Mode.PREFIX, false);
     }
 
     /**
@@ -80,7 +112,7 @@ public class QueryField {
      * @return the generated query field
      */
     public static QueryField contains(Mapping field) {
-        return new QueryField(field, Mode.CONTAINS);
+        return new QueryField(field, Mode.CONTAINS, true);
     }
 
     public Mapping getField() {
@@ -89,5 +121,9 @@ public class QueryField {
 
     public Mode getMode() {
         return mode;
+    }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
     }
 }

--- a/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
@@ -52,7 +52,7 @@ public class MongoQueryCompiler extends QueryCompiler<MongoConstraint> {
     }
 
     @Override
-    protected MongoConstraint compileSearchToken(Mapping field, QueryField.Mode mode, String value) {
+    protected MongoConstraint compileSearchToken(Mapping field, QueryField.Mode mode, boolean caseSensitive, String value) {
         if (FULLTEXT_MAPPING.equals(field)) {
             return QueryBuilder.FILTERS.text(value.toLowerCase());
         }

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -24,6 +24,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
     hostname: mysql
+    command: --collation-server=utf8mb4_bin --character-set-server=utf8mb4
   clickhouse:
     image: clickhouse/clickhouse-server:24.5.8-alpine
     ports:


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
also switch mariaDB collation in tests to case-sensitive as we mostly use that to test it properly

earlier we used _ci collations and this wasn't a problem then...

The use case ist e.g. searching a username by startsWith. until now a user named "Max Mustermann" cannot be found by typing "max" oder "mustermann", but via "max*" e.g. so we introduce a new method for searching SQL in LIKE or PREFIX mode case-insensitive, but that won´t use an existing index then so only should be called on limited values.

on Mongo + Elastic contraints the logic is already case-insensitve.

Technically BREAKING for Implementations of sirius.db.mixing.query.QueryCompiler

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14367](https://scireum.myjetbrains.com/youtrack/issue/SE-14367)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
