### PR TITLE
Fixes amount with large scale persistence 

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -168,7 +168,9 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
 
     @Override
     protected Object transformToElastic(Object object) {
-        return object == null || ((Amount) object).isEmpty() ? null : ((Amount) object).getAmount().toPlainString();
+        return object == null || ((Amount) object).isEmpty() ?
+               null :
+               applyNumericRounding(((Amount) object)).getAmount().toPlainString();
     }
 
     @Override
@@ -197,7 +199,7 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
         if (Strings.isEmpty(valueAsString)) {
             return Amount.NOTHING;
         }
-        return Amount.of(new BigDecimal(valueAsString));
+        return Amount.ofRounded(new BigDecimal(valueAsString));
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -129,10 +129,10 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
 
     private Amount parseWithNLS(@Nonnull Value value) {
         try {
-            return applyNumericRounding(Amount.ofMachineString(value.asString()));
+            return applyNumericRounding(Amount.ofRoundedMachineString(value.asString()));
         } catch (IllegalArgumentException originalFormatException) {
             try {
-                return applyNumericRounding(Amount.ofUserString(value.asString()));
+                return applyNumericRounding(Amount.ofRoundedUserString(value.asString()));
             } catch (Exception ignored) {
                 throw originalFormatException;
             }

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -175,7 +175,9 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
 
     @Override
     protected Object transformToMongo(Object object) {
-        return object == null || ((Amount) object).isEmpty() ? null : ((Amount) object).getAmount();
+        return object == null || ((Amount) object).isEmpty() ?
+               null :
+               applyNumericRounding(((Amount) object)).getAmount();
     }
 
     @Override
@@ -204,7 +206,7 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
 
     @Override
     protected Object transformFromMongo(Value object) {
-        return object.getAmount();
+        return object.getRoundedAmount();
     }
 
     @Override

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -188,7 +188,7 @@ public class AmountProperty extends NumberProperty implements SQLPropertyInfo, E
         if (object instanceof Integer value) {
             return Amount.of(value);
         }
-        return Amount.of((BigDecimal) object);
+        return Amount.ofRounded((BigDecimal) object);
     }
 
     @Override

--- a/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
@@ -14,6 +14,7 @@ import sirius.db.jdbc.TestEntity;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
+import sirius.db.mixing.annotations.Numeric;
 import sirius.db.mixing.annotations.Ordinal;
 import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.commons.Amount;
@@ -22,6 +23,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ESDataTypesEntity extends ElasticEntity {
+
+    public static final int AMOUNT_SCALE = 6;
 
     public enum TestEnum {
         Test1, Test2;
@@ -47,6 +50,7 @@ public class ESDataTypesEntity extends ElasticEntity {
 
     private static final Mapping AMOUNT_VALUE = Mapping.named("amountValue");
     @NullAllowed
+    @Numeric(precision = 20, scale = AMOUNT_SCALE)
     private Amount amountValue = Amount.NOTHING;
 
     private static final Mapping LOCALDATE_VALUE = Mapping.named("localDateValue");

--- a/src/test/java/sirius/db/jdbc/DataTypesEntity.java
+++ b/src/test/java/sirius/db/jdbc/DataTypesEntity.java
@@ -20,7 +20,7 @@ import java.time.LocalTime;
 
 public class DataTypesEntity extends SQLEntity {
 
-    public static final int AMOUNT_SCALE = 3;
+    public static final int AMOUNT_SCALE = 6;
 
     public enum TestEnum {
         Test1, TestTest, Test2

--- a/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
@@ -16,7 +16,7 @@ import sirius.kernel.commons.Amount;
 
 public class MongoAmountEntity extends MongoEntity {
 
-    public static final int AMOUNT_SCALE = 3;
+    public static final int AMOUNT_SCALE = 6;
 
     public static final Mapping TEST_AMOUNT = Mapping.named("testAmount");
     private Amount testAmount = Amount.NOTHING;

--- a/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
@@ -14,6 +14,7 @@ import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Amount
 import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part
+import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Duration
 import kotlin.test.assertEquals
@@ -101,6 +102,18 @@ class DataTypesTest {
         // Storing the same value twice must not trigger a change
         amountProperty.parseValue(test, unscaledValue)
         assertFalse { test.isAnyMappingChanged }
+    }
+
+    @Test
+    fun `Persisting large scale amounts works properly`() {
+        var test = DataTypesEntity()
+        val unscaledValue = Amount.ofRounded(BigDecimal("1.23456789"))
+
+        test.amountValue = unscaledValue
+        oma.update(test)
+        test = oma.refreshOrFail(test)
+        val expectedAmount = unscaledValue.round(DataTypesEntity.AMOUNT_SCALE, RoundingMode.HALF_UP)
+        assertEquals(expectedAmount, test.amountValue)
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoAmountPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoAmountPropertyTest.kt
@@ -15,6 +15,7 @@ import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Amount
 import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part
+import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -49,6 +50,19 @@ class MongoAmountPropertyTest {
         scaledAmountProperty.parseValue(test, unscaledValue)
         testAmountProperty.parseValue(test, unscaledValue)
         assertFalse { test.isAnyMappingChanged }
+    }
+
+    @Test
+    fun `Persisting large scale amounts works properly`() {
+        var test = MongoAmountEntity()
+        val unscaledValue = Amount.ofRounded(BigDecimal("1.23456789"))
+
+        test.scaledAmount = unscaledValue
+        test.testAmount = Amount.ONE
+        mango.update(test)
+        test = mango.refreshOrFail(test)
+        val expectedAmount = unscaledValue.round(MongoAmountEntity.AMOUNT_SCALE, RoundingMode.HALF_UP)
+        assertEquals(expectedAmount, test.scaledAmount)
     }
 
     companion object {


### PR DESCRIPTION
### Description
When having more scale than default (sirius.kernel.commons.Amount#SCALE = 5), we now properly store and read Amounts from databases. 

Waits for https://github.com/scireum/sirius-kernel/pull/549

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14351](https://scireum.myjetbrains.com/youtrack/issue/SE-14351)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
