### PR TITLE
Update libraries to latest versions and link to change logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,20 +42,26 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- Changelog: https://github.com/apache/commons-dbcp/blob/master/RELEASE-NOTES.txt -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.12.0</version>
+            <version>2.13.0</version>
         </dependency>
+
+        <!-- Changelog: https://github.com/mongodb/mongo-java-driver/releases -->
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <version>4.11.1</version>
         </dependency>
+
+        <!-- Changelog: https://github.com/redis/jedis/releases -->
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>5.1.5</version>
+            <version>5.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>
@@ -64,17 +70,22 @@
             </exclusions>
         </dependency>
 
+        <!-- Changelog: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/release-highlights.html -->
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>8.15.3</version>
+            <version>8.17.1</version>
         </dependency>
+
+        <!-- Changelog: https://github.com/mariadb-corporation/mariadb-connector-j/releases -->
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Changelog: https://github.com/ClickHouse/clickhouse-java/releases -->
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-44.0.0</sirius.kernel>
+        <sirius.kernel>dev-44.4.0</sirius.kernel>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Description

- commons-dbcp2: 2.12.0 -> 2.13.0
- jedis: 5.1.5 -> 5.2.0
- elasticsearch-rest-client: 8.15.3 -> 8.17.1
- mariadb-java-client -> 3.4.1 -> 3.5.2

ClickHouse Driver also has a version upgrade available but will be done in a separate ticket, as historically these upgrade tend to cause problems.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1071](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1071)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
