### PR TITLE
SIRI-1076 update container image versions for redis, mariadb, elasticsearch

### DIFF
--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:7.2.6-alpine
+    image: redis:7.4.2-alpine
     ports:
     - "6379"
     hostname: redis
@@ -18,12 +18,13 @@ services:
     hostname: qdrant
 
   mariadb:
-    image: mariadb:11.4.3-noble
+    image: mariadb:11.4.5-noble
     ports:
     - "3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
     hostname: mysql
+    command: --collation-server=utf8mb4_bin --character-set-server=utf8mb4
   clickhouse:
     image: clickhouse/clickhouse-server:24.5.8-alpine
     ports:
@@ -31,7 +32,7 @@ services:
     - "9000"
     hostname: clickhouse
   elasticsearch:
-    image: elasticsearch:8.15.3
+    image: elasticsearch:8.17.2
     ports:
     - "9200"
     environment:

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -32,7 +32,7 @@ services:
     - "9000"
     hostname: clickhouse
   elasticsearch:
-    image: elasticsearch:8.17.2
+    image: elasticsearch:8.15.3
     ports:
     - "9200"
     environment:


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

the mariadb tests will now use a defined collation-server and character-set clickhouse is excluded in this update run due to compatibility problems, will be updated separatly in https://scireum.myjetbrains.com/youtrack/issue/SIRI-1086
elasticsearch will follow in https://scireum.myjetbrains.com/youtrack/issue/DO-353/Elasticsearch-Upgrade-auf-8.17.2

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1076](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1076)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise --> https://github.com/scireum/sirius-biz/pull/2100

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
