### PR TITLE
Redis - Allow to control whether client info is sent for each pool

### DIFF
--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -56,6 +56,13 @@ public class RedisDB {
     private String sentinels;
     private boolean available = true;
 
+    /**
+     * Determines whether additional client information should be sent to the server when connecting.
+     * <p>
+     * This may be disabled for some redis servers that do not support this feature.
+     */
+    private final boolean enableClientInfo;
+
     protected JedisPool jedis;
     protected JedisSentinelPool sentinelPool;
 
@@ -72,6 +79,7 @@ public class RedisDB {
         this.maxIdle = config.getInt("maxIdle");
         this.masterName = config.getString("masterName");
         this.sentinels = config.getString("sentinels");
+        this.enableClientInfo = config.get("enableClientInfo").asBoolean(true);
     }
 
     /**
@@ -162,7 +170,7 @@ public class RedisDB {
                                                                                  .connectionTimeoutMillis(connectTimeout)
                                                                                  .socketTimeoutMillis(readTimeout)
                                                                                  .clientSetInfoConfig(new ClientSetInfoConfig(
-                                                                                         true))
+                                                                                         !enableClientInfo))
                                                                                  .password(Strings.isFilled(password) ?
                                                                                            password :
                                                                                            null)

--- a/src/main/resources/component-060-db.conf
+++ b/src/main/resources/component-060-db.conf
@@ -356,7 +356,7 @@ redis {
             # Contains a list of sentinels to connect to in a HA environment.
             sentinels = ""
 
-            # Contians the port to connect to
+            # Contains the port to connect to
             port = 6379
 
             # Contains the connection timeout in ms
@@ -378,6 +378,9 @@ redis {
 
             # Determines how many unused connections are kept in the pool
             maxIdle = 8
+
+            # Determines whether additional client information should be sent to the server when connecting.
+            enableClientInfo = true
         }
 
         # Defines the default redis instance being used. The hostname has to be


### PR DESCRIPTION
### Description

This was disabled globally in [SIRI-921](https://scireum.myjetbrains.com/youtrack/issue/SIRI-921) as our Jupiter server seem to have problems with it. As it turns out it answers the calls correctly but struggles with the way jedis sends 3 calls and expects 3 responses in bulk during the connection phase in Connection#initializeFromClientConfig. To not waste much time on something that is actually ignored on the receiving side of jupiter anyway we just make it configurable to be able to enable it for the real redis connection and disable it for the jupiter connection.

### BREAKING CHANGE

When using [jupiter](scireum/jupiter) sirius-biz should also be upgraded to the linked version or `enableClientInfo = false` should be added to the `jupiter` pool config manually.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-971](https://scireum.myjetbrains.com/youtrack/issue/SIRI-971)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2115

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
