### PR TITLE
Redis - Invert default for client info flag

### DIFF
--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -79,7 +79,7 @@ public class RedisDB {
         this.maxIdle = config.getInt("maxIdle");
         this.masterName = config.getString("masterName");
         this.sentinels = config.getString("sentinels");
-        this.enableClientInfo = config.get("enableClientInfo").asBoolean(true);
+        this.enableClientInfo = config.get("enableClientInfo").asBoolean(false);
     }
 
     /**

--- a/src/main/resources/component-060-db.conf
+++ b/src/main/resources/component-060-db.conf
@@ -380,13 +380,15 @@ redis {
             maxIdle = 8
 
             # Determines whether additional client information should be sent to the server when connecting.
-            enableClientInfo = true
+            # Its the far safer approach to disable this by default and enable it only when accessing supported servers.
+            enableClientInfo = false
         }
 
         # Defines the default redis instance being used. The hostname has to be
         # set in the application.conf
         system {
-
+            # Enables sending additional client information to our main Redis instance
+            enableClientInfo = true
         }
     }
 }


### PR DESCRIPTION
### Description
This flag was introduced as some of our systems also have a fallback jupiter server next to the main instance. To prevent needing to toggle this flag via config there we just invert the flag and enable it for the main Redis server connection.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-971](https://scireum.myjetbrains.com/youtrack/issue/SIRI-971)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
