### PR TITLE
Suppress warning to non-supported method in the ClickHouse dialect

### DIFF
--- a/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
+++ b/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
@@ -92,15 +92,16 @@ public class SchemaTool {
         fillColumns(connection, table);
         fillPK(connection, table);
         fillIndices(connection, table);
+        fillFKs(connection, table);
+    }
+
+    private void fillFKs(Connection connection, Table table) throws SQLException {
         if (dialect instanceof ClickhouseDatabaseDialect) {
             // ClickHouse does not support calls to getImportedKeys, and it will throw a warning such as
             // "getImportedKeys is not supported and may return invalid results"
             return;
         }
-        fillFKs(connection, table);
-    }
 
-    private void fillFKs(Connection connection, Table table) throws SQLException {
         ResultSet rs = connection.getMetaData()
                                  .getImportedKeys(connection.getCatalog(), connection.getSchema(), table.getName());
         while (rs.next()) {


### PR DESCRIPTION
### Description

Our SchemaTool calls the `DatabaseMetaData.getImportedKeys()`, which was actually **never supported** by the ClickHouse dialect.

Older drivers just returned an empty ResultSet, but the latest ones warns the user that it is unsupported.
`getImportedKeys is not supported and may return invalid results`

Old Implementation: https://github.com/ClickHouse/clickhouse-java/blob/v0.6.5/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java#L925

New Implementation: https://github.com/ClickHouse/clickhouse-java/blob/v0.9.0/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java#L967

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1084](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1084)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/691

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
