### PR TITLE
Upgrades the ClickHouse container to 25.5.9.14

### DIFF
--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -2,19 +2,19 @@ services:
   redis:
     image: redis:7.4.3-alpine
     ports:
-    - "6379"
+      - "6379"
     hostname: redis
 
   mongo:
     image: mongo:8.0.8
     ports:
-    - "27017"
+      - "27017"
     hostname: mongo
 
   mariadb:
     image: mariadb:11.4.5-noble
     ports:
-    - "3306"
+      - "3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
     hostname: mysql
@@ -23,8 +23,8 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:25.5.9.14-alpine
     ports:
-    - "8123"
-    - "9000"
+      - "8123"
+      - "9000"
     hostname: clickhouse
     environment:
       CLICKHOUSE_USER: default
@@ -33,10 +33,10 @@ services:
   elasticsearch:
     image: elasticsearch:8.18.3
     ports:
-    - "9200"
+      - "9200"
     environment:
-    - ES_JAVA_OPTS=-Xms128M -Xmx128M
-    - discovery.type=single-node
-    - ingest.geoip.downloader.enabled=false
-    - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms128M -Xmx128M
+      - discovery.type=single-node
+      - ingest.geoip.downloader.enabled=false
+      - xpack.security.enabled=false
     hostname: es

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -19,12 +19,17 @@ services:
       MYSQL_ROOT_PASSWORD: root
     hostname: mysql
     command: --collation-server=utf8mb4_bin --character-set-server=utf8mb4
+
   clickhouse:
-    image: clickhouse/clickhouse-server:24.5.8-alpine
+    image: clickhouse/clickhouse-server:25.5.9.14-alpine
     ports:
     - "8123"
     - "9000"
     hostname: clickhouse
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: secret
+
   elasticsearch:
     image: elasticsearch:8.18.3
     ports:

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -12,7 +12,7 @@ jdbc {
         clickhouse {
             profile = "clickhouse"
             user = "default"
-            password = ""
+            password = "secret"
             database = "test"
         }
     }


### PR DESCRIPTION
### Description

Starting in V25, auth is required. We now set a dummy password in both container and config file. Production servers SHOULD BE already running with authentication password.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1086](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1086)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
