### PR TITLE
Upgrades driver (0.9.1) and container version (25.8.2.29)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.1</version>
         </dependency>
     </dependencies>
 

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -21,7 +21,7 @@ services:
     command: --collation-server=utf8mb4_bin --character-set-server=utf8mb4
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.5.9.14-alpine
+    image: clickhouse/clickhouse-server:25.8.2.29
     ports:
       - "8123"
       - "9000"


### PR DESCRIPTION
Adopting the latest LTS version. Clickhouse publishes 2 LTS versions per year, in March and August.

Fixes: SIRI-1086
