### PR TITLE
Fixes the usage of `StringLocalDateTimeMap` in MongoDB

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
@@ -82,7 +82,7 @@ public class StringLocalDateTimeMapProperty extends BaseMapProperty implements E
     @Override
     protected Object transformToMongo(Object object) {
         Document doc = new Document();
-        ((Map<String, StringLocalDateTimeMap>) object).forEach((k, v) -> doc.put(k, QueryBuilder.FILTERS.transform(v)));
+        ((Map<String, LocalDateTime>) object).forEach((k, v) -> doc.put(k, QueryBuilder.FILTERS.transform(v)));
         return doc;
     }
 

--- a/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
@@ -44,12 +44,12 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * Represents an {@link StringLocalDateTimeMap} field within a {@link Mixable}.
+ * Represents a {@link StringLocalDateTimeMap} field within a {@link Mixable}.
  */
 public class StringLocalDateTimeMapProperty extends BaseMapProperty implements ESPropertyInfo {
 
     /**
-     * Factory for generating properties based on their field type
+     * Factory for generating properties based on their field type.
      */
     @Register
     public static class Factory implements PropertyFactory {
@@ -82,15 +82,15 @@ public class StringLocalDateTimeMapProperty extends BaseMapProperty implements E
     @Override
     protected Object transformToMongo(Object object) {
         Document doc = new Document();
-        ((Map<String, LocalDateTime>) object).forEach((k, v) -> doc.put(k, QueryBuilder.FILTERS.transform(v)));
+        ((Map<String, LocalDateTime>) object).forEach((key, value) -> doc.put(key,
+                                                                              QueryBuilder.FILTERS.transform(value)));
         return doc;
     }
 
     @Override
     protected Object transformFromMongo(Value object) {
         Map<String, LocalDateTime> result = new LinkedHashMap<>();
-        Object obj = object.get();
-        if (obj instanceof Document document) {
+        if (object.get() instanceof Document document) {
             for (Map.Entry<String, Object> entry : document.entrySet()) {
                 try {
                     result.put(entry.getKey(),
@@ -123,7 +123,7 @@ public class StringLocalDateTimeMapProperty extends BaseMapProperty implements E
         try {
             return LocalDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(date))
                                 .truncatedTo(ChronoUnit.MILLIS);
-        } catch (DateTimeParseException e) {
+        } catch (DateTimeParseException _) {
             return LocalDateTime.from(DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(date)).truncatedTo(ChronoUnit.MILLIS);
         }
     }

--- a/src/main/java/sirius/db/mixing/types/StringLocalDateTimeMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringLocalDateTimeMap.java
@@ -11,7 +11,7 @@ package sirius.db.mixing.types;
 import java.time.LocalDateTime;
 
 /**
- * Represents map of <tt>String</tt> pointing to <tt>LocalDateTime</tt> values.
+ * Represents a map of <tt>String</tt> pointing to <tt>LocalDateTime</tt> values.
  */
 public class StringLocalDateTimeMap extends SafeMap<String, LocalDateTime> {
 

--- a/src/test/java/sirius/db/mongo/properties/MongoStringLocalDateTimeMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringLocalDateTimeMapEntity.java
@@ -1,0 +1,23 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties;
+
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.types.StringLocalDateTimeMap;
+import sirius.db.mongo.MongoEntity;
+
+public class MongoStringLocalDateTimeMapEntity extends MongoEntity {
+
+    public static final Mapping MAP = Mapping.named("map");
+    private final StringLocalDateTimeMap map = new StringLocalDateTimeMap();
+
+    public StringLocalDateTimeMap getMap() {
+        return map;
+    }
+}

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringLocalDateTimeMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringLocalDateTimeMapPropertyTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.mongo.properties
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.db.mongo.Mango
+import sirius.db.mongo.Mongo
+import sirius.kernel.SiriusExtension
+import sirius.kernel.di.std.Part
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@ExtendWith(SiriusExtension::class)
+class MongoStringLocalDateTimeMapPropertyTest {
+    @Test
+    fun `reading and writing works`() {
+        val test = MongoStringLocalDateTimeMapEntity()
+        val now = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+        test.map.put("Test", now).put("Foo", now)
+        mango.update(test)
+        var resolved = mango.refreshOrFail(test)
+
+        assertEquals(2, resolved.map.size())
+        assertEquals(now, resolved.map.get("Test").get())
+        assertEquals(now, resolved.map.get("Foo").get())
+
+        resolved.map.modify().remove("Test")
+        mango.update(resolved)
+        resolved = mango.refreshOrFail(test)
+
+        assertEquals(1, resolved.map.size())
+        assertFalse { resolved.map.containsKey("Test") }
+        assertEquals(now, resolved.map.get("Foo").get())
+    }
+
+    companion object {
+        @Part
+        private lateinit var mango: Mango
+
+        @Part
+        private lateinit var mongo: Mongo
+    }
+}


### PR DESCRIPTION

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12426](https://scireum.myjetbrains.com/youtrack/issue/OX-12426)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
