### PR TITLE
BREAKING: Prevent SQL injection attacks in SmartQuery#aggregationField() and SmartQuery#groupBy()

### DIFF
--- a/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
+++ b/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.db.jdbc;
+
+import sirius.kernel.commons.Strings;
+
+import java.util.Set;
+
+/**
+ * Validates SQL expressions which are directly embedded into generated SQL statements.
+ */
+public class SQLExpressionValidator {
+
+    private static final Set<String> FORBIDDEN_SQL_EXPRESSION_PARTS = Set.of("--", "/*", "*/", ";");
+    private static final Set<String> FORBIDDEN_SQL_EXPRESSION_KEYWORDS = Set.of("ALTER",
+                                                                                "CALL",
+                                                                                "CREATE",
+                                                                                "DELETE",
+                                                                                "DROP",
+                                                                                "EXEC",
+                                                                                "EXECUTE",
+                                                                                "FROM",
+                                                                                "HAVING",
+                                                                                "INSERT",
+                                                                                "INTO",
+                                                                                "JOIN",
+                                                                                "LIMIT",
+                                                                                "MERGE",
+                                                                                "OFFSET",
+                                                                                "ORDER",
+                                                                                "SELECT",
+                                                                                "TRUNCATE",
+                                                                                "UNION",
+                                                                                "UPDATE",
+                                                                                "VALUES",
+                                                                                "WHERE",
+                                                                                "WITH");
+
+    private SQLExpressionValidator() {
+    }
+
+    /**
+     * Validates an SQL expression against a basic SQL injection blocklist.
+     *
+     * @param expression the SQL expression to validate
+     * @throws IllegalArgumentException if the expression is empty or contains blocked SQL syntax
+     */
+    public static void assertAllowedSQLExpression(String expression) {
+        if (Strings.isEmpty(expression)) {
+            throw new IllegalArgumentException("Expression must not be empty.");
+        }
+
+        if (containsForbiddenSQLExpressionPart(expression) || containsForbiddenSQLKeyword(expression)) {
+            throw new IllegalArgumentException("Expression contains forbidden SQL syntax: " + expression);
+        }
+    }
+
+    private static boolean containsForbiddenSQLExpressionPart(String expression) {
+        for (String forbiddenPart : FORBIDDEN_SQL_EXPRESSION_PARTS) {
+            if (expression.contains(forbiddenPart)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean containsForbiddenSQLKeyword(String expression) {
+        int index = 0;
+        while (index < expression.length()) {
+            if (isSQLIdentifierPart(expression.charAt(index))) {
+                int end = determineIdentifierEnd(expression, index);
+                String identifier = expression.substring(index, end).toUpperCase();
+                if (FORBIDDEN_SQL_EXPRESSION_KEYWORDS.contains(identifier)) {
+                    return true;
+                }
+                index = end;
+            } else {
+                index++;
+            }
+        }
+
+        return false;
+    }
+
+    private static int determineIdentifierEnd(String expression, int start) {
+        int end = start + 1;
+
+        while (end < expression.length() && isSQLIdentifierPart(expression.charAt(end))) {
+            end++;
+        }
+
+        return end;
+    }
+
+    private static boolean isSQLIdentifierPart(char current) {
+        return Character.isLetterOrDigit(current) || current == '_';
+    }
+}

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -237,8 +237,10 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * <b>NOTE:</b> This cannot be used in "normal" entity queries, as the O/R mapper cannot handle aggregations.
      * Rather, the query has to be converted using {@link #asSQLQuery()} which then permits direct access to rows.
      * <p>
-     * <b>ALSO NOTE:</b> The given expressions will directly end up on the SQL query and must therefore be constant
-     * and safe string which aren't subject to SQL injection attacks!
+     * <b>ALSO NOTE:</b> The given expression will directly end up in the SQL query and is therefore validated against
+     * a basic SQL injection blocklist. It must not contain SQL comments, statement separators, or DDL/DML keywords.
+     * User input must still be bound as parameters in normal query constraints and must never be concatenated into this
+     * expression.
      *
      * @param expression the expression to group by
      * @return the query itself for fluent method calls
@@ -250,6 +252,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             this.aggregationFields = new ArrayList<>();
         }
 
+        SQLExpressionValidator.assertAllowedSQLExpression(expression);
         this.aggregationFields.add(expression);
         return this;
     }
@@ -260,8 +263,10 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
      * <b>NOTE:</b> This cannot be used in "normal" entity queries, as the O/R mapper cannot handle aggregations.
      * Rather, the query has to be converted using {@link #asSQLQuery()} which then permits direct access to rows.
      * <p>
-     * <b>ALSO NOTE:</b> The given expressions will directly end up on the SQL query and must therefore be constant
-     * and safe string which aren't subject to SQL injection attacks!
+     * <b>ALSO NOTE:</b> The given expression will directly end up in the SQL query and is therefore validated against
+     * a basic SQL injection blocklist. It must not contain SQL comments, statement separators, or DDL/DML keywords.
+     * User input must still be bound as parameters in normal query constraints and must never be concatenated into this
+     * expression.
      *
      * @param expression the expression to group by
      * @return the query itself for fluent method calls
@@ -273,6 +278,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
             this.groupBys = new ArrayList<>();
         }
 
+        SQLExpressionValidator.assertAllowedSQLExpression(expression);
         this.groupBys.add(expression);
         return this;
     }

--- a/src/main/java/sirius/db/jdbc/batch/BatchContext.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchContext.java
@@ -305,6 +305,11 @@ public class BatchContext implements Closeable {
 
     /**
      * Prepares the given SQL statement as {@link CustomQuery custom query}.
+     * <p>
+     * This is a low-level API for callers which intentionally provide complete SQL statements. Use JDBC parameter
+     * placeholders and {@link CustomQuery#setParameter(int, Object)} for all values derived from user input. SQL
+     * identifiers or expressions cannot be bound as parameters and therefore must only be taken from trusted constants
+     * as that can lead to SQL injection attacks.
      *
      * @param type    the type of entities to process
      * @param fetchId determines if generated IDs should be fetched

--- a/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
@@ -20,6 +20,10 @@ import java.util.Collections;
 
 /**
  * Wraps a SQL statement as {@link BatchSQLQuery}.
+ * <p>
+ * This intentionally accepts complete SQL statements. Callers must use placeholders and {@link #setParameter(int,
+ * Object)} for values derived from user input and must not concatenate user input into the SQL string itself as that
+ * can lead to SQL injection attacks.
  */
 public class CustomQuery extends BatchQuery<SQLEntity> {
 

--- a/src/test/java/sirius/db/jdbc/SmartQueryTest.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTest.java
@@ -4,11 +4,50 @@ import org.junit.Assert;
 import org.junit.Test;
 import sirius.db.jdbc.constraints.SQLConstraint;
 import sirius.db.mixing.Mapping;
+import sirius.kernel.commons.Strings;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class SmartQueryTest {
+
+    @Test
+    public void testAggregationField_withNumericTestEntityFieldAndAlias_acceptsExpression() {
+        SmartQuery<SmartQueryTestLargeTableEntity> query = new SmartQuery<>(null, null);
+
+        query.aggregationField(Strings.apply("SUM(%s) as totalValue",
+                                             SmartQueryTestLargeTableEntity.TEST_NUMBER.getName()));
+
+        Assert.assertEquals("SUM(testNumber) as totalValue", query.aggregationFields.getFirst());
+    }
+
+    @Test
+    public void testGroupBy_withStringFunction_acceptsExpression() {
+        SmartQuery<SmartQueryTestSortingEntity> query = new SmartQuery<>(null, null);
+
+        query.groupBy(Strings.apply("LOWER(%s)", SmartQueryTestSortingEntity.VALUE_ONE.getName()));
+
+        Assert.assertEquals("LOWER(valueOne)", query.groupBys.getFirst());
+    }
+
+    @Test
+    public void testAggregationField_withAdditionalStatement_rejectsExpression() {
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .aggregationField("COUNT(*); DROP TABLE smartquerytestsortingentity; --"));
+    }
+
+    @Test
+    public void testAggregationField_withSelectKeyword_rejectsExpression() {
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .aggregationField("(SELECT id)"));
+    }
+
+    @Test
+    public void testGroupBy_withSubqueryKeyword_rejectsExpression() {
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .groupBy("LOWER(valueOne) FROM smartquerytestsortingentity"));
+    }
+
     @Test
     public void testCreateSqlConstraintForSortingColumn_withPreviousColumns_returnValidSqlQuery() {
         SmartQuery<SmartQueryTestSortingEntity> query = new SmartQuery<>(null, null);
@@ -31,5 +70,14 @@ public class SmartQueryTest {
                 "1",
                 previousSortingColumns);
         Assert.assertEquals("id > 1", constraint.toString());
+    }
+
+    private void assertInvalidSQLExpression(Runnable runnable) {
+        try {
+            runnable.run();
+            Assert.fail("Expected an IllegalArgumentException.");
+        } catch (IllegalArgumentException exception) {
+            Assert.assertNotNull(exception.getMessage());
+        }
     }
 }


### PR DESCRIPTION
### Description

Disallow invoking SmartQuery#aggregationField() or SmartQuery#groupBy() with expressions that feature comments, statement separators, or DDL/DML keywords to prevent SQL injection attacks.

As far as I've seen, there is no place in the framework or in our products where expresssions with sub queries and the like are used.

BREAKING CHANGE: SmartQuery#aggregationField() and SmartQuery#groupBy() now no longer allow sub-queries and the like.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1203](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1203)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
