### PR TITLE
Fix streamBlockwise pagination for distinct sorted queries

### DIFF
--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -397,7 +397,7 @@ public class SmartQuery<E extends SQLEntity> extends Query<SmartQuery<E>, E, SQL
                 adjusted.orderAsc(BaseEntity.ID);
             }
 
-            if (!adjusted.distinct && !fields.isEmpty()) {
+            if (!fields.isEmpty()) {
                 // We SELECT a subset of the columns to optimize the network bandwidth.
                 // When pulling the next block, we need to continue exactly where we left of, so we need to SELECT
                 // at least all the fields from the ORDER BY clause.

--- a/src/test/kotlin/sirius/db/jdbc/SmartQuerySortingTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQuerySortingTest.kt
@@ -2,14 +2,44 @@ package sirius.db.jdbc
 
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.ExtendWith
 import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(SiriusExtension::class)
 class SmartQuerySortingTest {
+
+    @Test
+    @Timeout(30, unit = TimeUnit.SECONDS)
+    fun `streamBlockwise progresses when sorting values were not originally selected`() {
+        oma.select(SmartQueryTestSortingEntity::class.java).delete()
+
+        val entityCount = 1500
+        for (i in 1..entityCount) {
+            val entity = SmartQueryTestSortingEntity()
+            entity.valueOne = "sort_%04d".format(i)
+            entity.valueTwo = "distinct_%04d".format(i)
+            oma.update(entity)
+        }
+
+        val query = oma.select(SmartQueryTestSortingEntity::class.java)
+            .distinctFields(SmartQueryTestSortingEntity.VALUE_TWO)
+            .orderAsc(SmartQueryTestSortingEntity.VALUE_ONE)
+
+        val result = query.streamBlockwise()
+            .toList()
+
+        val uniqueValues = result.map { it.valueTwo }.toSet()
+
+        assertEquals(entityCount, result.size)
+        assertEquals(entityCount, uniqueValues.size)
+    }
+
     @Test
     fun `sorting asc without null values returns all entries`() {
         prepareWithNonNullValues()


### PR DESCRIPTION
### Description
- when requesting fields, it does not matter if they came from a distinct or non-distinct select, we do need them in the result set for obvious reasons. But here comes the change, we also need the fields that are used to order by. The database does of course know them, but we also need them to create the follow-up request in streaming.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1212](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1212)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
