### PR TITLE
Fix possible NPE when calling `getFirstBucket` on an aggregation without buckets

### DIFF
--- a/src/main/java/sirius/db/es/AggregationResult.java
+++ b/src/main/java/sirius/db/es/AggregationResult.java
@@ -121,7 +121,7 @@ public class AggregationResult {
                                             .stream()
                                             .findFirst()
                                             .map(entry -> new Bucket(entry.getKey(), (ObjectNode) entry.getValue()));
-            default -> Optional.empty();
+            case null, default -> Optional.empty();
         };
     }
 


### PR DESCRIPTION
### Description

This may be the case when `getAggregation` does not find the named aggregation and creates a result.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1220](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1220)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
