### PR TITLE
Allow string literals that contain forbidden keywords

### DIFF
--- a/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
+++ b/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
@@ -74,7 +74,10 @@ public class SQLExpressionValidator {
     private static boolean containsForbiddenSQLKeyword(String expression) {
         int index = 0;
         while (index < expression.length()) {
-            if (isSQLIdentifierPart(expression.charAt(index))) {
+            char current = expression.charAt(index);
+            if (current == '\'') {
+                index = skipStringLiteral(expression, index);
+            } else if (isSQLIdentifierPart(current)) {
                 int end = determineIdentifierEnd(expression, index);
                 String identifier = expression.substring(index, end).toUpperCase();
                 if (FORBIDDEN_SQL_EXPRESSION_KEYWORDS.contains(identifier)) {
@@ -87,6 +90,41 @@ public class SQLExpressionValidator {
         }
 
         return false;
+    }
+
+    /**
+     * Skips over a single-quoted SQL string literal so that its content is treated as data, not as SQL syntax.
+     * <p>
+     * Both the SQL-style escaped quote ({@code ''}) and backslash escapes ({@code \'}) are honored.
+     *
+     * @param expression the expression being scanned
+     * @param start      the index of the opening quote
+     * @return the index right after the closing quote
+     * @throws IllegalArgumentException if the literal is never terminated, as this is invalid SQL which would fail
+     *                                  once executed
+     */
+    private static int skipStringLiteral(String expression, int start) {
+        int index = start + 1;
+        while (index < expression.length()) {
+            char current = expression.charAt(index);
+            if (current == '\\') {
+                // Skip over the escape-character and the character it escapes as it doesn't matter what it is in a
+                // string literal (it especially mustn't be treated as the end of the string literal).
+                index += 2;
+            } else if (current == '\'') {
+                if (index + 1 < expression.length() && expression.charAt(index + 1) == '\'') {
+                    // Skip over special SQL-style escaped quote character (via two single quotes in a row).
+                    index += 2;
+                } else {
+                    // This is the closing quote. Return the index right after it.
+                    return index + 1;
+                }
+            } else {
+                index++;
+            }
+        }
+
+        throw new IllegalArgumentException("Expression contains an unterminated string literal: " + expression);
     }
 
     private static int determineIdentifierEnd(String expression, int start) {

--- a/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
+++ b/src/main/java/sirius/db/jdbc/SQLExpressionValidator.java
@@ -95,7 +95,8 @@ public class SQLExpressionValidator {
     /**
      * Skips over a single-quoted SQL string literal so that its content is treated as data, not as SQL syntax.
      * <p>
-     * Both the SQL-style escaped quote ({@code ''}) and backslash escapes ({@code \'}) are honored.
+     * Only the SQL-standard escaped quote ({@code ''}) is honored. Backslash escapes are intentionally not
+     * treated as escapes as they are dialect-specific.
      *
      * @param expression the expression being scanned
      * @param start      the index of the opening quote
@@ -107,11 +108,7 @@ public class SQLExpressionValidator {
         int index = start + 1;
         while (index < expression.length()) {
             char current = expression.charAt(index);
-            if (current == '\\') {
-                // Skip over the escape-character and the character it escapes as it doesn't matter what it is in a
-                // string literal (it especially mustn't be treated as the end of the string literal).
-                index += 2;
-            } else if (current == '\'') {
+            if (current == '\'') {
                 if (index + 1 < expression.length() && expression.charAt(index + 1) == '\'') {
                     // Skip over special SQL-style escaped quote character (via two single quotes in a row).
                     index += 2;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTest.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTest.java
@@ -88,6 +88,15 @@ public class SmartQueryTest {
     }
 
     @Test
+    public void testGroupBy_withForbiddenKeywordInsideStringLiteral_acceptsExpression() {
+        SmartQuery<SmartQueryTestSortingEntity> query = new SmartQuery<>(null, null);
+
+        query.groupBy("IF(valueOne = 'EXECUTE-FOOBAR', 1, 0)");
+
+        assertEquals("IF(valueOne = 'EXECUTE-FOOBAR', 1, 0)", query.groupBys.getFirst());
+    }
+
+    @Test
     public void testAggregationField_withUnterminatedStringLiteral_rejectsExpression() {
         assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
                 .aggregationField("countIf(valueOne = 'unterminated)"));

--- a/src/test/java/sirius/db/jdbc/SmartQueryTest.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTest.java
@@ -78,6 +78,27 @@ public class SmartQueryTest {
         assertEquals("id > 1", constraint.toString());
     }
 
+    @Test
+    public void testAggregationField_withForbiddenKeywordInsideStringLiteral_acceptsExpression() {
+        SmartQuery<SmartQueryTestSortingEntity> query = new SmartQuery<>(null, null);
+
+        query.aggregationField("countIf(valueOne = 'EXECUTE-FOOBAR') as filteredCount");
+
+        assertEquals("countIf(valueOne = 'EXECUTE-FOOBAR') as filteredCount", query.aggregationFields.getFirst());
+    }
+
+    @Test
+    public void testAggregationField_withUnterminatedStringLiteral_rejectsExpression() {
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .aggregationField("countIf(valueOne = 'unterminated)"));
+    }
+
+    @Test
+    public void testAggregationField_withForbiddenKeywordOutsideStringLiteral_rejectsExpression() {
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .aggregationField("countIf(valueOne = 'safe') UNION SELECT id"));
+    }
+
     private void assertInvalidSQLExpression(Runnable runnable) {
         try {
             runnable.run();

--- a/src/test/java/sirius/db/jdbc/SmartQueryTest.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTest.java
@@ -99,6 +99,14 @@ public class SmartQueryTest {
                 .aggregationField("countIf(valueOne = 'safe') UNION SELECT id"));
     }
 
+    @Test
+    public void testAggregationField_withBackslashEscapedQuoteHidingKeyword_rejectsExpression() {
+        // A backslash must not be treated as an escape for the closing quote, otherwise the trailing UNION SELECT
+        // (which is real SQL in dialects with standard string handling) would be hidden inside the literal.
+        assertInvalidSQLExpression(() -> new SmartQuery<SmartQueryTestSortingEntity>(null, null)
+                .aggregationField("countIf(valueOne = 'abc\\') UNION SELECT id"));
+    }
+
     private void assertInvalidSQLExpression(Runnable runnable) {
         try {
             runnable.run();


### PR DESCRIPTION
### Description

We have cases where we want to count only if a field has e.g. the value "EXECUTE-XYZ". However "EXECUTE" and many more words were treated as forbidden no matter the context they were used in. However, in string literals, they are fine and must be supported.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15243](https://scireum.myjetbrains.com/youtrack/issue/SE-15243)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/720

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
