### PR TITLE
Separate Docker socket volumes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,9 @@
 ---
-scireum_volumes: &scireum_volumes
+scireum_m2_volumes: &scireum_m2_volumes
+  - name: m2
+    path: /root/.m2
+
+scireum_m2_docker_volumes: &scireum_m2_docker_volumes
   - name: docker_socket
     path: /var/run/docker.sock
   - name: m2
@@ -20,7 +24,7 @@ steps:
     image: scireum/sirius-build-jdk24
     commands:
       - mvn clean compile
-    volumes: *scireum_volumes
+    volumes: *scireum_m2_volumes
     when:
       branch:
         - main
@@ -31,7 +35,7 @@ steps:
     image: scireum/sirius-build-jdk24
     commands:
       - mvn clean test
-    volumes: *scireum_volumes
+    volumes: *scireum_m2_docker_volumes
     when:
       event:
         - cron
@@ -52,7 +56,7 @@ steps:
     image: scireum/sirius-build-jdk24
     commands:
       - mvn clean test -Dtest.excluded.groups=nightly
-    volumes: *scireum_volumes
+    volumes: *scireum_m2_docker_volumes
     when:
       event:
         - pull_request
@@ -62,7 +66,7 @@ steps:
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean deploy -DskipTests
-    volumes: *scireum_volumes
+    volumes: *scireum_m2_volumes
     when:
       event:
         - tag
@@ -83,7 +87,7 @@ steps:
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME}
-    volumes: *scireum_volumes
+    volumes: *scireum_m2_docker_volumes
     when:
       event:
         - tag


### PR DESCRIPTION
## Summary
- Drop the Docker socket volume from Drone pipelines without Docker build steps.
- Keep Maven cache volumes for compile, test, deploy and sonar steps.
- Remove unused Docker-related host volumes.

## Test plan
- Not run; Drone CI configuration only.