### PR TITLE
Bump Elasticsearch version and REST client to 8.19.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>8.19.12</version>
+            <version>8.19.18</version>
         </dependency>
 
         <!-- Changelog: https://github.com/mariadb-corporation/mariadb-connector-j/releases -->

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -31,7 +31,7 @@ services:
       CLICKHOUSE_PASSWORD: secret
 
   elasticsearch:
-    image: elasticsearch:8.19.3
+    image: elasticsearch:8.19.18
     ports:
       - "9200"
     environment:


### PR DESCRIPTION
### Description

This PR updates the Elasticsearch Docker image and the Elasticsearch REST client to version 8.19.18. These changes are intended to update dependencies for testing purposes and ensure compatibility.

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1153](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1153)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.