### PR TITLE
Upgrade jackson from 2.22.0 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>15.3.0</version>
+        <version>16.0.0</version>
     </parent>
     <artifactId>sirius-db</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>
@@ -19,7 +19,7 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>52.1.1</sirius.kernel>
+        <sirius.kernel>53.0.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -8,9 +8,9 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/db/es/AggregationResult.java
+++ b/src/main/java/sirius/db/es/AggregationResult.java
@@ -8,9 +8,9 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Tuple;

--- a/src/main/java/sirius/db/es/Bucket.java
+++ b/src/main/java/sirius/db/es/Bucket.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Json;
 

--- a/src/main/java/sirius/db/es/BulkContext.java
+++ b/src/main/java/sirius/db/es/BulkContext.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.kernel.commons.Json;
 import sirius.kernel.di.std.Part;

--- a/src/main/java/sirius/db/es/BulkResult.java
+++ b/src/main/java/sirius/db/es/BulkResult.java
@@ -8,8 +8,8 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.health.Exceptions;
 

--- a/src/main/java/sirius/db/es/ESPropertyInfo.java
+++ b/src/main/java/sirius/db/es/ESPropertyInfo.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
 

--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;

--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -8,9 +8,9 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.Mapping;
@@ -143,7 +143,7 @@ public abstract class ElasticEntity extends BaseEntity<String> {
         ArrayNode matchedQueriesArray = Json.getArray(searchHit, MATCHED_QUERIES);
         return matchedQueriesArray.valueStream()
                                   .filter(Objects::nonNull)
-                                  .map(JsonNode::asText)
+                                  .map(JsonNode::asString)
                                   .collect(Collectors.toSet());
     }
 

--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -143,7 +143,7 @@ public abstract class ElasticEntity extends BaseEntity<String> {
         ArrayNode matchedQueriesArray = Json.getArray(searchHit, MATCHED_QUERIES);
         return matchedQueriesArray.valueStream()
                                   .filter(Objects::nonNull)
-                                  .map(JsonNode::asString)
+                                  .map(jsonNode -> jsonNode.asString(""))
                                   .collect(Collectors.toSet());
     }
 

--- a/src/main/java/sirius/db/es/ElasticMetricsProvider.java
+++ b/src/main/java/sirius/db/es/ElasticMetricsProvider.java
@@ -8,9 +8,9 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.metrics.Metric;

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -8,10 +8,10 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.constraints.BoolQueryBuilder;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.mixing.DateRange;
@@ -497,7 +497,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
             return Collections.emptyList();
         }
 
-        return jsonSorts.valueStream().map(JsonNode::asText).toList();
+        return jsonSorts.valueStream().map(JsonNode::asString).toList();
     }
 
     /**
@@ -1170,7 +1170,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
             return Elastic.make(descriptor, (ObjectNode) jsonEntity);
         }
 
-        String indexName = jsonEntity.get("_index").asText(null);
+        String indexName = jsonEntity.get("_index").asString(null);
         return additionalDescriptors.stream()
                                     .filter(additionalDescriptor -> Strings.areEqual(elastic.determineEffectiveIndex(
                                             additionalDescriptor), indexName))

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -497,7 +497,7 @@ public class ElasticQuery<E extends ElasticEntity> extends Query<ElasticQuery<E>
             return Collections.emptyList();
         }
 
-        return jsonSorts.valueStream().map(JsonNode::asString).toList();
+        return jsonSorts.valueStream().map(jsonNode -> jsonNode.asString("")).toList();
     }
 
     /**

--- a/src/main/java/sirius/db/es/FunctionScoreBuilder.java
+++ b/src/main/java/sirius/db/es/FunctionScoreBuilder.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;

--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.annotations.CustomSettings;
 import sirius.db.es.annotations.IndexMode;
 import sirius.db.es.annotations.RoutedBy;

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -8,8 +8,8 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;

--- a/src/main/java/sirius/db/es/NearestNeighborsSearch.java
+++ b/src/main/java/sirius/db/es/NearestNeighborsSearch.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.constraints.BoolQueryBuilder;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.mixing.Mapping;

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;

--- a/src/main/java/sirius/db/es/SettingsCustomizer.java
+++ b/src/main/java/sirius/db/es/SettingsCustomizer.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.kernel.di.std.AutoRegister;
 

--- a/src/main/java/sirius/db/es/SortBuilder.java
+++ b/src/main/java/sirius/db/es/SortBuilder.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.constraints.ElasticConstraint;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
+++ b/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.constraints;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticQuery;
 import sirius.kernel.commons.Explain;

--- a/src/main/java/sirius/db/es/constraints/ElasticCSVFilter.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticCSVFilter.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.constraints;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.query.constraints.CSVFilter;

--- a/src/main/java/sirius/db/es/constraints/ElasticConstraint.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticConstraint.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.constraints;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.mixing.query.constraints.Constraint;
 import sirius.kernel.commons.Explain;

--- a/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
@@ -8,8 +8,8 @@
 
 package sirius.db.es.constraints;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;

--- a/src/main/java/sirius/db/es/constraints/NestedQuery.java
+++ b/src/main/java/sirius/db/es/constraints/NestedQuery.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.constraints;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/db/es/suggest/SuggesterBuilder.java
+++ b/src/main/java/sirius/db/es/suggest/SuggesterBuilder.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.suggest;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticQuery;
 import sirius.db.mixing.Mapping;

--- a/src/main/java/sirius/db/es/suggest/SuggestionQuery.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestionQuery.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.suggest;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticEntity;
 import sirius.db.es.LowLevelClient;

--- a/src/main/java/sirius/db/es/suggest/SuggestionResult.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestionResult.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.suggest;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Json;
 

--- a/src/main/java/sirius/db/es/suggest/TermSuggestion.java
+++ b/src/main/java/sirius/db/es/suggest/TermSuggestion.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.suggest;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 
 /**

--- a/src/main/java/sirius/db/es/suggest/TextPartSuggestion.java
+++ b/src/main/java/sirius/db/es/suggest/TextPartSuggestion.java
@@ -8,7 +8,7 @@
 
 package sirius.db.es.suggest;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 
 import java.util.List;

--- a/src/main/java/sirius/db/es/types/DenseVectorProperty.java
+++ b/src/main/java/sirius/db/es/types/DenseVectorProperty.java
@@ -8,8 +8,8 @@
 
 package sirius.db.es.types;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.mixing.AccessPath;
 import sirius.db.mixing.EntityDescriptor;

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/ElasticRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/ElasticRefProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticEntity;

--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/LongProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LongProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/MongoRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MongoRefProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.Elastic;

--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;

--- a/src/main/java/sirius/db/mixing/properties/StringIntMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringIntMapProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;

--- a/src/main/java/sirius/db/mixing/properties/StringListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringListProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.Elastic;

--- a/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.ElasticEntity;

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.db.mixing.properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.Analyzed;

--- a/src/main/java/sirius/db/util/Tensors.java
+++ b/src/main/java/sirius/db/util/Tensors.java
@@ -8,7 +8,7 @@
 
 package sirius.db.util;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;

--- a/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
+++ b/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
@@ -129,9 +129,9 @@ class ElasticQueryTest {
         val buckets = query.rawAggregations.withArray("/test/keys/buckets")
 
         assertEquals(3, buckets.size())
-        assertEquals("1", buckets.get(0).path("key").asText())
-        assertEquals("2", buckets.get(1).path("key").asText())
-        assertEquals("test", buckets.get(2).path("key").asText())
+        assertEquals("1", buckets.get(0).path("key").asString())
+        assertEquals("2", buckets.get(1).path("key").asString())
+        assertEquals("test", buckets.get(2).path("key").asString())
     }
 
     @Test
@@ -156,7 +156,7 @@ class ElasticQueryTest {
         val buckets = query.rawAggregations.withArray("/test/filter/keys/buckets")
 
         assertEquals(1, buckets.size())
-        assertEquals("3", buckets.get(0).path("key").asText())
+        assertEquals("3", buckets.get(0).path("key").asString())
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
+++ b/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
@@ -129,9 +129,9 @@ class ElasticQueryTest {
         val buckets = query.rawAggregations.withArray("/test/keys/buckets")
 
         assertEquals(3, buckets.size())
-        assertEquals("1", buckets.get(0).path("key").asString())
-        assertEquals("2", buckets.get(1).path("key").asString())
-        assertEquals("test", buckets.get(2).path("key").asString())
+        assertEquals("1", buckets.get(0).path("key").asString(""))
+        assertEquals("2", buckets.get(1).path("key").asString(""))
+        assertEquals("test", buckets.get(2).path("key").asString(""))
     }
 
     @Test
@@ -156,7 +156,7 @@ class ElasticQueryTest {
         val buckets = query.rawAggregations.withArray("/test/filter/keys/buckets")
 
         assertEquals(1, buckets.size())
-        assertEquals("3", buckets.get(0).path("key").asString())
+        assertEquals("3", buckets.get(0).path("key").asString(""))
     }
 
     @Test

--- a/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
+++ b/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
@@ -42,7 +42,7 @@ class LowLevelClientTest {
         var data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
 
         assertTrue { data.get("found").booleanValue() }
-        assertEquals("World", data.get("_source").get("Hello").asString())
+        assertEquals("World", data.get("_source").get("Hello").asString(""))
 
         elastic.getLowLevelClient().delete("test1", "TEST", null, null, null)
         data = elastic.getLowLevelClient().get("test1", "TEST", null, true)

--- a/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
+++ b/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
@@ -42,7 +42,7 @@ class LowLevelClientTest {
         var data = elastic.getLowLevelClient().get("test1", "TEST", null, true)
 
         assertTrue { data.get("found").booleanValue() }
-        assertEquals("World", data.get("_source").get("Hello").asText())
+        assertEquals("World", data.get("_source").get("Hello").asString())
 
         elastic.getLowLevelClient().delete("test1", "TEST", null, null, null)
         data = elastic.getLowLevelClient().get("test1", "TEST", null, true)

--- a/src/test/kotlin/sirius/db/es/SuggestNightlyTest.kt
+++ b/src/test/kotlin/sirius/db/es/SuggestNightlyTest.kt
@@ -9,7 +9,6 @@
 package sirius.db.es
 
 
-import com.fasterxml.jackson.databind.node.ObjectNode
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -101,7 +100,7 @@ class SuggestNightlyTest {
             suggestTestEntity3.shop = 2
             elastic.update(suggestTestEntity3)
         }
-        val matchPhrase = Json.createObject().set<ObjectNode>(
+        val matchPhrase = Json.createObject().set(
                 "match",
                 Json.createObject().set(
                         SuggestTestEntity.CONTENT.name,


### PR DESCRIPTION
### BREAKING CHANGES

Upgrades Jackson from 2.22.0 to 3.2.0 across the sirius stack. Jackson 3 uses new Maven coordinates and Java packages — see the official [Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0) for the complete list of renames and behavioral changes.

What applications using the sirius framework have to change:

- Rename imports `com.fasterxml.jackson.*` → `tools.jackson.*` (annotations stay on `com.fasterxml.jackson.annotation`); drop `jackson-datatype-jsr310` and `JavaTimeModule` registrations (built-in now).
- Fix the resulting compile errors: unchecked exceptions (`JsonProcessingException` → `JacksonException`, dead `catch (IOException)` blocks), method renames (`asText()` → `asString()` etc., `writeFieldName()` → `writeName()` etc.), builder-based mapper/generator configuration — see the migration guide for details.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1149](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1149)
- This PR is related to PRs:
  - https://github.com/scireum/sirius-parent/pull/79
  - https://github.com/scireum/sirius-kernel/pull/628

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.