### PR TITLE
add missing/lost parameters in nls key and output the toString of the entity which couldn't be deleted.

### DIFF
--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -224,7 +224,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeSetNull")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, Strings.limit(e, 30))
+                                             .set(PARAM_OWNER, String.valueOf(e))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -284,6 +284,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         if (count == 1) {
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChild")
+                            .set(PARAM_OWNER, String.valueOf(e))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())
@@ -293,6 +294,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChildren")
                             .set(PARAM_COUNT, count)
+                            .set(PARAM_OWNER, String.valueOf(e))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -160,12 +160,12 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
     }
 
     @Override
-    public void parseValues(Object e, Values values) {
+    public void parseValues(Object entity, Values values) {
         List<String> stringData = new ArrayList<>();
         for (int i = 0; i < values.length(); i++) {
             values.at(i).ifFilled(value -> stringData.add(value.toString()));
         }
-        setValue(e, stringData);
+        setValue(entity, stringData);
     }
 
     protected BaseEntityRefList<?, ?> getReferenceEntityRefList() {
@@ -219,17 +219,17 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         }
     }
 
-    protected void onDeleteSetNull(Object e) {
+    protected void onDeleteSetNull(Object entity) {
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeSetNull")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, String.valueOf(e))
+                                             .set(PARAM_OWNER, String.valueOf(entity))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
 
-        Object idBeingDeleted = ((BaseEntity<?>) e).getId();
+        Object idBeingDeleted = ((BaseEntity<?>) entity).getId();
         if (referenceInstance instanceof MongoEntity) {
             // MongoDB provides a fast and efficient way of removing and ID from a list...
             mongo.update()
@@ -252,18 +252,18 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         taskContext.addTiming(NLS.get("BaseEntityRefProperty.cascadedSetNull"), watch.elapsedMillis());
     }
 
-    protected void onDeleteCascade(Object e) {
+    protected void onDeleteCascade(Object entity) {
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeDelete")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, String.valueOf(e))
+                                             .set(PARAM_OWNER, String.valueOf(entity))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
-                         .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
+                         .eq(nameAsMapping, ((BaseEntity<?>) entity).getId())
                          .streamBlockwise()
                          .forEach(other -> cascadeDelete(taskContext, other));
     }
@@ -274,16 +274,16 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         taskContext.addTiming(NLS.get("BaseEntityRefProperty.cascadedDelete"), watch.elapsedMillis(), true);
     }
 
-    protected void onDeleteReject(Object e) {
+    protected void onDeleteReject(Object entity) {
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
         long count = referenceInstance.getMapper()
                                       .select(referenceInstance.getClass())
-                                      .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
+                                      .eq(nameAsMapping, ((BaseEntity<?>) entity).getId())
                                       .count();
         if (count == 1) {
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChild")
-                            .set(PARAM_OWNER, String.valueOf(e))
+                            .set(PARAM_OWNER, String.valueOf(entity))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())
@@ -293,7 +293,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChildren")
                             .set(PARAM_COUNT, count)
-                            .set(PARAM_OWNER, String.valueOf(e))
+                            .set(PARAM_OWNER, String.valueOf(entity))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -24,7 +24,6 @@ import sirius.db.mixing.types.BaseEntityRefList;
 import sirius.db.mongo.Mongo;
 import sirius.db.mongo.MongoEntity;
 import sirius.kernel.async.TaskContext;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Values;
 import sirius.kernel.commons.Watch;
@@ -257,7 +256,7 @@ public class BaseEntityRefListProperty extends Property implements ESPropertyInf
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeDelete")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, Strings.limit(e, 30))
+                                             .set(PARAM_OWNER, String.valueOf(e))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -18,7 +18,6 @@ import sirius.db.mixing.annotations.ComplexDelete;
 import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.TaskContext;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.Part;
@@ -278,7 +277,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeSetNull")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, Strings.limit(e, 30))
+                                             .set(PARAM_OWNER, String.valueOf(e))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -302,7 +302,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
 
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeDelete")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, Strings.limit(e, 30))
+                                             .set(PARAM_OWNER, String.valueOf(e))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -273,18 +273,18 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         return true;
     }
 
-    protected void onDeleteSetNull(Object e) {
+    protected void onDeleteSetNull(Object entity) {
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeSetNull")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, String.valueOf(e))
+                                             .set(PARAM_OWNER, String.valueOf(entity))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
-                         .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
+                         .eq(nameAsMapping, ((BaseEntity<?>) entity).getId())
                          .streamBlockwise()
                          .forEach(other -> cascadeSetNull(taskContext, other));
     }
@@ -296,19 +296,19 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         taskContext.addTiming(NLS.get("BaseEntityRefProperty.cascadedSetNull"), watch.elapsedMillis());
     }
 
-    protected void onDeleteCascade(Object e) {
+    protected void onDeleteCascade(Object entity) {
         TaskContext taskContext = TaskContext.get();
 
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeDelete")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())
-                                             .set(PARAM_OWNER, String.valueOf(e))
+                                             .set(PARAM_OWNER, String.valueOf(entity))
                                              .set(PARAM_FIELD, getLabel())
                                              .format());
 
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
         referenceInstance.getMapper()
                          .select(referenceInstance.getClass())
-                         .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
+                         .eq(nameAsMapping, ((BaseEntity<?>) entity).getId())
                          .streamBlockwise()
                          .forEach(other -> cascadeDelete(taskContext, other));
     }
@@ -319,16 +319,16 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         taskContext.addTiming(NLS.get("BaseEntityRefProperty.cascadedDelete"), watch.elapsedMillis(), true);
     }
 
-    protected void onDeleteReject(Object e) {
+    protected void onDeleteReject(Object entity) {
         BaseEntity<?> referenceInstance = (BaseEntity<?>) getDescriptor().getReferenceInstance();
         long count = referenceInstance.getMapper()
                                       .select(referenceInstance.getClass())
-                                      .eq(nameAsMapping, ((BaseEntity<?>) e).getId())
+                                      .eq(nameAsMapping, ((BaseEntity<?>) entity).getId())
                                       .count();
         if (count == 1) {
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChild")
-                            .set(PARAM_OWNER, String.valueOf(e))
+                            .set(PARAM_OWNER, String.valueOf(entity))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())
@@ -338,7 +338,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChildren")
                             .set(PARAM_COUNT, count)
-                            .set(PARAM_OWNER, String.valueOf(e))
+                            .set(PARAM_OWNER, String.valueOf(entity))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -329,6 +329,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
         if (count == 1) {
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChild")
+                            .set(PARAM_OWNER, String.valueOf(e))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())
@@ -338,6 +339,7 @@ public abstract class BaseEntityRefProperty<I extends Serializable, E extends Ba
             throw Exceptions.createHandled()
                             .withNLSKey("BaseEntityRefProperty.cannotDeleteEntityWithChildren")
                             .set(PARAM_COUNT, count)
+                            .set(PARAM_OWNER, String.valueOf(e))
                             .set(PARAM_FIELD, getFullLabel())
                             .set(PARAM_TYPE, getReferencedDescriptor().getLabel())
                             .set(PARAM_SOURCE, getDescriptor().getLabel())

--- a/src/main/resources/db_cs.properties
+++ b/src/main/resources/db_cs.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekt nelze odstranit. Stále existuje odkaz v '${source}' (pole: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekt nelze odstranit. Stále existuje ${count} odkazů v '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekt '${owner}' typu '${type}' nelze odstranit. Stále existuje odkaz v '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekt '${owner}' typu '${type}' nelze odstranit. Stále existuje ${count} odkazů v '${source}' (pole: ${field}).
 BaseEntityRefProperty.cascadeDelete = Odstraňte objekty typu '${type}', které obsahují '${owner}' v poli '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Odebrat '${owner}' z pole '${field}' pro všechny objekty typu '${type}'.
 BaseEntityRefProperty.cascadedDelete = Pokračování v mazání

--- a/src/main/resources/db_de.properties
+++ b/src/main/resources/db_de.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Das Objekt kann nicht gelöscht werden. Es gibt noch eine Referenz in '${source}' (Feld: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Das Objekt kann nicht gelöscht werden. Es gibt noch ${count} Referenzen in '${source}' (Feld: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Das Objekt '${owner}' vom Typ '${type}' kann nicht gelöscht werden. Es gibt noch eine Referenz in '${source}' (Feld: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Das Objekt '${owner}' vom Typ '${type}' kann nicht gelöscht werden. Es gibt noch ${count} Referenzen in '${source}' (Feld: ${field}).
 BaseEntityRefProperty.cascadeDelete = Lösche Objekte vom Typ '${type}', die '${owner}' im Feld '${field}' enthalten.
 BaseEntityRefProperty.cascadeSetNull = Entferne '${owner}' aus dem Feld '${field}' für alle Objekte vom Typ '${type}'.
 BaseEntityRefProperty.cascadedDelete = Kaskadierte Löschung

--- a/src/main/resources/db_en.properties
+++ b/src/main/resources/db_en.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = The object cannot be deleted. There is still a reference in '${source}' (field: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = The object cannot be deleted. There are still ${count} references in '${source}' (Field: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = The object '${owner}' of type '${type}' cannot be deleted. There is still a reference in '${source}' (field: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = The object '${owner}' of type '${type}' cannot be deleted. There are still ${count} references in '${source}' (Field: ${field}).
 BaseEntityRefProperty.cascadeDelete = Delete objects of type '${type}' which contain '${owner}' in the field '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Remove '${owner}' from the '${field}' field for all objects of type '${type}'.
 BaseEntityRefProperty.cascadedDelete = Continued deletion

--- a/src/main/resources/db_es.properties
+++ b/src/main/resources/db_es.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = El objeto no puede ser eliminado. Todavía existe una referencia en '${source}' (Campo: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = El objeto no puede ser eliminado. Todavía hay ${count} referencias en '${source}' (Campo: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = El objeto '${owner}' de tipo '${type}' no puede ser eliminado. Todavía existe una referencia en '${source}' (Campo: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = El objeto '${owner}' de tipo '${type}' no puede ser eliminado. Todavía hay ${count} referencias en '${source}' (Campo: ${field}).
 BaseEntityRefProperty.cascadeDelete = Eliminar objetos de tipo '${type}' que contengan '${owner}' en el campo '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Elimina '${owner}' del campo '${field}' para todos los objetos de tipo '${type}'.
 BaseEntityRefProperty.cascadedDelete = Supresión continuada

--- a/src/main/resources/db_et.properties
+++ b/src/main/resources/db_et.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekti ei saa kustutada. Viide '${source}' (väli: ${field}) on endiselt olemas.
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekti ei saa kustutada. Viited ${count} on endiselt '${source}' (väli: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekti '${owner}' tüübiga '${type}' ei saa kustutada. Viide '${source}' (väli: ${field}) on endiselt olemas.
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekti '${owner}' tüübiga '${type}' ei saa kustutada. Viited ${count} on endiselt '${source}' (väli: ${field}).
 BaseEntityRefProperty.cascadeDelete = Kustuta tüübi '${type}' objektid, mis sisaldavad '${owner}' väljal '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Eemalda '${owner}' kõikidel objektidel, mille tüüp on '${type}', väljal '${field}'.
 BaseEntityRefProperty.cascadedDelete = Jätkuv kustutamine

--- a/src/main/resources/db_fr.properties
+++ b/src/main/resources/db_fr.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = L'objet ne peut pas être supprimé. Il existe encore une référence dans '${source}' (champ: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = L'objet ne peut pas être supprimé. Il y a encore ${count} références dans '${source}' (champ : ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = L'objet '${owner}' de type '${type}' ne peut pas être supprimé. Il existe encore une référence dans '${source}' (champ: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = L'objet '${owner}' de type '${type}' ne peut pas être supprimé. Il y a encore ${count} références dans '${source}' (champ : ${field}).
 BaseEntityRefProperty.cascadeDelete = Supprimez les objets de type '${type}' qui contiennent '${owner}' dans le champ '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Supprimez '${owner}' du champ '${field}' pour tous les objets de type '${type}'.
 BaseEntityRefProperty.cascadedDelete = Poursuite de la suppression

--- a/src/main/resources/db_hu.properties
+++ b/src/main/resources/db_hu.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Az objektum nem törölhető. Még mindig van egy hivatkozás a '${source}' (mező: ${field}) mezőben.
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Az objektum nem törölhető. Még mindig vannak ${count} hivatkozások a '${source}' -ben (mező: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = A(z) '${owner}' objektum ('${type}' típus) nem törölhető. Még mindig van egy hivatkozás a '${source}' (mező: ${field}) mezőben.
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = A(z) '${owner}' objektum ('${type}' típus) nem törölhető. Még mindig vannak ${count} hivatkozások a '${source}' -ben (mező: ${field}).
 BaseEntityRefProperty.cascadeDelete = A '${type}' típusú objektumok törlése, amelyek a '${field}' mezőben '${owner}' típusú objektumokat tartalmaznak.
 BaseEntityRefProperty.cascadeSetNull = Távolítsa el a(z) '${owner}' elemet a(z) '${field}' mezőből az összes '${type}' típusú objektumnál.
 BaseEntityRefProperty.cascadedDelete = Folyamatos törlés

--- a/src/main/resources/db_it.properties
+++ b/src/main/resources/db_it.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = L'oggetto non può essere eliminato. Esiste ancora un riferimento in '${source}' (campo: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = L'oggetto non può essere eliminato. Ci sono ancora ${count} riferimenti in '${source}' (campo: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = L'oggetto '${owner}' di tipo '${type}' non può essere eliminato. Esiste ancora un riferimento in '${source}' (campo: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = L'oggetto '${owner}' di tipo '${type}' non può essere eliminato. Ci sono ancora ${count} riferimenti in '${source}' (campo: ${field}).
 BaseEntityRefProperty.cascadeDelete = Cancellare gli oggetti di tipo '${type}' che contengono '${owner}' nel campo '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Rimuovere '${owner}' dal campo '${field}' per tutti gli oggetti di tipo '${type}'.
 BaseEntityRefProperty.cascadedDelete = Continua la cancellazione

--- a/src/main/resources/db_lt.properties
+++ b/src/main/resources/db_lt.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekto negalima ištrinti. Vis dar yra nuoroda į '${source}' (laukas: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekto negalima ištrinti. Objekte '${source}' (laukas: ${field}) vis dar yra ${count} nuorodų.
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekto '${owner}', kurio tipas '${type}', negalima ištrinti. Vis dar yra nuoroda į '${source}' (laukas: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekto '${owner}', kurio tipas '${type}', negalima ištrinti. Objekte '${source}' (laukas: ${field}) vis dar yra ${count} nuorodų.
 BaseEntityRefProperty.cascadeDelete = Ištrinkite tipo '${type}' objektus, kurių lauke '${owner}' yra '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Pašalinkite „${owner}“ iš lauko „${field}“ visiems „${type}“ tipo objektams.
 BaseEntityRefProperty.cascadedDelete = Tęstinis ištrynimas

--- a/src/main/resources/db_lv.properties
+++ b/src/main/resources/db_lv.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Objektu nevar dzēst. Joprojām ir atsauce uz "${source}" (lauks: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objektu nevar izdzēst. Joprojām ir ${count} atsauces uz "${source}" (lauks: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Objektu '${owner}' ar tipu '${type}' nevar dzēst. Joprojām ir atsauce uz "${source}" (lauks: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objektu '${owner}' ar tipu '${type}' nevar izdzēst. Joprojām ir ${count} atsauces uz "${source}" (lauks: ${field}).
 BaseEntityRefProperty.cascadeDelete = Dzēst tipa '${type}' objektus, kas satur '${owner}' laukā '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Noņemiet '${owner}' no '${field}' lauka visiem '${type}' tipa objektiem.
 BaseEntityRefProperty.cascadedDelete = Turpināt dzēšanu

--- a/src/main/resources/db_nl.properties
+++ b/src/main/resources/db_nl.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Het object kan niet worden verwijderd. Er is nog een verwijzing in '${source}' (veld: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Het object kan niet worden verwijderd. Er zijn nog ${count} verwijzingen in '${source}' (veld: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Het object '${owner}' van type '${type}' kan niet worden verwijderd. Er is nog een verwijzing in '${source}' (veld: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Het object '${owner}' van type '${type}' kan niet worden verwijderd. Er zijn nog ${count} verwijzingen in '${source}' (veld: ${field}).
 BaseEntityRefProperty.cascadeDelete = Verwijder objecten van het type '${type}' die '${owner}' bevatten in het veld '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Verwijder '${owner}' uit het veld '${field}' voor alle objecten van het type '${type}'.
 BaseEntityRefProperty.cascadedDelete = Voortzetting van de verwijdering

--- a/src/main/resources/db_pl.properties
+++ b/src/main/resources/db_pl.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Obiekt nie może zostać usunięty. Istnieje jeszcze odniesienie w '${source}' (pole: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Obiekt nie może zostać usunięty. Istnieje jeszcze ${count} odniesień w '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Obiekt '${owner}' typu '${type}' nie może zostać usunięty. Istnieje jeszcze odniesienie w '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Obiekt '${owner}' typu '${type}' nie może zostać usunięty. Istnieje jeszcze ${count} odniesień w '${source}' (pole: ${field}).
 BaseEntityRefProperty.cascadeDelete = Usuwanie obiektów typu '${type}', które zawierają '${owner}' w polu '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Usuń '${owner}' z pola '${field}' dla wszystkich obiektów typu '${type}'.
 BaseEntityRefProperty.cascadedDelete = Ciągłe usuwanie

--- a/src/main/resources/db_sk.properties
+++ b/src/main/resources/db_sk.properties
@@ -1,5 +1,5 @@
-BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekt nemôže byť odstránený. Stále existuje odkaz v '${source}' (pole: ${field}).
-BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekt nie je možné odstrániť. Stále existuje ${count} odkazov v '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChild = Objekt '${owner}' typu '${type}' nemôže byť odstránený. Stále existuje odkaz v '${source}' (pole: ${field}).
+BaseEntityRefProperty.cannotDeleteEntityWithChildren = Objekt '${owner}' typu '${type}' nie je možné odstrániť. Stále existuje ${count} odkazov v '${source}' (pole: ${field}).
 BaseEntityRefProperty.cascadeDelete = Odstránenie objektov typu '${type}', ktoré obsahujú '${owner}' v poli '${field}'.
 BaseEntityRefProperty.cascadeSetNull = Odstráňte '${owner}' z poľa '${field}' pre všetky objekty typu '${type}'.
 BaseEntityRefProperty.cascadedDelete = Pokračovanie vymazávania


### PR DESCRIPTION

### Description
before: Das Objekt kann nicht gelöscht werden. Es gibt noch 65 Referenzen in 'Artikel' (Feld: Mengeneinheit).
now: "Das Objekt 'Fetz' vom Typ 'Mengeneinheit' kann nicht gelöscht werden. Es gibt noch 65 Referenzen in 'Artikel' (Feld: Mengeneinheit)."

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15286](https://scireum.myjetbrains.com/youtrack/issue/SE-15286)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
