### PR TITLE
Upgrade Redis dependencies and fix related issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.0.0</version>
+            <version>7.5.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>

--- a/src/main/java/sirius/db/redis/Redis.java
+++ b/src/main/java/sirius/db/redis/Redis.java
@@ -8,8 +8,8 @@
 
 package sirius.db.redis;
 
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.SetParams;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
@@ -102,7 +102,8 @@ public class Redis implements Startable, Stoppable {
 
     private void subscribe(Subscriber subscriber, JedisPubSub subscription) {
         while (subscriptionsActive.get()) {
-            try (Jedis redis = getConnection()) {
+            try {
+                UnifiedJedis redis = getConnection();
                 LOG.INFO("Starting subscription for: %s", subscriber.getTopic());
                 redis.subscribe(subscription, subscriber.getTopic());
                 if (subscriptionsActive.get()) {
@@ -202,7 +203,7 @@ public class Redis implements Startable, Stoppable {
         return system;
     }
 
-    private Jedis getConnection() {
+    private UnifiedJedis getConnection() {
         return getSystem().getConnection();
     }
 
@@ -223,7 +224,7 @@ public class Redis implements Startable, Stoppable {
      * @param <T>         the generic type of the result
      * @return a result computed by <tt>task</tt>
      */
-    public <T> T query(Supplier<String> description, Function<Jedis, T> task) {
+    public <T> T query(Supplier<String> description, Function<UnifiedJedis, T> task) {
         return getSystem().query(description, task);
     }
 
@@ -233,7 +234,7 @@ public class Redis implements Startable, Stoppable {
      * @param description a description of the actions performed used for debugging and tracing
      * @param task        the actual task to perform using redis
      */
-    public void exec(Supplier<String> description, Consumer<Jedis> task) {
+    public void exec(Supplier<String> description, Consumer<UnifiedJedis> task) {
         getSystem().exec(description, task);
     }
 
@@ -346,7 +347,7 @@ public class Redis implements Startable, Stoppable {
         return result;
     }
 
-    protected Optional<LockInfo> computeLockInfo(Jedis redis, String key) {
+    protected Optional<LockInfo> computeLockInfo(UnifiedJedis redis, String key) {
         String owner = redis.get(key);
         String since = redis.get(key + SUFFIX_DATE);
 

--- a/src/main/java/sirius/db/redis/Redis.java
+++ b/src/main/java/sirius/db/redis/Redis.java
@@ -396,7 +396,9 @@ public class Redis implements Startable, Stoppable {
                                                 CallContext.getNodeName(),
                                                 SetParams.setParams().nx().ex(lockTimeout.getSeconds()));
                     if ("OK".equals(response)) {
-                        redis.setex(key + SUFFIX_DATE, lockTimeout.getSeconds(), LocalDateTime.now().toString());
+                        redis.set(key + SUFFIX_DATE,
+                                  LocalDateTime.now().toString(),
+                                  SetParams.setParams().ex(lockTimeout.getSeconds()));
                         return true;
                     }
 

--- a/src/main/java/sirius/db/redis/Redis.java
+++ b/src/main/java/sirius/db/redis/Redis.java
@@ -49,7 +49,7 @@ import java.util.function.Supplier;
  * Provides a thin layer to access Redis.
  * <p>
  * The configuration is loaded from <tt>redis.pools</tt>. By default, the <b>system</b> pool is used,
- * but multiple database can be used at the same time.
+ * but multiple databases can be used at the same time.
  */
 @Register(classes = {Redis.class, Startable.class, Stoppable.class})
 public class Redis implements Startable, Stoppable {
@@ -72,7 +72,7 @@ public class Redis implements Startable, Stoppable {
     private static final String SUFFIX_DATE = "_date";
 
     /**
-     * Contains the logger for all redis related messages.
+     * Contains the logger for all redis-related messages.
      */
     public static final Log LOG = Log.get("redis");
 
@@ -192,7 +192,7 @@ public class Redis implements Startable, Stoppable {
     }
 
     /**
-     * Provides access the to default (system) database.
+     * Provides access to the default (system) database.
      *
      * @return the default database
      */
@@ -302,7 +302,7 @@ public class Redis implements Startable, Stoppable {
         public final String name;
 
         /**
-         * The current value of the lock which can be used to determine who holds the lock
+         * The current value of the lock that can be used to determine who holds the lock
          */
         public final String value;
 
@@ -314,7 +314,7 @@ public class Redis implements Startable, Stoppable {
         /**
          * The maximal time to live of the lock.
          * <p>
-         * The lock will be auto released after a certain amount of seconds in case of a server crash
+         * The lock will be auto-released after a certain number of seconds in case of a server crash
          */
         public final Long ttl;
 
@@ -381,7 +381,7 @@ public class Redis implements Startable, Stoppable {
      * out due to a single node crash. However, it is very important to choose a sane value here.
      *
      * @param lock           the name of the lock to acquire
-     * @param acquireTimeout the max duration during which retires (in 1 second intervals) will be performed
+     * @param acquireTimeout the max duration during which retires (in 1-second intervals) will be performed
      * @param lockTimeout    the max duration for which the lock will be kept before auto-releasing it
      * @return <tt>true</tt> if the lock was acquired, <tt>false</tt> otherwise
      */
@@ -428,7 +428,7 @@ public class Redis implements Startable, Stoppable {
      * thrown).
      *
      * @param lock           the name of the lock to acquire
-     * @param acquireTimeout the max duration during which retires (in 1 second intervals) will be performed
+     * @param acquireTimeout the max duration during which retires (in 1-second intervals) will be performed
      * @param lockTimeout    the max duration for which the lock will be kept before auto-releasing it
      * @param lockedTask     the task to execute while holding the given lock. The task will not be executed if the
      *                       lock cannot be acquired within the given period

--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -264,7 +264,7 @@ public class RedisDB {
     }
 
     /**
-     * Broadcasts a message to a pub-sub topic in redis.
+     * Broadcasts a message to a pubsub topic in redis.
      *
      * @param topic   the name of the topic to broadcast to
      * @param message the message to send

--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -9,12 +9,12 @@
 package sirius.db.redis;
 
 import redis.clients.jedis.ClientSetInfoConfig;
+import redis.clients.jedis.ConnectionPoolConfig;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
-import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.RedisSentinelClient;
+import redis.clients.jedis.UnifiedJedis;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Operation;
 import sirius.kernel.commons.Strings;
@@ -29,8 +29,10 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -66,8 +68,7 @@ public class RedisDB {
      */
     private final boolean enableClientInfo;
 
-    protected JedisPool jedis;
-    protected JedisSentinelPool sentinelPool;
+    protected UnifiedJedis jedis;
 
     protected RedisDB(Redis redisInstance, Extension config) {
         this.redisInstance = redisInstance;
@@ -97,14 +98,8 @@ public class RedisDB {
     protected void close() {
         available = false;
 
-        if (sentinelPool != null) {
-            JedisSentinelPool copy = this.sentinelPool;
-            this.sentinelPool = null;
-            copy.close();
-        }
-
         if (jedis != null) {
-            JedisPool copy = this.jedis;
+            UnifiedJedis copy = this.jedis;
             this.jedis = null;
             copy.close();
         }
@@ -116,73 +111,86 @@ public class RedisDB {
      * Note that this method should be used with absolute care and calling {@link #query(Supplier, Function)}
      * or {@link #exec(Supplier, Consumer)} is preferred as it ensures monitoring and proper connection handling.
      *
-     * @return access to a Redis connection from the managed pool. Note that {@link Jedis#close()} has to be called
-     * in any case to ensure that the connection is returned to the pool.
+     * @return access to the managed Redis client.
      */
-    public Jedis getConnection() {
-        if (sentinelPool != null) {
-            return sentinelPool.getResource();
-        }
+    public UnifiedJedis getConnection() {
         if (jedis != null) {
-            return jedis.getResource();
+            return jedis;
         }
 
         return setupConnection();
     }
 
-    private synchronized Jedis setupConnection() {
-        if (sentinelPool == null && Strings.isFilled(sentinels)) {
-            JedisPoolConfig poolConfig = new JedisPoolConfig();
-            poolConfig.setMaxTotal(maxActive);
-            poolConfig.setMaxIdle(maxIdle);
-
-            sentinelPool = new JedisSentinelPool(masterName,
-                                                 Arrays.stream(sentinels.split(","))
-                                                       .map(String::trim)
-                                                       .collect(Collectors.toSet()),
-                                                 poolConfig,
-                                                 connectTimeout,
-                                                 readTimeout,
-                                                 null,
-                                                 db);
-            return sentinelPool.getResource();
-        }
-        if (sentinelPool != null) {
-            return sentinelPool.getResource();
+    private synchronized UnifiedJedis setupConnection() {
+        if (jedis != null) {
+            return jedis;
         }
 
-        if (jedis == null) {
-            if (Strings.isEmpty(host)) {
-                Redis.LOG.SEVERE(Strings.apply(
-                        "Missing a Redis host for config '%s'! This might lead to undefined behaviour."
-                        + " Please specify redis.host or redis.sentinels!",
-                        name));
-            }
-
-            JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
-            jedisPoolConfig.setMaxTotal(maxActive);
-            jedisPoolConfig.setMaxIdle(maxIdle);
-
-            Tuple<String, Integer> effectiveHostAndPort = PortMapper.mapPort(determineServiceName(), host, port);
-            HostAndPort hostAndPort =
-                    new HostAndPort(effectiveHostAndPort.getFirst(), effectiveHostAndPort.getSecond());
-
-            DefaultJedisClientConfig jedisClientConfig = DefaultJedisClientConfig.builder()
-                                                                                 .database(db)
-                                                                                 .clientName(CallContext.getNodeName())
-                                                                                 .connectionTimeoutMillis(connectTimeout)
-                                                                                 .socketTimeoutMillis(readTimeout)
-                                                                                 .clientSetInfoConfig(new ClientSetInfoConfig(
-                                                                                         !enableClientInfo))
-                                                                                 .password(Strings.isFilled(password) ?
-                                                                                           password :
-                                                                                           null)
-                                                                                 .build();
-
-            jedis = new JedisPool(jedisPoolConfig, hostAndPort, jedisClientConfig);
+        if (Strings.isFilled(sentinels)) {
+            jedis = RedisSentinelClient.builder()
+                                       .masterName(masterName)
+                                       .sentinels(parseSentinels())
+                                       .clientConfig(createClientConfig())
+                                       .sentinelClientConfig(createClientConfig())
+                                       .poolConfig(createPoolConfig())
+                                       .build();
+            return jedis;
         }
 
-        return jedis.getResource();
+        if (Strings.isEmpty(host)) {
+            Redis.LOG.SEVERE(Strings.apply(
+                    "Missing a Redis host for config '%s'! This might lead to undefined behaviour."
+                    + " Please specify redis.host or redis.sentinels!",
+                    name));
+        }
+
+        Tuple<String, Integer> effectiveHostAndPort = PortMapper.mapPort(determineServiceName(), host, port);
+        HostAndPort hostAndPort = new HostAndPort(effectiveHostAndPort.getFirst(), effectiveHostAndPort.getSecond());
+
+        jedis = RedisClient.builder()
+                           .hostAndPort(hostAndPort)
+                           .clientConfig(createClientConfig())
+                           .poolConfig(createPoolConfig())
+                           .build();
+
+        return jedis;
+    }
+
+    private Set<HostAndPort> parseSentinels() {
+        return Arrays.stream(sentinels.split(","))
+                     .map(String::trim)
+                     .filter(Strings::isFilled)
+                     .map(this::parseHostAndPort)
+                     .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private HostAndPort parseHostAndPort(String hostAndPort) {
+        int separator = hostAndPort.lastIndexOf(':');
+        if (separator < 0 || separator == hostAndPort.length() - 1) {
+            return new HostAndPort(hostAndPort, 26379);
+        }
+
+        String sentinelHost = hostAndPort.substring(0, separator);
+        int sentinelPort = Integer.parseInt(hostAndPort.substring(separator + 1));
+        return new HostAndPort(sentinelHost, sentinelPort);
+    }
+
+    private ConnectionPoolConfig createPoolConfig() {
+        ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+        poolConfig.setMaxTotal(maxActive);
+        poolConfig.setMaxIdle(maxIdle);
+        return poolConfig;
+    }
+
+    private DefaultJedisClientConfig createClientConfig() {
+        return DefaultJedisClientConfig.builder()
+                                       .database(db)
+                                       .clientName(CallContext.getNodeName())
+                                       .connectionTimeoutMillis(connectTimeout)
+                                       .socketTimeoutMillis(readTimeout)
+                                       .clientSetInfoConfig(new ClientSetInfoConfig(!enableClientInfo))
+                                       .password(Strings.isFilled(password) ? password : null)
+                                       .build();
     }
 
     private String determineServiceName() {
@@ -197,9 +205,10 @@ public class RedisDB {
      * @param <T>         the generic type of the result
      * @return a result computed by <tt>task</tt>
      */
-    public <T> T query(Supplier<String> description, Function<Jedis, T> task) {
+    public <T> T query(Supplier<String> description, Function<UnifiedJedis, T> task) {
         Watch w = Watch.start();
-        try (var _ = new Operation(description, Duration.ofSeconds(10)); Jedis redis = getConnection()) {
+        try (var _ = new Operation(description, Duration.ofSeconds(10))) {
+            UnifiedJedis redis = getConnection();
             return task.apply(redis);
         } catch (Exception exception) {
             throw Exceptions.handle(Redis.LOG, exception);
@@ -217,7 +226,7 @@ public class RedisDB {
      * @param description a description of the actions performed used for debugging and tracing
      * @param task        the actual task to perform using redis
      */
-    public void exec(Supplier<String> description, Consumer<Jedis> task) {
+    public void exec(Supplier<String> description, Consumer<UnifiedJedis> task) {
         query(description, r -> {
             task.accept(r);
             return null;
@@ -273,7 +282,7 @@ public class RedisDB {
      */
     public Map<String, String> getInfo() {
         try {
-            return Arrays.stream(query(() -> "info", Jedis::info).split("\n"))
+            return Arrays.stream(query(() -> "info", UnifiedJedis::info).split("\n"))
                          .map(line -> Strings.split(line, ":"))
                          .filter(keyAndValue -> Strings.areAllFilled(keyAndValue.getFirst(), keyAndValue.getSecond()))
                          // Modules are listed under the same "key", so we skip them from here
@@ -292,7 +301,7 @@ public class RedisDB {
      */
     public List<String> getModules() {
         try {
-            return Arrays.stream(query(() -> "info", Jedis::info).split("\n"))
+            return Arrays.stream(query(() -> "info", UnifiedJedis::info).split("\n"))
                          .map(line -> Strings.split(line, ":"))
                          .filter(keyAndValue -> INFO_MODULE.equals(keyAndValue.getFirst()))
                          .map(Tuple::getSecond)

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.2.6-alpine
+    image: redis:8.8.0-alpine
     ports:
       - "6379"
     hostname: redis


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- Upgraded the Redis Docker image to `8.8.0-alpine` for testing purposes.
- Fixed typos found in the related code.
- Replaced a deprecated call with its updated alternative.
- Upgraded the Redis client to use the new `UnifiedJedis`, which introduces a breaking change as `Jedis` and `JedisPool` are now replaced.

**Breaking Change**: Code relying on `Jedis` or `JedisPool` will need to be updated to utilize the new `UnifiedJedis` client.

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1196](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1196)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.