### PR TITLE
Upgrade MariaDB to 11.8.8-noble

### DIFF
--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -12,7 +12,7 @@ services:
     hostname: mongo
 
   mariadb:
-    image: mariadb:11.8.3-noble
+    image: mariadb:11.8.8-noble
     ports:
       - "3306"
     environment:


### PR DESCRIPTION
Part of SIRI-1255.

Upgrades the MariaDB Docker image `11.8.3-noble` -> `11.8.8-noble` (current 11.8 LTS patch) in `src/test/resources/docker-db.yml`. Only the image tag changed.