### PR TITLE
Bump MongoDB driver to 5.9.0 and test image to 8.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.6.5</version>
+            <version>5.9.0</version>
         </dependency>
 
         <!-- Changelog: https://github.com/redis/jedis/releases -->

--- a/src/test/resources/docker-db.yml
+++ b/src/test/resources/docker-db.yml
@@ -6,7 +6,7 @@ services:
     hostname: redis
 
   mongo:
-    image: mongo:8.0.8
+    image: mongo:8.3.7
     ports:
       - "27017"
     hostname: mongo


### PR DESCRIPTION
### Description

This PR upgrades MongoDB dependencies:
- `mongodb-driver-sync` from 5.6.5 to 5.9.0
- The `docker-db.yml` test MongoDB server image from 8.0.8 to 8.3.7

This is a low-risk upgrade: the driver bump is purely additive (no breaking changes intersect with this codebase's usage), and 8.3.7 is a security-relevant patch fixing several CVEs (authz-bypass, use-after-free, privilege-injection).

Per the ticket's Patch Tasks, a feature compatibility version (FCV) change is required on deployed MongoDB instances:
- Before upgrade: verify FCV is `8.0` via `db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })`, set with `db.adminCommand({ setFeatureCompatibilityVersion: "8.0", confirm: true })` if needed.
- After upgrade: `db.adminCommand({ setFeatureCompatibilityVersion: "8.3", confirm: true })`

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1198](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1198)
- This PR is related to PR:

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.