### PR TITLE
Moves the copyright headers to Stuttgart and https

### DIFF
--- a/src/main/java/sirius/db/DB.java
+++ b/src/main/java/sirius/db/DB.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db;

--- a/src/main/java/sirius/db/KeyGenerator.java
+++ b/src/main/java/sirius/db/KeyGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db;

--- a/src/main/java/sirius/db/es/AggregationBuilder.java
+++ b/src/main/java/sirius/db/es/AggregationBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/AggregationResult.java
+++ b/src/main/java/sirius/db/es/AggregationResult.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/Bucket.java
+++ b/src/main/java/sirius/db/es/Bucket.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/BulkContext.java
+++ b/src/main/java/sirius/db/es/BulkContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/BulkResult.java
+++ b/src/main/java/sirius/db/es/BulkResult.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/ESIndexCommand.java
+++ b/src/main/java/sirius/db/es/ESIndexCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/ESPropertyInfo.java
+++ b/src/main/java/sirius/db/es/ESPropertyInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/Elastic.java
+++ b/src/main/java/sirius/db/es/Elastic.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/ElasticEntity.java
+++ b/src/main/java/sirius/db/es/ElasticEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/ElasticMetricsProvider.java
+++ b/src/main/java/sirius/db/es/ElasticMetricsProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/ElasticQuery.java
+++ b/src/main/java/sirius/db/es/ElasticQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/FunctionScoreBuilder.java
+++ b/src/main/java/sirius/db/es/FunctionScoreBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/IndexMappings.java
+++ b/src/main/java/sirius/db/es/IndexMappings.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/IndexNaming.java
+++ b/src/main/java/sirius/db/es/IndexNaming.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/LowLevelClient.java
+++ b/src/main/java/sirius/db/es/LowLevelClient.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/NearestNeighborsSearch.java
+++ b/src/main/java/sirius/db/es/NearestNeighborsSearch.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/RequestBuilder.java
+++ b/src/main/java/sirius/db/es/RequestBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/SettingsCustomizer.java
+++ b/src/main/java/sirius/db/es/SettingsCustomizer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/SortBuilder.java
+++ b/src/main/java/sirius/db/es/SortBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/main/java/sirius/db/es/annotations/Analyzed.java
+++ b/src/main/java/sirius/db/es/annotations/Analyzed.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.annotations;

--- a/src/main/java/sirius/db/es/annotations/CustomSettings.java
+++ b/src/main/java/sirius/db/es/annotations/CustomSettings.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.annotations;

--- a/src/main/java/sirius/db/es/annotations/ESOption.java
+++ b/src/main/java/sirius/db/es/annotations/ESOption.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.annotations;

--- a/src/main/java/sirius/db/es/annotations/IndexMode.java
+++ b/src/main/java/sirius/db/es/annotations/IndexMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.annotations;

--- a/src/main/java/sirius/db/es/annotations/RoutedBy.java
+++ b/src/main/java/sirius/db/es/annotations/RoutedBy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.annotations;

--- a/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
+++ b/src/main/java/sirius/db/es/constraints/BoolQueryBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/constraints/ElasticCSVFilter.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticCSVFilter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/constraints/ElasticConstraint.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticConstraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticFilterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/constraints/ElasticQueryCompiler.java
+++ b/src/main/java/sirius/db/es/constraints/ElasticQueryCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/constraints/NestedQuery.java
+++ b/src/main/java/sirius/db/es/constraints/NestedQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.constraints;

--- a/src/main/java/sirius/db/es/suggest/SuggesterBuilder.java
+++ b/src/main/java/sirius/db/es/suggest/SuggesterBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.suggest;

--- a/src/main/java/sirius/db/es/suggest/SuggestionQuery.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestionQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.suggest;

--- a/src/main/java/sirius/db/es/suggest/SuggestionResult.java
+++ b/src/main/java/sirius/db/es/suggest/SuggestionResult.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.suggest;

--- a/src/main/java/sirius/db/es/suggest/TermSuggestion.java
+++ b/src/main/java/sirius/db/es/suggest/TermSuggestion.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.suggest;

--- a/src/main/java/sirius/db/es/suggest/TextPartSuggestion.java
+++ b/src/main/java/sirius/db/es/suggest/TextPartSuggestion.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.suggest;

--- a/src/main/java/sirius/db/es/types/DenseVector.java
+++ b/src/main/java/sirius/db/es/types/DenseVector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.types;

--- a/src/main/java/sirius/db/es/types/DenseVectorProperty.java
+++ b/src/main/java/sirius/db/es/types/DenseVectorProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.types;

--- a/src/main/java/sirius/db/es/types/ElasticRef.java
+++ b/src/main/java/sirius/db/es/types/ElasticRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.types;

--- a/src/main/java/sirius/db/es/types/ElasticRefList.java
+++ b/src/main/java/sirius/db/es/types/ElasticRefList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.types;

--- a/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/BaseSQLQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/Capability.java
+++ b/src/main/java/sirius/db/jdbc/Capability.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/Database.java
+++ b/src/main/java/sirius/db/jdbc/Database.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/Databases.java
+++ b/src/main/java/sirius/db/jdbc/Databases.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/DelegatingConnection.java
+++ b/src/main/java/sirius/db/jdbc/DelegatingConnection.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/DeleteStatement.java
+++ b/src/main/java/sirius/db/jdbc/DeleteStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/GeneratedStatement.java
+++ b/src/main/java/sirius/db/jdbc/GeneratedStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/MonitoredDataSource.java
+++ b/src/main/java/sirius/db/jdbc/MonitoredDataSource.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/OMA.java
+++ b/src/main/java/sirius/db/jdbc/OMA.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/Operator.java
+++ b/src/main/java/sirius/db/jdbc/Operator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/Row.java
+++ b/src/main/java/sirius/db/jdbc/Row.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SQLCall.java
+++ b/src/main/java/sirius/db/jdbc/SQLCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SQLEntity.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SQLEntityCache.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntityCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SQLEntityRef.java
+++ b/src/main/java/sirius/db/jdbc/SQLEntityRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/SQLQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/SmartQuery.java
+++ b/src/main/java/sirius/db/jdbc/SmartQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/StatementCompiler.java
+++ b/src/main/java/sirius/db/jdbc/StatementCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/TransformedQuery.java
+++ b/src/main/java/sirius/db/jdbc/TransformedQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/TranslationState.java
+++ b/src/main/java/sirius/db/jdbc/TranslationState.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/UpdateStatement.java
+++ b/src/main/java/sirius/db/jdbc/UpdateStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/WrappedConnection.java
+++ b/src/main/java/sirius/db/jdbc/WrappedConnection.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedPreparedStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/WrappedStatement.java
+++ b/src/main/java/sirius/db/jdbc/WrappedStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/main/java/sirius/db/jdbc/batch/BatchContext.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/BatchSQLQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/CustomQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/DeleteQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/FindQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/FindQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/InsertQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/UpdateQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/UpdateQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch;

--- a/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchContext.java
+++ b/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch.external;

--- a/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
+++ b/src/main/java/sirius/db/jdbc/batch/external/ExternalBatchQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch.external;

--- a/src/main/java/sirius/db/jdbc/constraints/And.java
+++ b/src/main/java/sirius/db/jdbc/constraints/And.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/CombinedConstraint.java
+++ b/src/main/java/sirius/db/jdbc/constraints/CombinedConstraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/CompoundValue.java
+++ b/src/main/java/sirius/db/jdbc/constraints/CompoundValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/Exists.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Exists.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/FieldOperator.java
+++ b/src/main/java/sirius/db/jdbc/constraints/FieldOperator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/Filled.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Filled.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/Like.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Like.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/Not.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Not.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/NotFilled.java
+++ b/src/main/java/sirius/db/jdbc/constraints/NotFilled.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/Or.java
+++ b/src/main/java/sirius/db/jdbc/constraints/Or.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/SQLConstraint.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLConstraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLFilterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/constraints/SQLQueryCompiler.java
+++ b/src/main/java/sirius/db/jdbc/constraints/SQLQueryCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.constraints;

--- a/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/BasicDatabaseDialect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/ClickhouseDatabaseDialect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/DatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/DatabaseDialect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/ForeignKey.java
+++ b/src/main/java/sirius/db/jdbc/schema/ForeignKey.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/Key.java
+++ b/src/main/java/sirius/db/jdbc/schema/Key.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/MariaDBDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/MariaDBDatabaseDialect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
+++ b/src/main/java/sirius/db/jdbc/schema/MySQLDatabaseDialect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/SQLPropertyInfo.java
+++ b/src/main/java/sirius/db/jdbc/schema/SQLPropertyInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/Schema.java
+++ b/src/main/java/sirius/db/jdbc/schema/Schema.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
+++ b/src/main/java/sirius/db/jdbc/schema/SchemaTool.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/SchemaUpdateAction.java
+++ b/src/main/java/sirius/db/jdbc/schema/SchemaUpdateAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/Table.java
+++ b/src/main/java/sirius/db/jdbc/schema/Table.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/jdbc/schema/TableColumn.java
+++ b/src/main/java/sirius/db/jdbc/schema/TableColumn.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.schema;

--- a/src/main/java/sirius/db/mixing/AccessPath.java
+++ b/src/main/java/sirius/db/mixing/AccessPath.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/BaseEntity.java
+++ b/src/main/java/sirius/db/mixing/BaseEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/BaseMapper.java
+++ b/src/main/java/sirius/db/mixing/BaseMapper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Composite.java
+++ b/src/main/java/sirius/db/mixing/Composite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/ContextInfo.java
+++ b/src/main/java/sirius/db/mixing/ContextInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/DateRange.java
+++ b/src/main/java/sirius/db/mixing/DateRange.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Entity.java
+++ b/src/main/java/sirius/db/mixing/Entity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/EntityDescriptor.java
+++ b/src/main/java/sirius/db/mixing/EntityDescriptor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/EntityLoadAction.java
+++ b/src/main/java/sirius/db/mixing/EntityLoadAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/FieldLookupCache.java
+++ b/src/main/java/sirius/db/mixing/FieldLookupCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/IntegrityConstraintFailedException.java
+++ b/src/main/java/sirius/db/mixing/IntegrityConstraintFailedException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/InvalidFieldException.java
+++ b/src/main/java/sirius/db/mixing/InvalidFieldException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Mapping.java
+++ b/src/main/java/sirius/db/mixing/Mapping.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Mixable.java
+++ b/src/main/java/sirius/db/mixing/Mixable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/MixinLoadAction.java
+++ b/src/main/java/sirius/db/mixing/MixinLoadAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Mixing.java
+++ b/src/main/java/sirius/db/mixing/Mixing.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Nested.java
+++ b/src/main/java/sirius/db/mixing/Nested.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/NestedLoadAction.java
+++ b/src/main/java/sirius/db/mixing/NestedLoadAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/OptimisticLockException.java
+++ b/src/main/java/sirius/db/mixing/OptimisticLockException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/Property.java
+++ b/src/main/java/sirius/db/mixing/Property.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/PropertyFactory.java
+++ b/src/main/java/sirius/db/mixing/PropertyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/PropertyValidator.java
+++ b/src/main/java/sirius/db/mixing/PropertyValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/main/java/sirius/db/mixing/annotations/AfterDelete.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterDelete.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/AfterSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/AfterSave.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/BeforeDelete.java
+++ b/src/main/java/sirius/db/mixing/annotations/BeforeDelete.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
+++ b/src/main/java/sirius/db/mixing/annotations/BeforeSave.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/ComplexDelete.java
+++ b/src/main/java/sirius/db/mixing/annotations/ComplexDelete.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/DefaultValue.java
+++ b/src/main/java/sirius/db/mixing/annotations/DefaultValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Engine.java
+++ b/src/main/java/sirius/db/mixing/annotations/Engine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Index.java
+++ b/src/main/java/sirius/db/mixing/annotations/Index.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Indices.java
+++ b/src/main/java/sirius/db/mixing/annotations/Indices.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Length.java
+++ b/src/main/java/sirius/db/mixing/annotations/Length.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Lob.java
+++ b/src/main/java/sirius/db/mixing/annotations/Lob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/LowerCase.java
+++ b/src/main/java/sirius/db/mixing/annotations/LowerCase.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/MaxValue.java
+++ b/src/main/java/sirius/db/mixing/annotations/MaxValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/MinValue.java
+++ b/src/main/java/sirius/db/mixing/annotations/MinValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Mixin.java
+++ b/src/main/java/sirius/db/mixing/annotations/Mixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/NullAllowed.java
+++ b/src/main/java/sirius/db/mixing/annotations/NullAllowed.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Numeric.java
+++ b/src/main/java/sirius/db/mixing/annotations/Numeric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/OnValidate.java
+++ b/src/main/java/sirius/db/mixing/annotations/OnValidate.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Ordinal.java
+++ b/src/main/java/sirius/db/mixing/annotations/Ordinal.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Positive.java
+++ b/src/main/java/sirius/db/mixing/annotations/Positive.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Realm.java
+++ b/src/main/java/sirius/db/mixing/annotations/Realm.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/RelationName.java
+++ b/src/main/java/sirius/db/mixing/annotations/RelationName.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/RemoveWhitespace.java
+++ b/src/main/java/sirius/db/mixing/annotations/RemoveWhitespace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/SkipDefaultValue.java
+++ b/src/main/java/sirius/db/mixing/annotations/SkipDefaultValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Transient.java
+++ b/src/main/java/sirius/db/mixing/annotations/Transient.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/TranslationSource.java
+++ b/src/main/java/sirius/db/mixing/annotations/TranslationSource.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Trim.java
+++ b/src/main/java/sirius/db/mixing/annotations/Trim.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Unique.java
+++ b/src/main/java/sirius/db/mixing/annotations/Unique.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/UpperCase.java
+++ b/src/main/java/sirius/db/mixing/annotations/UpperCase.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
+++ b/src/main/java/sirius/db/mixing/annotations/ValidatedBy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/annotations/Versioned.java
+++ b/src/main/java/sirius/db/mixing/annotations/Versioned.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations;

--- a/src/main/java/sirius/db/mixing/properties/AmountProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/AmountProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefListProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseEntityRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/BaseMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BaseMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/BooleanProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/CompositePropertyFactory.java
+++ b/src/main/java/sirius/db/mixing/properties/CompositePropertyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/ElasticRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/ElasticRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/EnumProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/EnumProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/InstantProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/InstantProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/IntegerProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalDateTimeProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LocalTimeProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/LongProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/LongProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/MongoRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MongoRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/MultiPointLocationProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/MultiPointLocationProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/NestedListProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/NumberProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/NumberProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/SQLEntityRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringBooleanMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringIntMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringIntMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringListMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringListMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringListProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringListProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringLocalDateTimeMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringNestedMapProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringNestedMapProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/properties/StringProperty.java
+++ b/src/main/java/sirius/db/mixing/properties/StringProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/main/java/sirius/db/mixing/query/BaseQuery.java
+++ b/src/main/java/sirius/db/mixing/query/BaseQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/Query.java
+++ b/src/main/java/sirius/db/mixing/query/Query.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/QueryCompiler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/QueryField.java
+++ b/src/main/java/sirius/db/mixing/query/QueryField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/QueryTag.java
+++ b/src/main/java/sirius/db/mixing/query/QueryTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/QueryTagHandler.java
+++ b/src/main/java/sirius/db/mixing/query/QueryTagHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query;

--- a/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/CSVFilter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query.constraints;

--- a/src/main/java/sirius/db/mixing/query/constraints/Constraint.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/Constraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query.constraints;

--- a/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/FilterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query.constraints;

--- a/src/main/java/sirius/db/mixing/query/constraints/OneInField.java
+++ b/src/main/java/sirius/db/mixing/query/constraints/OneInField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.query.constraints;

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/BaseEntityRefList.java
+++ b/src/main/java/sirius/db/mixing/types/BaseEntityRefList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/NestedList.java
+++ b/src/main/java/sirius/db/mixing/types/NestedList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/SafeList.java
+++ b/src/main/java/sirius/db/mixing/types/SafeList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/SafeMap.java
+++ b/src/main/java/sirius/db/mixing/types/SafeMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringBooleanMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringBooleanMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringIntMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringIntMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringList.java
+++ b/src/main/java/sirius/db/mixing/types/StringList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringListMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringListMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringLocalDateTimeMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringLocalDateTimeMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mixing/types/StringNestedMap.java
+++ b/src/main/java/sirius/db/mixing/types/StringNestedMap.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.types;

--- a/src/main/java/sirius/db/mongo/Deleter.java
+++ b/src/main/java/sirius/db/mongo/Deleter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Doc.java
+++ b/src/main/java/sirius/db/mongo/Doc.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Finder.java
+++ b/src/main/java/sirius/db/mongo/Finder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/IndexDescription.java
+++ b/src/main/java/sirius/db/mongo/IndexDescription.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Inserter.java
+++ b/src/main/java/sirius/db/mongo/Inserter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Mango.java
+++ b/src/main/java/sirius/db/mongo/Mango.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Mongo.java
+++ b/src/main/java/sirius/db/mongo/Mongo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/MongoEntity.java
+++ b/src/main/java/sirius/db/mongo/MongoEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/MongoEntityCache.java
+++ b/src/main/java/sirius/db/mongo/MongoEntityCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/MongoMetricsProvider.java
+++ b/src/main/java/sirius/db/mongo/MongoMetricsProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/MongoQuery.java
+++ b/src/main/java/sirius/db/mongo/MongoQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/QueryBuilder.java
+++ b/src/main/java/sirius/db/mongo/QueryBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/ReadonlyObject.java
+++ b/src/main/java/sirius/db/mongo/ReadonlyObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/SecondaryCapableMapper.java
+++ b/src/main/java/sirius/db/mongo/SecondaryCapableMapper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/Updater.java
+++ b/src/main/java/sirius/db/mongo/Updater.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/main/java/sirius/db/mongo/constraints/MongoConstraint.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoConstraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.constraints;

--- a/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoFilterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.constraints;

--- a/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoOneInField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.constraints;

--- a/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
+++ b/src/main/java/sirius/db/mongo/constraints/MongoQueryCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.constraints;

--- a/src/main/java/sirius/db/mongo/facets/MongoAverageFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoAverageFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/facets/MongoBooleanFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoBooleanFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/facets/MongoDateRangeFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoDateRangeFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/facets/MongoFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/facets/MongoSumFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoSumFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/facets/MongoTermFacet.java
+++ b/src/main/java/sirius/db/mongo/facets/MongoTermFacet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.facets;

--- a/src/main/java/sirius/db/mongo/package-info.java
+++ b/src/main/java/sirius/db/mongo/package-info.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/java/sirius/db/mongo/types/MongoRef.java
+++ b/src/main/java/sirius/db/mongo/types/MongoRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.types;

--- a/src/main/java/sirius/db/mongo/types/MongoRefList.java
+++ b/src/main/java/sirius/db/mongo/types/MongoRefList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.types;

--- a/src/main/java/sirius/db/mongo/types/MultiPointLocation.java
+++ b/src/main/java/sirius/db/mongo/types/MultiPointLocation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.types;

--- a/src/main/java/sirius/db/redis/Redis.java
+++ b/src/main/java/sirius/db/redis/Redis.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis;

--- a/src/main/java/sirius/db/redis/RedisCommand.java
+++ b/src/main/java/sirius/db/redis/RedisCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis;

--- a/src/main/java/sirius/db/redis/RedisDB.java
+++ b/src/main/java/sirius/db/redis/RedisDB.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis;

--- a/src/main/java/sirius/db/redis/RedisMetricProvider.java
+++ b/src/main/java/sirius/db/redis/RedisMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis;

--- a/src/main/java/sirius/db/redis/Subscriber.java
+++ b/src/main/java/sirius/db/redis/Subscriber.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis;

--- a/src/main/java/sirius/db/text/BasicIndexTokenizer.java
+++ b/src/main/java/sirius/db/text/BasicIndexTokenizer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/BasicSearchTokenizer.java
+++ b/src/main/java/sirius/db/text/BasicSearchTokenizer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/BypassProcessor.java
+++ b/src/main/java/sirius/db/text/BypassProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/ChainableTokenProcessor.java
+++ b/src/main/java/sirius/db/text/ChainableTokenProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/DeduplicateProcessor.java
+++ b/src/main/java/sirius/db/text/DeduplicateProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/PatternExtractProcessor.java
+++ b/src/main/java/sirius/db/text/PatternExtractProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/PatternReplaceProcessor.java
+++ b/src/main/java/sirius/db/text/PatternReplaceProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/PatternSplitProcessor.java
+++ b/src/main/java/sirius/db/text/PatternSplitProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/PipelineProcessor.java
+++ b/src/main/java/sirius/db/text/PipelineProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/PurgeProcessor.java
+++ b/src/main/java/sirius/db/text/PurgeProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/ReduceCharacterProcessor.java
+++ b/src/main/java/sirius/db/text/ReduceCharacterProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/ToLowercaseProcessor.java
+++ b/src/main/java/sirius/db/text/ToLowercaseProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/TokenLimitProcessor.java
+++ b/src/main/java/sirius/db/text/TokenLimitProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/TokenProcessor.java
+++ b/src/main/java/sirius/db/text/TokenProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/text/Tokenizer.java
+++ b/src/main/java/sirius/db/text/Tokenizer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text;

--- a/src/main/java/sirius/db/util/BaseEntityCache.java
+++ b/src/main/java/sirius/db/util/BaseEntityCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.util;

--- a/src/main/java/sirius/db/util/Tensors.java
+++ b/src/main/java/sirius/db/util/Tensors.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.util;

--- a/src/main/resources/component-060-db.conf
+++ b/src/main/resources/component-060-db.conf
@@ -1,9 +1,9 @@
 #
 # Made with all the love in the world
-# by scireum in Remshalden, Germany
+# by scireum in Stuttgart, Germany
 #
 # Copyright by scireum GmbH
-# http://www.scireum.de - info@scireum.de
+# https://www.scireum.de - info@scireum.de
 #
 
 # Adding the db module to the list of known modules...

--- a/src/test/java/sirius/db/es/BatchTestEntity.java
+++ b/src/test/java/sirius/db/es/BatchTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/ESListTestEntity.java
+++ b/src/test/java/sirius/db/es/ESListTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/ElasticTestEntity.java
+++ b/src/test/java/sirius/db/es/ElasticTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/ElasticWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/es/ElasticWasCreatedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/LockedTestEntity.java
+++ b/src/test/java/sirius/db/es/LockedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/QueryTestEntity.java
+++ b/src/test/java/sirius/db/es/QueryTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/RoutedBatchTestEntity.java
+++ b/src/test/java/sirius/db/es/RoutedBatchTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/RoutedTestEntity.java
+++ b/src/test/java/sirius/db/es/RoutedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/SuggestTestEntity.java
+++ b/src/test/java/sirius/db/es/SuggestTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/SuppressedRoutedTestEntity.java
+++ b/src/test/java/sirius/db/es/SuppressedRoutedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es;

--- a/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESDataTypesEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESDenseVectorEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESDenseVectorEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESFilledEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESFilledEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESNestedListEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESNestedListEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESStringBooleanMapEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESStringBooleanMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESStringListEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESStringListEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESStringListMapEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESStringListMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESStringLocalDateTimeMapEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESStringLocalDateTimeMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/es/properties/ESStringMapEntity.java
+++ b/src/test/java/sirius/db/es/properties/ESStringMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties;

--- a/src/test/java/sirius/db/jdbc/DataTypesEntity.java
+++ b/src/test/java/sirius/db/jdbc/DataTypesEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/GeneratedStatementTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/GeneratedStatementTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/LegacyEntity.java
+++ b/src/test/java/sirius/db/jdbc/LegacyEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/ListTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/ListTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SQLLockedTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLLockedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SQLStringListNonNullAllowedPropertyEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLStringListNonNullAllowedPropertyEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SQLStringListPropertyEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLStringListPropertyEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SQLUniqueTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLUniqueTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SQLWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/SQLWasCreatedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestChildChildEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestChildChildEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestChildEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestChildEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestCountEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestCountEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestLargeTableEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestLargeTableEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestMixinEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestMixinEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestMixinEntityMixin.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestMixinEntityMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestParentEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestParentEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/SmartQueryTestSortingEntity.java
+++ b/src/test/java/sirius/db/jdbc/SmartQueryTestSortingEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/StringManipulationTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/StringManipulationTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestClobEntity.java
+++ b/src/test/java/sirius/db/jdbc/TestClobEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestComposite.java
+++ b/src/test/java/sirius/db/jdbc/TestComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestCompositeWithComposite.java
+++ b/src/test/java/sirius/db/jdbc/TestCompositeWithComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestEntity.java
+++ b/src/test/java/sirius/db/jdbc/TestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestEntityWithComposite.java
+++ b/src/test/java/sirius/db/jdbc/TestEntityWithComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestEntityWithMixin.java
+++ b/src/test/java/sirius/db/jdbc/TestEntityWithMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestEntityWithNullRef.java
+++ b/src/test/java/sirius/db/jdbc/TestEntityWithNullRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestMixin.java
+++ b/src/test/java/sirius/db/jdbc/TestMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TestMixinMixin.java
+++ b/src/test/java/sirius/db/jdbc/TestMixinMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/TransformedQueryTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/TransformedQueryTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc;

--- a/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
+++ b/src/test/java/sirius/db/jdbc/clickhouse/ClickhouseTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.clickhouse;

--- a/src/test/java/sirius/db/mixing/MongoComposite.java
+++ b/src/test/java/sirius/db/mixing/MongoComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/MongoMixable.java
+++ b/src/test/java/sirius/db/mixing/MongoMixable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/RefElasticEntity.java
+++ b/src/test/java/sirius/db/mixing/RefElasticEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/RefEntity.java
+++ b/src/test/java/sirius/db/mixing/RefEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/RefListElasticEntity.java
+++ b/src/test/java/sirius/db/mixing/RefListElasticEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/RefListMongoEntity.java
+++ b/src/test/java/sirius/db/mixing/RefListMongoEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/RefMongoEntity.java
+++ b/src/test/java/sirius/db/mixing/RefMongoEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/SQLDefaultValuesEntity.java
+++ b/src/test/java/sirius/db/mixing/SQLDefaultValuesEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/WriteOnceChildEntity.java
+++ b/src/test/java/sirius/db/mixing/WriteOnceChildEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/WriteOnceParentEntity.java
+++ b/src/test/java/sirius/db/mixing/WriteOnceParentEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing;

--- a/src/test/java/sirius/db/mixing/fieldlookup/MongoFieldLookUpTestEntity.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/MongoFieldLookUpTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup;

--- a/src/test/java/sirius/db/mixing/fieldlookup/MongoSuperHeroTestMixin.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/MongoSuperHeroTestMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup;

--- a/src/test/java/sirius/db/mixing/fieldlookup/NameFieldsTestComposite.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/NameFieldsTestComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup;

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLFieldLookUpTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup;

--- a/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
+++ b/src/test/java/sirius/db/mixing/fieldlookup/SQLSuperHeroTestMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup;

--- a/src/test/java/sirius/db/mixing/properties/DateEntity.java
+++ b/src/test/java/sirius/db/mixing/properties/DateEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties;

--- a/src/test/java/sirius/db/mongo/MangoAggregationsTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoAggregationsTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/MangoListTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoListTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/MangoTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/MangoWasCreatedTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MangoWasCreatedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/MongoLockedTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MongoLockedTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/MongoUniqueTestEntity.java
+++ b/src/test/java/sirius/db/mongo/MongoUniqueTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/PrefixTestEntity.java
+++ b/src/test/java/sirius/db/mongo/PrefixTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/SkipDefaultTestEntity.java
+++ b/src/test/java/sirius/db/mongo/SkipDefaultTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
+++ b/src/test/java/sirius/db/mongo/ValidatedByTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo;

--- a/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoAmountEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoExistsEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoExistsEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoFilledEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoFilledEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoIntEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoIntEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoMultiPointEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoMultiPointEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoNestedListEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoNestedListEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringBooleanMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringBooleanMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringIntMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringIntMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringListEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringListEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringListMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringListMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringListMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringListMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringListMixinEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringListMixinEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringLocalDateTimeMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringLocalDateTimeMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringMapMixin.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringMapMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringMapMixinEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringMapMixinEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapEntity.java
+++ b/src/test/java/sirius/db/mongo/properties/MongoStringNestedMapEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties;

--- a/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
+++ b/src/test/java/sirius/db/mongo/validators/StringTestPropertyValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.validators;

--- a/src/test/kotlin/sirius/db/es/BulkContextTest.kt
+++ b/src/test/kotlin/sirius/db/es/BulkContextTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/ElasticQueryNightlyTest.kt
+++ b/src/test/kotlin/sirius/db/es/ElasticQueryNightlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
+++ b/src/test/kotlin/sirius/db/es/ElasticQueryTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/ElasticTest.kt
+++ b/src/test/kotlin/sirius/db/es/ElasticTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
+++ b/src/test/kotlin/sirius/db/es/LowLevelClientTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/ReindexTest.kt
+++ b/src/test/kotlin/sirius/db/es/ReindexTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/SuggestNightlyTest.kt
+++ b/src/test/kotlin/sirius/db/es/SuggestNightlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es

--- a/src/test/kotlin/sirius/db/es/properties/ElasticDataTypesTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticDataTypesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticDenseVectorTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticDenseVectorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticFilledTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticFilledTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticNestedListPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticNestedListPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticStringBooleanMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticStringBooleanMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticStringListMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticStringListMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticStringListPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticStringListPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticStringLocalDateTimePropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticStringLocalDateTimePropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/es/properties/ElasticStringMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/es/properties/ElasticStringMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.es.properties

--- a/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/DataTypesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/DeleteStatementTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/DeleteStatementTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/JDBCTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/JDBCTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.database.jdatabasec

--- a/src/test/kotlin/sirius/db/jdbc/LegacyTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/LegacyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/OMATest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/OMATest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/SQLQueryCompilerTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SQLQueryCompilerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/SQLStringListPropertyEntityTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SQLStringListPropertyEntityTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryKotlinTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/SmartQueryNighlyTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/SmartQueryNighlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/StringPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/StringPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/TransformedQueryTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/TransformedQueryTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/UpdateStatementTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/UpdateStatementTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc

--- a/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/batch/BatchContextTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.batch

--- a/src/test/kotlin/sirius/db/jdbc/clickhouse/ClickhouseTest.kt
+++ b/src/test/kotlin/sirius/db/jdbc/clickhouse/ClickhouseTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.jdbc.clickhouse

--- a/src/test/kotlin/sirius/db/mixing/BaseEntityRefListTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/BaseEntityRefListTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing

--- a/src/test/kotlin/sirius/db/mixing/BaseEntityRefTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/BaseEntityRefTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing

--- a/src/test/kotlin/sirius/db/mixing/CompositeTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/CompositeTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing

--- a/src/test/kotlin/sirius/db/mixing/annotations/SkipDefaultValueTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/annotations/SkipDefaultValueTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations

--- a/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/annotations/ValidatedByTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.annotations

--- a/src/test/kotlin/sirius/db/mixing/fieldlookup/FieldLookupCacheTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/fieldlookup/FieldLookupCacheTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.fieldlookup

--- a/src/test/kotlin/sirius/db/mixing/properties/DefaultValuesTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/DefaultValuesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties

--- a/src/test/kotlin/sirius/db/mixing/properties/EnumPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/EnumPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties

--- a/src/test/kotlin/sirius/db/mixing/properties/LocalDatePropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/LocalDatePropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties

--- a/src/test/kotlin/sirius/db/mixing/properties/LocalDateTimePropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/LocalDateTimePropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties

--- a/src/test/kotlin/sirius/db/mixing/properties/LocalTimePropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mixing/properties/LocalTimePropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mixing.properties

--- a/src/test/kotlin/sirius/db/mongo/FacetTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/FacetTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/MangoNightlyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/MangoNightlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/MangoTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/MangoTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/MongoFilterFactoryTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/MongoFilterFactoryTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/MongoQueryCompilerTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/MongoQueryCompilerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/MongoTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/MongoTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoAmountPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoAmountPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoExistsTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoExistsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoFilledTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoFilledTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoIntPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoIntPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoMultiPointTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoMultiPointTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoNestedListPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoNestedListPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringBooleanMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringBooleanMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringIntMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringIntMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringListMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringListMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringListMixinEntityTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringListMixinEntityTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringListPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringListPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringLocalDateTimeMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringLocalDateTimeMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringMapMixinEntityTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringMapMixinEntityTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/mongo/properties/MongoStringNestedMapPropertyTest.kt
+++ b/src/test/kotlin/sirius/db/mongo/properties/MongoStringNestedMapPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.mongo.properties

--- a/src/test/kotlin/sirius/db/redis/RedisTest.kt
+++ b/src/test/kotlin/sirius/db/redis/RedisTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.redis

--- a/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
+++ b/src/test/kotlin/sirius/db/testutil/MongoMocks.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.testutil

--- a/src/test/kotlin/sirius/db/text/BasicIndexTokenizerTest.kt
+++ b/src/test/kotlin/sirius/db/text/BasicIndexTokenizerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/PatternExtractProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/PatternExtractProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/PatternReplaceProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/PatternReplaceProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/PatternSplitProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/PatternSplitProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/PipelineProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/PipelineProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/ReduceCharactersProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/ReduceCharactersProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/ToLowercaseProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/ToLowercaseProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/TokenLimitProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/TokenLimitProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/text/TokenProcessorTest.kt
+++ b/src/test/kotlin/sirius/db/text/TokenProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.text

--- a/src/test/kotlin/sirius/db/util/TensorsTest.kt
+++ b/src/test/kotlin/sirius/db/util/TensorsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.db.util


### PR DESCRIPTION
### Description

scireum sits in Stuttgart, but 421 files still credited Remshalden or linked the website over plain `http`. Part of a sweep across the scireum repositories, prompted by a review in scireum/sirius-web#1729 where a file added this week had inherited the outdated header from the file next to it.

**Scope.** Two lines per file and nothing else - every changed line in the diff is one of these two forms, in whichever comment style the file uses:

```
- by scireum in Remshalden, Germany         + by scireum in Stuttgart, Germany
- http://www.scireum.de - info@scireum.de   + https://www.scireum.de - info@scireum.de
```

Two deliberate details in how the replacement is anchored:

- The city line is matched on the **whole header phrase**, never on the word alone, so postal addresses in test data or documentation cannot be caught by it.
- The URL is replaced **on its own**, not as part of the whole line, so `info@@scireum.de` survives - the doubled at-sign is the escape Tagliatelle needs in `.pasta` templates, and a whole-line pattern would have skipped those lines entirely, quietly leaving them on `http`.


### Verification

Compiles cleanly (`mvn clean test-compile`), and the pipeline runs the suite.

The suite was **not** run to completion locally, and the reason is worth recording rather than hiding: MongoDB will not start on this machine at all. `mongo:8.3.7` exits immediately with *"Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB"* ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)), so every Mongo-backed test times out after 30 seconds against a port with nothing behind it. In a first run all 18 failing test methods were Mongo ones, by name or by that timeout signature; the JDBC, Redis, Elasticsearch and ClickHouse tests passed. A local run therefore cannot cover the Mongo paths of this change - which, being comment text, has no paths.

### Note on formatting

The IntelliJ formatter was deliberately **not** run: the change edits comment text only and cannot violate the code style, whereas formatting this many otherwise untouched files would bury the change under unrelated hunks.

### Additional Notes

- This PR fixes or works on following ticket(s): none - housekeeping
- This PR is related to PR: scireum/sirius-web#1731

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows best practices - see the note above on why the formatter was not run; **SonarLint was not run** either, as it cannot be executed headlessly
- [x] Patch Tasks: not necessary